### PR TITLE
Improve `ETCD` peer options rules

### DIFF
--- a/pkg/kubernetes/config/etcd.go
+++ b/pkg/kubernetes/config/etcd.go
@@ -6,6 +6,7 @@ package config
 
 // EtcdConfig describes ETCD configuration values.
 type EtcdConfig struct {
+	InitialCluster          string            `yaml:"initial-cluster"`
 	ClientTransportSecurity TransportSecurity `yaml:"client-transport-security"`
 	PeerTransportSecurity   TransportSecurity `yaml:"peer-transport-security"`
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242426.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242426.go
@@ -7,6 +7,7 @@ package v1r8
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
@@ -76,6 +77,12 @@ func (r *Rule242426) checkStatefulSet(ctx context.Context, statefulSetName strin
 	err = yaml.Unmarshal(configByteSlice, config)
 	if err != nil {
 		return rule.ErroredCheckResult(err.Error(), target)
+	}
+
+	// We do not check the command-line flags and environment variables,
+	// since they are ignored when a config file is set. ref https://etcd.io/docs/v3.5/op-guide/configuration/
+	if len(strings.Split(config.InitialCluster, ",")) == 1 {
+		return rule.SkippedCheckResult("ETCD runs as a single instance, peer communication options are not used.", target)
 	}
 
 	if config.PeerTransportSecurity.CertAuth == nil {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242432.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242432.go
@@ -79,6 +79,12 @@ func (r *Rule242432) checkStatefulSet(ctx context.Context, statefulSetName strin
 		return rule.ErroredCheckResult(err.Error(), target)
 	}
 
+	// We do not check the command-line flags and environment variables,
+	// since they are ignored when a config file is set. ref https://etcd.io/docs/v3.5/op-guide/configuration/
+	if len(strings.Split(config.InitialCluster, ",")) == 1 {
+		return rule.SkippedCheckResult("ETCD runs as a single instance, peer communication options are not used.", target)
+	}
+
 	if config.PeerTransportSecurity.CertFile == nil {
 		return rule.FailedCheckResult("Option peer-transport-security.cert-file has not been set.", target)
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242432_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242432_test.go
@@ -26,7 +26,7 @@ var _ = Describe("#242432", func() {
 		singleETCDCluster = `
 initial-cluster: etcd-main-0=foo
 peer-transport-security:
-  client-cert-auth: false`
+  cert-file: false`
 		ptsCertFileNotSetConfig = `
 initial-cluster: etcd-main-0=foo,etcd-main-1=bar
 peer-transport-security:`

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242432_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242432_test.go
@@ -22,6 +22,24 @@ import (
 )
 
 var _ = Describe("#242432", func() {
+	const (
+		singleETCDCluster = `
+initial-cluster: etcd-main-0=foo
+peer-transport-security:
+  client-cert-auth: false`
+		ptsCertFileNotSetConfig = `
+initial-cluster: etcd-main-0=foo,etcd-main-1=bar
+peer-transport-security:`
+		ptsCertFileSetConfig = `
+initial-cluster: etcd-main-0=foo,etcd-main-1=bar
+peer-transport-security:
+  cert-file: set`
+		ptsCertFileSetEmptyConfig = `
+initial-cluster: etcd-main-0=foo,etcd-main-1=bar
+peer-transport-security:
+  cert-file: ""`
+	)
+
 	var (
 		fakeClient client.Client
 		ctx        = context.TODO()
@@ -141,8 +159,8 @@ var _ = Describe("#242432", func() {
 		Entry("should error when statefulSet does not have volume 'etcd-config-file' or secret is not found",
 			corev1.Volume{Name: "not-etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "foo"}}},
 			corev1.Volume{Name: "etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "bar"}}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsCertAuthSetTrueConfig)}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "not-bar", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsCertAuthSetTrueConfig)}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsCertFileSetConfig)}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "not-bar", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsCertFileSetConfig)}},
 			[]rule.CheckResult{
 				{
 					Status:  rule.Errored,
@@ -156,16 +174,23 @@ var _ = Describe("#242432", func() {
 				},
 			},
 			BeNil()),
+		Entry("should skip when initial-cluster is set with signel value",
+			corev1.Volume{Name: "etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "foo"}}},
+			corev1.Volume{Name: "etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "bar"}}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(singleETCDCluster)}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(singleETCDCluster)}},
+			[]rule.CheckResult{
+				{
+					Status:  rule.Skipped,
+					Message: "ETCD runs as a single instance, peer communication options are not used.",
+					Target:  targetEtcdMain,
+				},
+				{
+					Status:  rule.Skipped,
+					Message: "ETCD runs as a single instance, peer communication options are not used.",
+					Target:  targetEtcdEvents,
+				},
+			},
+			BeNil()),
 	)
 })
-
-const (
-	ptsCertFileNotSetConfig = `
-peer-transport-security:`
-	ptsCertFileSetConfig = `
-peer-transport-security:
-  cert-file: set`
-	ptsCertFileSetEmptyConfig = `
-peer-transport-security:
-  cert-file: ""`
-)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242433.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242433.go
@@ -79,6 +79,12 @@ func (r *Rule242433) checkStatefulSet(ctx context.Context, statefulSetName strin
 		return rule.ErroredCheckResult(err.Error(), target)
 	}
 
+	// We do not check the command-line flags and environment variables,
+	// since they are ignored when a config file is set. ref https://etcd.io/docs/v3.5/op-guide/configuration/
+	if len(strings.Split(config.InitialCluster, ",")) == 1 {
+		return rule.SkippedCheckResult("ETCD runs as a single instance, peer communication options are not used.", target)
+	}
+
 	if config.PeerTransportSecurity.KeyFile == nil {
 		return rule.FailedCheckResult("Option peer-transport-security.key-file has not been set.", target)
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242433_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242433_test.go
@@ -26,7 +26,7 @@ var _ = Describe("#242433", func() {
 		singleETCDCluster = `
 initial-cluster: etcd-main-0=foo
 peer-transport-security:
-  client-cert-auth: false`
+  key-file: false`
 		ptsKeyFileNotSetConfig = `
 initial-cluster: etcd-main-0=foo,etcd-main-1=bar
 peer-transport-security:`

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242433_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8/242433_test.go
@@ -22,6 +22,24 @@ import (
 )
 
 var _ = Describe("#242433", func() {
+	const (
+		singleETCDCluster = `
+initial-cluster: etcd-main-0=foo
+peer-transport-security:
+  client-cert-auth: false`
+		ptsKeyFileNotSetConfig = `
+initial-cluster: etcd-main-0=foo,etcd-main-1=bar
+peer-transport-security:`
+		ptsKeyFileSetConfig = `
+initial-cluster: etcd-main-0=foo,etcd-main-1=bar
+peer-transport-security:
+  key-file: set`
+		ptsKeyFileSetEmptyConfig = `
+initial-cluster: etcd-main-0=foo,etcd-main-1=bar
+peer-transport-security:
+  key-file: ""`
+	)
+
 	var (
 		fakeClient client.Client
 		ctx        = context.TODO()
@@ -141,8 +159,8 @@ var _ = Describe("#242433", func() {
 		Entry("should error when statefulSet does not have volume 'etcd-config-file' or secret is not found",
 			corev1.Volume{Name: "not-etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "foo"}}},
 			corev1.Volume{Name: "etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "bar"}}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsCertAuthSetTrueConfig)}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "not-bar", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsCertAuthSetTrueConfig)}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsKeyFileSetConfig)}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "not-bar", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(ptsKeyFileSetConfig)}},
 			[]rule.CheckResult{
 				{
 					Status:  rule.Errored,
@@ -156,16 +174,23 @@ var _ = Describe("#242433", func() {
 				},
 			},
 			BeNil()),
+		Entry("should skip when initial-cluster is set with signel value",
+			corev1.Volume{Name: "etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "foo"}}},
+			corev1.Volume{Name: "etcd-config-file", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "bar"}}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(singleETCDCluster)}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: namespace}, Data: map[string][]byte{"etcd.conf.yaml": []byte(singleETCDCluster)}},
+			[]rule.CheckResult{
+				{
+					Status:  rule.Skipped,
+					Message: "ETCD runs as a single instance, peer communication options are not used.",
+					Target:  targetEtcdMain,
+				},
+				{
+					Status:  rule.Skipped,
+					Message: "ETCD runs as a single instance, peer communication options are not used.",
+					Target:  targetEtcdEvents,
+				},
+			},
+			BeNil()),
 	)
 })
-
-const (
-	ptsKeyFileNotSetConfig = `
-peer-transport-security:`
-	ptsKeyFileSetConfig = `
-peer-transport-security:
-  key-file: set`
-	ptsKeyFileSetEmptyConfig = `
-peer-transport-security:
-  key-file: ""`
-)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves `ETCD` peer options rules `242380`, `242426`, `242432` and `242433` by skipping them when ETCD runs as a single instance, since they are not used in that case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`ETCD` peer options rules `242380`, `242426`, `242432` and `242433` are now skipped when `ETCD` runs as a single instance.
```
