### PR TITLE
Fix `ssh` rules

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242393.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242393.go
@@ -66,10 +66,10 @@ func (r *Rule242393) Run(ctx context.Context) (rule.RuleResult, error) {
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}
-	if strings.HasSuffix(strings.ToLower(commandResult), "no such file or directory") {
+	if strings.TrimSpace(strings.ToLower(commandResult)) == "inactive" {
 		return rule.SingleCheckResult(r, rule.PassedCheckResult("SSH daemon service not installed", target)), nil
 	}
-	if strings.ToLower(commandResult) == "active" {
+	if strings.TrimSpace(strings.ToLower(commandResult)) == "active" {
 		return rule.SingleCheckResult(r, rule.FailedCheckResult("SSH daemon active", target)), nil
 	}
 	return rule.SingleCheckResult(r, rule.PassedCheckResult("SSH daemon inactive (or could not be probed)", target)), nil

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242393_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242393_test.go
@@ -46,8 +46,8 @@ var _ = Describe("#242393", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("SSH daemon started on port 22", gardener.NewTarget("cluster", "shoot")),
 			}),
-		Entry("should return passed checkResult when sshd is not found in systemctl",
-			[][]string{{"", "foo NO such file or directory"}},
+		Entry("should return passed checkResult when sshd is inactive in systemctl",
+			[][]string{{"", "Inactive"}},
 			[][]error{{nil, nil}},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("SSH daemon service not installed", gardener.NewTarget("cluster", "shoot")),
@@ -72,9 +72,9 @@ var _ = Describe("#242393", func() {
 			}),
 		Entry("should return errored checkResult when second execute errors",
 			[][]string{{"", "foo"}},
-			[][]error{{nil, errors.New("bat")}},
+			[][]error{{nil, errors.New("bar")}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("bat", gardener.NewTarget("cluster", "shoot")),
+				rule.ErroredCheckResult("bar", gardener.NewTarget("cluster", "shoot")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242394.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242394.go
@@ -64,12 +64,14 @@ func (r *Rule242394) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	commandResult, err = clusterPodExecutor.Execute(ctx, "/bin/sh", `systemctl is-enabled sshd || true`)
 	if err != nil {
+		if strings.HasSuffix(strings.TrimSpace(strings.ToLower(err.Error())), "no such file or directory") {
+			return rule.SingleCheckResult(r, rule.PassedCheckResult("SSH daemon service not installed", target)), nil
+		}
+
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}
-	if strings.HasSuffix(strings.ToLower(commandResult), "no such file or directory") {
-		return rule.SingleCheckResult(r, rule.PassedCheckResult("SSH daemon service not installed", target)), nil
-	}
-	if strings.ToLower(commandResult) == "alias" {
+
+	if strings.TrimSpace(strings.ToLower(commandResult)) == "alias" {
 		return rule.SingleCheckResult(r, rule.FailedCheckResult("SSH daemon enabled", target)), nil
 	}
 	return rule.SingleCheckResult(r, rule.PassedCheckResult("SSH daemon disabled (or could not be probed)", target)), nil

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242394_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242394_test.go
@@ -47,9 +47,9 @@ var _ = Describe("#242394", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("SSH daemon started on port 22", target),
 			}),
-		Entry("should return passed checkResult when sshd is not found in systemctl",
-			[][]string{{"", "foo NO such file or directory"}},
-			[][]error{{nil, nil}},
+		Entry("should return passed checkResult when second execute errors with sshd is not found in systemctl",
+			[][]string{{"", ""}},
+			[][]error{{nil, errors.New(" foo NO such file or directory  ")}},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("SSH daemon service not installed", target),
 			}),
@@ -73,9 +73,9 @@ var _ = Describe("#242394", func() {
 			}),
 		Entry("should return errored checkResult when second execute errors",
 			[][]string{{"", "foo"}},
-			[][]error{{nil, errors.New("bat")}},
+			[][]error{{nil, errors.New("bar")}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("bat", target),
+				rule.ErroredCheckResult("bar", target),
 			}),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes rules `242393` and `242394`.

Rule `242393` when passed always reported with `SSH daemon inactive (or could not be probed)`, now it should report with `SSH daemon service not installed` when the `systemctl is-active sshd` command outputs `inactive`.

Rule `242394` returned errored status in cases it should have passed. Rule `242394` now correctly passes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing rule `242393` to pass with wrong message was fixed.
```
```bugfix user
A bug causing rule `242394` to error when it should pass was fixed.
```
