### PR TITLE
Add merge reports option in report command

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+	cliflag "k8s.io/component-base/cli/flag"
 
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/provider"
@@ -80,26 +81,36 @@ func addRunFlags(cmd *cobra.Command, opts *runOptions) {
 
 func addReportFlags(cmd *cobra.Command, opts *reportOptions) {
 	cmd.PersistentFlags().StringVar(&opts.output, "output", "html", "Output type.")
+	cmd.PersistentFlags().Var(cliflag.NewMapStringString(&opts.distinctBy), "distinct-by", "If set the created reports is a merged between all given reports containing only the slelected providers in this filed with their fistinct metadata field.")
 }
 
 func reportCmd(args []string, opts reportOptions) error {
-	if len(args) != 1 {
-		return errors.New("report requires a single filepath argument")
+	if len(args) == 0 {
+		return errors.New("report requires a minimum of one filepath arguments")
+	}
+
+	if len(args) > 1 && len(opts.distinctBy) == 0 {
+		return errors.New("report requires a single filepath argument when flag distinct-by is not set ")
 	}
 
 	if opts.output != "html" {
 		return fmt.Errorf("unsuported output format: %s", opts.output)
 	}
 
-	fileData, err := os.ReadFile(args[0])
-	if err != nil {
-		return fmt.Errorf("failed to read file %s:%w", args[0], err)
-	}
+	reports := []*report.Report{}
+	for _, arg := range args {
+		fileData, err := os.ReadFile(filepath.Clean(arg))
+		if err != nil {
+			return fmt.Errorf("failed to read file %s:%w", arg, err)
+		}
 
-	// TODO: handle report types
-	rep := &report.Report{}
-	if err := json.Unmarshal(fileData, rep); err != nil {
-		return fmt.Errorf("failed to unmarshal data: %w", err)
+		// TODO: handle report types
+		rep := &report.Report{}
+		if err := json.Unmarshal(fileData, rep); err != nil {
+			return fmt.Errorf("failed to unmarshal data: %w", err)
+		}
+
+		reports = append(reports, rep)
 	}
 
 	htlmRenderer, err := report.NewHTMLRenderer()
@@ -107,7 +118,15 @@ func reportCmd(args []string, opts reportOptions) error {
 		return fmt.Errorf("failed to initialize renderer: %w", err)
 	}
 
-	return htlmRenderer.Render(os.Stdout, rep)
+	if len(opts.distinctBy) > 0 {
+		mergedReport, err := report.MergeReport(reports, opts.distinctBy)
+		if err != nil {
+			return err
+		}
+		return htlmRenderer.Render(os.Stdout, mergedReport)
+	}
+
+	return htlmRenderer.Render(os.Stdout, reports[0])
 }
 
 func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.ProviderFromConfigFunc, opts runOptions) error {
@@ -232,7 +251,8 @@ type runOptions struct {
 }
 
 type reportOptions struct {
-	output string
+	output     string
+	distinctBy map[string]string
 }
 
 func readConfig(filePath string) (*config.DikiConfig, error) {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/apimachinery v0.26.3
 	k8s.io/apiserver v0.26.3
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/component-base v0.26.3
 	k8s.io/pod-security-admission v0.26.3
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.6
@@ -96,7 +97,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.26.3 // indirect
 	k8s.io/autoscaler/vertical-pod-autoscaler v0.14.0 // indirect
 	k8s.io/code-generator v0.26.3 // indirect
-	k8s.io/component-base v0.26.3 // indirect
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/helm v2.16.1+incompatible // indirect
 	k8s.io/klog v1.0.0 // indirect

--- a/pkg/report/merged_report.go
+++ b/pkg/report/merged_report.go
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package report
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/gardener/diki/pkg/rule"
+)
+
+// MergedReport contains information about multiple Diki
+// runs in a suitable for reporting format.
+type MergedReport struct {
+	Time      time.Time        `json:"time"`
+	MinStatus rule.Status      `json:"minStatus,omitempty"`
+	Providers []MergedProvider `json:"providers"`
+}
+
+// MergedProvider contains information from multiple reports about
+// a known provider and its ran rulesets.
+type MergedProvider struct {
+	ID         string                       `json:"id"`
+	Name       string                       `json:"name"`
+	DistinctBy string                       `json:"distinctBy"`
+	Metadata   map[string]map[string]string `json:"metadata,omitempty"`
+	Rulesets   []MergedRuleset              `json:"rulesets"`
+}
+
+// addSingleReportRulesets adds rulesets from a single report.
+// Rulesets are converted to MergedRulesets if the selected ruleset has not been added
+// or they are added to existing MergedRulesets otherwise.
+func (mp *MergedProvider) addSingleReportRulesets(id string, rulesets []Ruleset) {
+	for _, ruleset := range rulesets {
+		idx := slices.IndexFunc(mp.Rulesets, func(mr MergedRuleset) bool {
+			return ruleset.ID == mr.ID && ruleset.Version == mr.Version
+		})
+
+		if idx >= 0 {
+			mp.Rulesets[idx].addSingleRulesetRules(id, ruleset.Rules)
+		} else {
+			mergedRuleset := MergedRuleset{
+				ID:      ruleset.ID,
+				Name:    ruleset.Name,
+				Version: ruleset.Version,
+				Rules:   []MergedRule{},
+			}
+			mergedRuleset.addSingleRulesetRules(id, ruleset.Rules)
+			mp.Rulesets = append(mp.Rulesets, mergedRuleset)
+		}
+	}
+}
+
+// MergedRuleset contains information from multiple reports about a ruleset and its rules.
+type MergedRuleset struct {
+	ID      string       `json:"id"`
+	Name    string       `json:"name"`
+	Version string       `json:"version"`
+	Rules   []MergedRule `json:"rules"`
+}
+
+// addSingleReportRulesets adds rules from a single ruleset.
+// Rules are converted to MergedRules if the selected rule has not been added
+// or they are added to existing MergedRules otherwise.
+func (mr *MergedRuleset) addSingleRulesetRules(id string, rules []Rule) {
+	for _, rule := range rules {
+		idx := slices.IndexFunc(mr.Rules, func(mr MergedRule) bool {
+			return rule.ID == mr.ID
+		})
+
+		if idx >= 0 {
+			mr.Rules[idx].addChecks(id, rule.Checks)
+		} else {
+			mergedRule := MergedRule{
+				ID:     rule.ID,
+				Name:   rule.Name,
+				Checks: []MergedCheck{},
+			}
+			mergedRule.addChecks(id, rule.Checks)
+			mr.Rules = append(mr.Rules, mergedRule)
+		}
+	}
+}
+
+// MergedRule contains information about a ran rule for multiple reports.
+type MergedRule struct {
+	ID     string        `json:"id"`
+	Name   string        `json:"name"`
+	Checks []MergedCheck `json:"checks"`
+}
+
+func (mr *MergedRule) addChecks(id string, checks []Check) {
+	for _, check := range checks {
+		idx := slices.IndexFunc(mr.Checks, func(mr MergedCheck) bool {
+			return check.Message == mr.Message && check.Status == mr.Status
+		})
+
+		if idx >= 0 {
+			mr.Checks[idx].ReportsTargets[id] = check.Targets
+		} else {
+			mergedCheck := MergedCheck{
+				Message:        check.Message,
+				Status:         check.Status,
+				ReportsTargets: map[string][]rule.Target{},
+			}
+			mergedCheck.ReportsTargets[id] = check.Targets
+			mr.Checks = append(mr.Checks, mergedCheck)
+		}
+	}
+}
+
+// MergedCheck is the result of a single Rule check for multiple reports.
+type MergedCheck struct {
+	Status         rule.Status              `json:"status"`
+	Message        string                   `json:"message"`
+	ReportsTargets map[string][]rule.Target `json:"targets,omitempty"`
+}
+
+// MergeReport merges given reports by specified providers and unique metadata attribute.
+func MergeReport(reports []*Report, distinctByAttrs map[string]string) (*MergedReport, error) {
+	if len(reports) == 0 {
+		return &MergedReport{}, errors.New("reports slice is empty")
+	}
+	mergedReport := &MergedReport{
+		Time:      time.Now(),
+		MinStatus: reports[0].MinStatus,
+		Providers: []MergedProvider{},
+	}
+
+	for selectedProvider, distinctBy := range distinctByAttrs {
+		mergedReport.Providers = append(mergedReport.Providers, MergedProvider{
+			ID:         selectedProvider,
+			Name:       "",
+			DistinctBy: distinctBy,
+			Metadata:   map[string]map[string]string{},
+			Rulesets:   []MergedRuleset{},
+		})
+	}
+
+	for _, report := range reports {
+		if report.MinStatus != mergedReport.MinStatus {
+			return &MergedReport{}, errors.New("reports must have equal minStatus to be merged")
+		}
+
+		for key, mergedProvider := range mergedReport.Providers {
+			idx := slices.IndexFunc(report.Providers, func(p Provider) bool {
+				return p.ID == mergedProvider.ID
+			})
+
+			if idx == -1 {
+				return &MergedReport{}, fmt.Errorf("provider %s not found in at least 1 of the selected reports", mergedProvider.ID)
+			}
+
+			if mergedReport.Providers[key].Name == "" {
+				mergedReport.Providers[key].Name = report.Providers[idx].Name
+			}
+
+			uniqueAttr := report.Providers[idx].Metadata[mergedProvider.DistinctBy]
+			if uniqueAttr == "" {
+				return &MergedReport{}, fmt.Errorf("distinct attribute %s is empty in at least 1 of the selected reports", mergedProvider.DistinctBy)
+			}
+
+			if _, ok := mergedProvider.Metadata[uniqueAttr]; ok {
+				return &MergedReport{}, fmt.Errorf("distinct attribute %s is not unique", mergedProvider.DistinctBy)
+			}
+
+			mergedProvider.Metadata[uniqueAttr] = report.Providers[idx].Metadata
+			mergedProvider.Metadata[uniqueAttr]["time"] = report.Time.Format("01-02-2006")
+		}
+	}
+	for _, report := range reports {
+		for idx, mergedProvider := range mergedReport.Providers {
+			for _, provider := range report.Providers {
+				if provider.ID == mergedProvider.ID {
+					uniqueAttr := provider.Metadata[mergedProvider.DistinctBy]
+					mergedProvider.addSingleReportRulesets(uniqueAttr, provider.Rulesets)
+					mergedReport.Providers[idx] = mergedProvider
+				}
+			}
+		}
+	}
+	return mergedReport, nil
+}
+
+// rulesWithStatus return all rules that have results with a given status.
+func mergedRulesWithStatus(ruleset *MergedRuleset, status rule.Status) []MergedRule {
+	result := []MergedRule{}
+	for _, rule := range ruleset.Rules {
+		ruleWithStatus := MergedRule{ID: rule.ID, Name: rule.Name}
+		for _, check := range rule.Checks {
+			if check.Status == status {
+				ruleWithStatus.Checks = append(ruleWithStatus.Checks, check)
+			}
+		}
+		if len(ruleWithStatus.Checks) > 0 {
+			result = append(result, ruleWithStatus)
+		}
+	}
+	return result
+}
+
+// mergedRulesetSummaryText returns a summary string with the number of merged rules with results per status.
+func mergedRulesetSummaryText(ruleset *MergedRuleset) string {
+	statuses := rule.Statuses()
+	summaryText := ""
+	for _, status := range statuses {
+		num := numOfMergedRulesWithStatus(ruleset, status)
+		if num != 0 {
+			if len(summaryText) > 0 {
+				summaryText = fmt.Sprintf("%s, ", summaryText)
+			}
+			summaryText = fmt.Sprintf("%s%dx %s %c", summaryText, num, status, rule.GetStatusIcon(status))
+		}
+	}
+	return summaryText
+}
+
+func numOfMergedRulesWithStatus(ruleset *MergedRuleset, status rule.Status) int {
+	num := 0
+	for _, rule := range ruleset.Rules {
+		for _, check := range rule.Checks {
+			if check.Status == status {
+				num++
+				break
+			}
+		}
+	}
+	return num
+}
+
+func metadataTextForMergedProvider(mp MergedProvider) map[string]string {
+	metadataTexts := map[string]string{}
+	for id, metadata := range mp.Metadata {
+		metadataText := "("
+		for key, value := range metadata {
+			if key == mp.DistinctBy {
+				continue
+			}
+			metadataText = fmt.Sprintf("%s%s: %s, ", metadataText, key, value)
+		}
+		if len(metadataText) > 1 {
+			metadataText = metadataText[:len(metadataText)-2]
+			metadataText = fmt.Sprintf("%s)", metadataText)
+		}
+		metadataTexts[id] = metadataText
+	}
+	return metadataTexts
+}

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/fs"
-	"strings"
 	"time"
 
 	"github.com/gardener/diki/pkg/rule"
@@ -18,7 +16,12 @@ import (
 
 var (
 	//go:embed templates/html/*
-	files embed.FS
+	files                embed.FS
+	tmplReportName       = "report"
+	tmplReportPath       = "templates/html/report.html"
+	tmplMergedReportName = "merged_report"
+	tmplMergedReportPath = "templates/html/merged_report.html"
+	tmplStylesPath       = "templates/html/_styles.tpl"
 )
 
 // HTMLRenderer renders Diki reports in html format.
@@ -28,34 +31,36 @@ type HTMLRenderer struct {
 
 // NewHTMLRenderer creates a HTMLRenderer.
 func NewHTMLRenderer() (*HTMLRenderer, error) {
-	tmplFiles, err := fs.ReadDir(files, "templates/html")
+	convTimeFunc := func(time time.Time) string {
+		return time.Format("01-02-2006")
+	}
+	templates := make(map[string]*template.Template)
+
+	parsedReport, err := template.New(tmplReportName+".html").Funcs(template.FuncMap{
+		"Statuses":           rule.Statuses,
+		"Icon":               rule.GetStatusIcon,
+		"Time":               convTimeFunc,
+		"RulesetSummaryText": rulesetSummaryText,
+		"RulesWithStatus":    rulesWithStatus,
+	}).ParseFS(files, tmplReportPath, tmplStylesPath)
 	if err != nil {
 		return nil, err
 	}
+	templates[tmplReportName] = parsedReport
 
-	templates := make(map[string]*template.Template)
-	for _, tmpl := range tmplFiles {
-		if tmpl.IsDir() {
-			continue
-		}
-		if !strings.HasSuffix(tmpl.Name(), ".html") {
-			continue
-		}
-
-		pt, err := template.New(tmpl.Name()).Funcs(template.FuncMap{
-			"Statuses": rule.Statuses,
-			"Icon":     rule.GetStatusIcon,
-			"Time": func(time time.Time) string {
-				return time.Format("01-02-2006")
-			},
-			"RulesetSummaryText": rulesetSummaryText,
-			"RulesWithStatus":    rulesWithStatus,
-		}).ParseFS(files, "templates/html/"+tmpl.Name(), "templates/html/_styles.tpl")
-		if err != nil {
-			return nil, err
-		}
-		templates[strings.TrimSuffix(tmpl.Name(), ".html")] = pt
+	parsedMergedReport, err := template.New(tmplMergedReportName+".html").Funcs(template.FuncMap{
+		"Statuses":                 rule.Statuses,
+		"Icon":                     rule.GetStatusIcon,
+		"Time":                     convTimeFunc,
+		"MergedMetadataTexts":      metadataTextForMergedProvider,
+		"MergedRulesetSummaryText": mergedRulesetSummaryText,
+		"MergedRulesWithStatus":    mergedRulesWithStatus,
+	}).ParseFS(files, tmplMergedReportPath, tmplStylesPath)
+	if err != nil {
+		return nil, err
 	}
+	templates[tmplMergedReportName] = parsedMergedReport
+
 	return &HTMLRenderer{
 		templates: templates,
 	}, nil
@@ -65,7 +70,9 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 func (r *HTMLRenderer) Render(w io.Writer, report any) error {
 	switch rep := report.(type) {
 	case *Report:
-		return r.templates["report"].Execute(w, rep)
+		return r.templates[tmplReportName].Execute(w, rep)
+	case *MergedReport:
+		return r.templates[tmplMergedReportName].Execute(w, rep)
 	default:
 		return fmt.Errorf("unsupported report type: %T", rep)
 	}

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {{ template "_styles" }}
+    <style>
+        .arrow {
+            border: solid black;
+            border-width: 0px 3px 3px 0px;
+            display: inline-block;
+            padding: 4px;
+        }
+
+        .right {
+            transform: rotate(-45deg);
+            -webkit-transform: rotate(-45deg);
+        }
+
+        .left {
+            transform: rotate(135deg);
+            -webkit-transform: rotate(135deg);
+        }
+
+        .up {
+            transform: rotate(-135deg);
+            -webkit-transform: rotate(-135deg);
+        }
+
+        .down {
+            transform: rotate(45deg);
+            -webkit-transform: rotate(45deg);
+        }
+    </style>
+    <script>
+        function collapse(event) {
+            const parent = event.currentTarget.parentElement
+            const list = parent.getElementsByTagName('ul')[0]
+            const arrow = event.currentTarget.getElementsByTagName('i')[0]
+
+            if (list.classList.contains('hidden') === true) {
+                list.classList.remove('hidden')
+                arrow.classList.replace('right', 'down')
+                return
+            }
+
+            list.classList.add('hidden')
+            arrow.classList.replace('down', 'right')
+        }
+    </script>
+</head>
+
+<body>
+    <div class="flex-col">
+        <h1 class="text-3xl font-bold pb-5 pt-2 flex justify-center">Compliance Run ({{ Time .Time }})</h1>
+        <div class="content px-6">
+            {{ range .Providers }}
+            <div>
+                <label class="font-bold text-2xl">Provider {{ .Name }}</label>
+                <ul class="list-disc  list-inside">
+
+                    {{ range $id, $metadataText := MergedMetadataTexts . }}
+                    <li>
+                        <span class="font-bold">{{ $id }}</span> {{ $metadataText }}
+                    </li>
+                    {{ end }}
+                </ul>
+                <ul class="list-none list-inside">
+                    {{ range .Rulesets }}
+                    {{ $statuses := Statuses }}
+                    {{ $ruleset := . }}
+                    <li>
+                        <span class="text-lg">
+                            <span class="font-semibold">{{ $ruleset.Version }} {{ $ruleset.Name }}</span> ({{
+                            MergedRulesetSummaryText $ruleset }})
+                        </span>
+                        {{ range $key, $value := $statuses }}
+                        <ul class="list-inside pl-2">
+                            {{ with MergedRulesWithStatus $ruleset $value }}
+                            <li>
+                                <button onclick="collapse(event)" class="text-lg pr-2"><i
+                                        class="arrow right"></i></button>
+                                <span class="text-lg">&#{{ Icon $value }} {{ $value }}</span>
+                                <ul class="list-inside pl-5 hidden">
+                                    {{ range . }}
+                                    <li>
+                                        <button onclick="collapse(event)" class="pr-2"><i
+                                                class="arrow right"></i></button>
+                                        <span class="font-semibold">{{ .Name }}</span>
+                                        <ul class="list-inside pl-5 hidden">
+                                            {{ range .Checks }}
+                                            <li>
+                                                <button onclick="collapse(event)" class="pr-2"><i
+                                                        class="arrow right"></i></button>
+                                                <span class="font-medium">{{ .Message }}</span>
+                                                <ul class="list-inside pl-5 hidden">
+                                                    {{ range $id, $targets := .ReportsTargets }}
+                                                    <li>
+                                                        <span class="font-semibold">{{ $id }}</span>
+                                                        <ul class="list-disc list-inside pl-5">
+                                                            {{ range $targets }}
+                                                            {{ if . }}
+                                                            <li>
+                                                                {{ range $key, $value := . }}
+                                                                <span class="font-medium">{{ $key }}</span>: {{ $value }}
+                                                                {{ end }}
+                                                            </li>
+                                                            {{ end }}
+                                                            {{ end }}
+                                                        </ul>
+                                                    </li>
+                                                    {{ end }}
+                                                </ul>
+                                            </li>
+                                            {{ end }}
+                                        </ul>
+                                    </li>
+                                    {{ end }}
+                                </ul>
+                            </li>
+                            {{ end }}
+                        </ul>
+                        {{ end }}
+                    </li>
+                    {{ end }}
+                </ul>
+            </div>
+            {{ end }}
+        </div>
+    </div>
+</body>
+
+</html>

--- a/vendor/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/vendor/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	// ciphers maps strings into tls package cipher constants in
+	// https://golang.org/pkg/crypto/tls/#pkg-constants
+	ciphers         = map[string]uint16{}
+	insecureCiphers = map[string]uint16{}
+)
+
+func init() {
+	for _, suite := range tls.CipherSuites() {
+		ciphers[suite.Name] = suite.ID
+	}
+	// keep legacy names for backward compatibility
+	ciphers["TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"] = tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+	ciphers["TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"] = tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+
+	for _, suite := range tls.InsecureCipherSuites() {
+		insecureCiphers[suite.Name] = suite.ID
+	}
+}
+
+// InsecureTLSCiphers returns the cipher suites implemented by crypto/tls which have
+// security issues.
+func InsecureTLSCiphers() map[string]uint16 {
+	cipherKeys := make(map[string]uint16, len(insecureCiphers))
+	for k, v := range insecureCiphers {
+		cipherKeys[k] = v
+	}
+	return cipherKeys
+}
+
+// InsecureTLSCipherNames returns a list of cipher suite names implemented by crypto/tls
+// which have security issues.
+func InsecureTLSCipherNames() []string {
+	cipherKeys := sets.NewString()
+	for key := range insecureCiphers {
+		cipherKeys.Insert(key)
+	}
+	return cipherKeys.List()
+}
+
+// PreferredTLSCipherNames returns a list of cipher suite names implemented by crypto/tls.
+func PreferredTLSCipherNames() []string {
+	cipherKeys := sets.NewString()
+	for key := range ciphers {
+		cipherKeys.Insert(key)
+	}
+	return cipherKeys.List()
+}
+
+func allCiphers() map[string]uint16 {
+	acceptedCiphers := make(map[string]uint16, len(ciphers)+len(insecureCiphers))
+	for k, v := range ciphers {
+		acceptedCiphers[k] = v
+	}
+	for k, v := range insecureCiphers {
+		acceptedCiphers[k] = v
+	}
+	return acceptedCiphers
+}
+
+// TLSCipherPossibleValues returns all acceptable cipher suite names.
+// This is a combination of both InsecureTLSCipherNames() and PreferredTLSCipherNames().
+func TLSCipherPossibleValues() []string {
+	cipherKeys := sets.NewString()
+	acceptedCiphers := allCiphers()
+	for key := range acceptedCiphers {
+		cipherKeys.Insert(key)
+	}
+	return cipherKeys.List()
+}
+
+// TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed.
+func TLSCipherSuites(cipherNames []string) ([]uint16, error) {
+	if len(cipherNames) == 0 {
+		return nil, nil
+	}
+	ciphersIntSlice := make([]uint16, 0)
+	possibleCiphers := allCiphers()
+	for _, cipher := range cipherNames {
+		intValue, ok := possibleCiphers[cipher]
+		if !ok {
+			return nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
+		}
+		ciphersIntSlice = append(ciphersIntSlice, intValue)
+	}
+	return ciphersIntSlice, nil
+}
+
+var versions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// TLSPossibleVersions returns all acceptable values for TLS Version.
+func TLSPossibleVersions() []string {
+	versionsKeys := sets.NewString()
+	for key := range versions {
+		versionsKeys.Insert(key)
+	}
+	return versionsKeys.List()
+}
+
+// TLSVersion returns the TLS Version ID for the version name passed.
+func TLSVersion(versionName string) (uint16, error) {
+	if len(versionName) == 0 {
+		return DefaultTLSVersion(), nil
+	}
+	if version, ok := versions[versionName]; ok {
+		return version, nil
+	}
+	return 0, fmt.Errorf("unknown tls version %q", versionName)
+}
+
+// DefaultTLSVersion defines the default TLS Version.
+func DefaultTLSVersion() uint16 {
+	// Can't use SSLv3 because of POODLE and BEAST
+	// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+	// Can't use TLSv1.1 because of RC4 cipher usage
+	return tls.VersionTLS12
+}

--- a/vendor/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string.go
+++ b/vendor/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ColonSeparatedMultimapStringString supports setting a map[string][]string from an encoding
+// that separates keys from values with ':' and separates key-value pairs with ','.
+// A key can be repeated multiple times, in which case the values are appended to a
+// slice of strings associated with that key. Items in the list associated with a given
+// key will appear in the order provided.
+// For example: `a:hello,b:again,c:world,b:beautiful` results in `{"a": ["hello"], "b": ["again", "beautiful"], "c": ["world"]}`
+// The first call to Set will clear the map before adding entries; subsequent calls will simply append to the map.
+// This makes it possible to override default values with a command-line option rather than appending to defaults,
+// while still allowing the distribution of key-value pairs across multiple flag invocations.
+// For example: `--flag "a:hello" --flag "b:again" --flag "b:beautiful" --flag "c:world"` results in `{"a": ["hello"], "b": ["again", "beautiful"], "c": ["world"]}`
+type ColonSeparatedMultimapStringString struct {
+	Multimap    *map[string][]string
+	initialized bool // set to true after the first Set call
+}
+
+// NewColonSeparatedMultimapStringString takes a pointer to a map[string][]string and returns the
+// ColonSeparatedMultimapStringString flag parsing shim for that map.
+func NewColonSeparatedMultimapStringString(m *map[string][]string) *ColonSeparatedMultimapStringString {
+	return &ColonSeparatedMultimapStringString{Multimap: m}
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *ColonSeparatedMultimapStringString) Set(value string) error {
+	if m.Multimap == nil {
+		return fmt.Errorf("no target (nil pointer to map[string][]string)")
+	}
+	if !m.initialized || *m.Multimap == nil {
+		// clear default values, or allocate if no existing map
+		*m.Multimap = make(map[string][]string)
+		m.initialized = true
+	}
+	for _, pair := range strings.Split(value, ",") {
+		if len(pair) == 0 {
+			continue
+		}
+		kv := strings.SplitN(pair, ":", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("malformed pair, expect string:string")
+		}
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+		(*m.Multimap)[k] = append((*m.Multimap)[k], v)
+	}
+	return nil
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *ColonSeparatedMultimapStringString) String() string {
+	type kv struct {
+		k string
+		v string
+	}
+	kvs := make([]kv, 0, len(*m.Multimap))
+	for k, vs := range *m.Multimap {
+		for i := range vs {
+			kvs = append(kvs, kv{k: k, v: vs[i]})
+		}
+	}
+	// stable sort by keys, order of values should be preserved
+	sort.SliceStable(kvs, func(i, j int) bool {
+		return kvs[i].k < kvs[j].k
+	})
+	pairs := make([]string, 0, len(kvs))
+	for i := range kvs {
+		pairs = append(pairs, fmt.Sprintf("%s:%s", kvs[i].k, kvs[i].v))
+	}
+	return strings.Join(pairs, ",")
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (m *ColonSeparatedMultimapStringString) Type() string {
+	return "colonSeparatedMultimapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *ColonSeparatedMultimapStringString) Empty() bool {
+	return len(*m.Multimap) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/configuration_map.go
+++ b/vendor/k8s.io/component-base/cli/flag/configuration_map.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type ConfigurationMap map[string]string
+
+func (m *ConfigurationMap) String() string {
+	pairs := []string{}
+	for k, v := range *m {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+func (m *ConfigurationMap) Set(value string) error {
+	for _, s := range strings.Split(value, ",") {
+		if len(s) == 0 {
+			continue
+		}
+		arr := strings.SplitN(s, "=", 2)
+		if len(arr) == 2 {
+			(*m)[strings.TrimSpace(arr[0])] = strings.TrimSpace(arr[1])
+		} else {
+			(*m)[strings.TrimSpace(arr[0])] = ""
+		}
+	}
+	return nil
+}
+
+func (*ConfigurationMap) Type() string {
+	return "mapStringString"
+}

--- a/vendor/k8s.io/component-base/cli/flag/flags.go
+++ b/vendor/k8s.io/component-base/cli/flag/flags.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	goflag "flag"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+var underscoreWarnings = make(map[string]bool)
+
+// WordSepNormalizeFunc changes all flags that contain "_" separators
+func WordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	if strings.Contains(name, "_") {
+		return pflag.NormalizedName(strings.Replace(name, "_", "-", -1))
+	}
+	return pflag.NormalizedName(name)
+}
+
+// WarnWordSepNormalizeFunc changes and warns for flags that contain "_" separators
+func WarnWordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	if strings.Contains(name, "_") {
+		nname := strings.Replace(name, "_", "-", -1)
+		if _, alreadyWarned := underscoreWarnings[name]; !alreadyWarned {
+			klog.Warningf("using an underscore in a flag name is not supported. %s has been converted to %s.", name, nname)
+			underscoreWarnings[name] = true
+		}
+
+		return pflag.NormalizedName(nname)
+	}
+	return pflag.NormalizedName(name)
+}
+
+// InitFlags normalizes, parses, then logs the command line flags
+func InitFlags() {
+	pflag.CommandLine.SetNormalizeFunc(WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.Parse()
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		klog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+}
+
+// PrintFlags logs the flags in the flagset
+func PrintFlags(flags *pflag.FlagSet) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+}

--- a/vendor/k8s.io/component-base/cli/flag/langle_separated_map_string_string.go
+++ b/vendor/k8s.io/component-base/cli/flag/langle_separated_map_string_string.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LangleSeparatedMapStringString can be set from the command line with the format `--flag "string<string"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported. For example: `--flag "a<foo,b<bar"`.
+// Multiple flag invocations are supported. For example: `--flag "a<foo" --flag "b<foo"`.
+type LangleSeparatedMapStringString struct {
+	Map         *map[string]string
+	initialized bool // set to true after first Set call
+}
+
+// NewLangleSeparatedMapStringString takes a pointer to a map[string]string and returns the
+// LangleSeparatedMapStringString flag parsing shim for that map
+func NewLangleSeparatedMapStringString(m *map[string]string) *LangleSeparatedMapStringString {
+	return &LangleSeparatedMapStringString{Map: m}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *LangleSeparatedMapStringString) String() string {
+	pairs := []string{}
+	for k, v := range *m.Map {
+		pairs = append(pairs, fmt.Sprintf("%s<%s", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *LangleSeparatedMapStringString) Set(value string) error {
+	if m.Map == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]string)")
+	}
+	if !m.initialized || *m.Map == nil {
+		// clear default values, or allocate if no existing map
+		*m.Map = make(map[string]string)
+		m.initialized = true
+	}
+	for _, s := range strings.Split(value, ",") {
+		if len(s) == 0 {
+			continue
+		}
+		arr := strings.SplitN(s, "<", 2)
+		if len(arr) != 2 {
+			return fmt.Errorf("malformed pair, expect string<string")
+		}
+		k := strings.TrimSpace(arr[0])
+		v := strings.TrimSpace(arr[1])
+		(*m.Map)[k] = v
+	}
+	return nil
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*LangleSeparatedMapStringString) Type() string {
+	return "mapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *LangleSeparatedMapStringString) Empty() bool {
+	return len(*m.Map) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/map_string_bool.go
+++ b/vendor/k8s.io/component-base/cli/flag/map_string_bool.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// MapStringBool can be set from the command line with the format `--flag "string=bool"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported. For example: `--flag "a=true,b=false"`.
+// Multiple flag invocations are supported. For example: `--flag "a=true" --flag "b=false"`.
+type MapStringBool struct {
+	Map         *map[string]bool
+	initialized bool
+}
+
+// NewMapStringBool takes a pointer to a map[string]string and returns the
+// MapStringBool flag parsing shim for that map
+func NewMapStringBool(m *map[string]bool) *MapStringBool {
+	return &MapStringBool{Map: m}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *MapStringBool) String() string {
+	if m == nil || m.Map == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.Map {
+		pairs = append(pairs, fmt.Sprintf("%s=%t", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *MapStringBool) Set(value string) error {
+	if m.Map == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]bool)")
+	}
+	if !m.initialized || *m.Map == nil {
+		// clear default values, or allocate if no existing map
+		*m.Map = make(map[string]bool)
+		m.initialized = true
+	}
+	for _, s := range strings.Split(value, ",") {
+		if len(s) == 0 {
+			continue
+		}
+		arr := strings.SplitN(s, "=", 2)
+		if len(arr) != 2 {
+			return fmt.Errorf("malformed pair, expect string=bool")
+		}
+		k := strings.TrimSpace(arr[0])
+		v := strings.TrimSpace(arr[1])
+		boolValue, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
+		}
+		(*m.Map)[k] = boolValue
+	}
+	return nil
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*MapStringBool) Type() string {
+	return "mapStringBool"
+}
+
+// Empty implements OmitEmpty
+func (m *MapStringBool) Empty() bool {
+	return len(*m.Map) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/map_string_string.go
+++ b/vendor/k8s.io/component-base/cli/flag/map_string_string.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MapStringString can be set from the command line with the format `--flag "string=string"`.
+// Multiple flag invocations are supported. For example: `--flag "a=foo" --flag "b=bar"`. If this is desired
+// to be the only type invocation `NoSplit` should be set to true.
+// Multiple comma-separated key-value pairs in a single invocation are supported if `NoSplit`
+// is set to false. For example: `--flag "a=foo,b=bar"`.
+type MapStringString struct {
+	Map         *map[string]string
+	initialized bool
+	NoSplit     bool
+}
+
+// NewMapStringString takes a pointer to a map[string]string and returns the
+// MapStringString flag parsing shim for that map
+func NewMapStringString(m *map[string]string) *MapStringString {
+	return &MapStringString{Map: m}
+}
+
+// NewMapStringString takes a pointer to a map[string]string and sets `NoSplit`
+// value to `true` and returns the MapStringString flag parsing shim for that map
+func NewMapStringStringNoSplit(m *map[string]string) *MapStringString {
+	return &MapStringString{
+		Map:     m,
+		NoSplit: true,
+	}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *MapStringString) String() string {
+	if m == nil || m.Map == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.Map {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *MapStringString) Set(value string) error {
+	if m.Map == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]string)")
+	}
+	if !m.initialized || *m.Map == nil {
+		// clear default values, or allocate if no existing map
+		*m.Map = make(map[string]string)
+		m.initialized = true
+	}
+
+	// account for comma-separated key-value pairs in a single invocation
+	if !m.NoSplit {
+		for _, s := range strings.Split(value, ",") {
+			if len(s) == 0 {
+				continue
+			}
+			arr := strings.SplitN(s, "=", 2)
+			if len(arr) != 2 {
+				return fmt.Errorf("malformed pair, expect string=string")
+			}
+			k := strings.TrimSpace(arr[0])
+			v := strings.TrimSpace(arr[1])
+			(*m.Map)[k] = v
+		}
+		return nil
+	}
+
+	// account for only one key-value pair in a single invocation
+	arr := strings.SplitN(value, "=", 2)
+	if len(arr) != 2 {
+		return fmt.Errorf("malformed pair, expect string=string")
+	}
+	k := strings.TrimSpace(arr[0])
+	v := strings.TrimSpace(arr[1])
+	(*m.Map)[k] = v
+	return nil
+
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*MapStringString) Type() string {
+	return "mapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *MapStringString) Empty() bool {
+	return len(*m.Map) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/namedcertkey_flag.go
+++ b/vendor/k8s.io/component-base/cli/flag/namedcertkey_flag.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"errors"
+	"flag"
+	"strings"
+)
+
+// NamedCertKey is a flag value parsing "certfile,keyfile" and "certfile,keyfile:name,name,name".
+type NamedCertKey struct {
+	Names             []string
+	CertFile, KeyFile string
+}
+
+var _ flag.Value = &NamedCertKey{}
+
+func (nkc *NamedCertKey) String() string {
+	s := nkc.CertFile + "," + nkc.KeyFile
+	if len(nkc.Names) > 0 {
+		s = s + ":" + strings.Join(nkc.Names, ",")
+	}
+	return s
+}
+
+func (nkc *NamedCertKey) Set(value string) error {
+	cs := strings.SplitN(value, ":", 2)
+	var keycert string
+	if len(cs) == 2 {
+		var names string
+		keycert, names = strings.TrimSpace(cs[0]), strings.TrimSpace(cs[1])
+		if names == "" {
+			return errors.New("empty names list is not allowed")
+		}
+		nkc.Names = nil
+		for _, name := range strings.Split(names, ",") {
+			nkc.Names = append(nkc.Names, strings.TrimSpace(name))
+		}
+	} else {
+		nkc.Names = nil
+		keycert = strings.TrimSpace(cs[0])
+	}
+	cs = strings.Split(keycert, ",")
+	if len(cs) != 2 {
+		return errors.New("expected comma separated certificate and key file paths")
+	}
+	nkc.CertFile = strings.TrimSpace(cs[0])
+	nkc.KeyFile = strings.TrimSpace(cs[1])
+	return nil
+}
+
+func (*NamedCertKey) Type() string {
+	return "namedCertKey"
+}
+
+// NamedCertKeyArray is a flag value parsing NamedCertKeys, each passed with its own
+// flag instance (in contrast to comma separated slices).
+type NamedCertKeyArray struct {
+	value   *[]NamedCertKey
+	changed bool
+}
+
+var _ flag.Value = &NamedCertKeyArray{}
+
+// NewNamedKeyCertArray creates a new NamedCertKeyArray with the internal value
+// pointing to p.
+func NewNamedCertKeyArray(p *[]NamedCertKey) *NamedCertKeyArray {
+	return &NamedCertKeyArray{
+		value: p,
+	}
+}
+
+func (a *NamedCertKeyArray) Set(val string) error {
+	nkc := NamedCertKey{}
+	err := nkc.Set(val)
+	if err != nil {
+		return err
+	}
+	if !a.changed {
+		*a.value = []NamedCertKey{nkc}
+		a.changed = true
+	} else {
+		*a.value = append(*a.value, nkc)
+	}
+	return nil
+}
+
+func (a *NamedCertKeyArray) Type() string {
+	return "namedCertKey"
+}
+
+func (a *NamedCertKeyArray) String() string {
+	nkcs := make([]string, 0, len(*a.value))
+	for i := range *a.value {
+		nkcs = append(nkcs, (*a.value)[i].String())
+	}
+	return "[" + strings.Join(nkcs, ";") + "]"
+}

--- a/vendor/k8s.io/component-base/cli/flag/noop.go
+++ b/vendor/k8s.io/component-base/cli/flag/noop.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	goflag "flag"
+	"github.com/spf13/pflag"
+)
+
+// NoOp implements goflag.Value and plfag.Value,
+// but has a noop Set implementation
+type NoOp struct{}
+
+var _ goflag.Value = NoOp{}
+var _ pflag.Value = NoOp{}
+
+func (NoOp) String() string {
+	return ""
+}
+
+func (NoOp) Set(val string) error {
+	return nil
+}
+
+func (NoOp) Type() string {
+	return "NoOp"
+}

--- a/vendor/k8s.io/component-base/cli/flag/omitempty.go
+++ b/vendor/k8s.io/component-base/cli/flag/omitempty.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+// OmitEmpty is an interface for flags to report whether their underlying value
+// is "empty." If a flag implements OmitEmpty and returns true for a call to Empty(),
+// it is assumed that flag may be omitted from the command line.
+type OmitEmpty interface {
+	Empty() bool
+}

--- a/vendor/k8s.io/component-base/cli/flag/sectioned.go
+++ b/vendor/k8s.io/component-base/cli/flag/sectioned.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	usageFmt = "Usage:\n  %s\n"
+)
+
+// NamedFlagSets stores named flag sets in the order of calling FlagSet.
+type NamedFlagSets struct {
+	// Order is an ordered list of flag set names.
+	Order []string
+	// FlagSets stores the flag sets by name.
+	FlagSets map[string]*pflag.FlagSet
+	// NormalizeNameFunc is the normalize function which used to initialize FlagSets created by NamedFlagSets.
+	NormalizeNameFunc func(f *pflag.FlagSet, name string) pflag.NormalizedName
+}
+
+// FlagSet returns the flag set with the given name and adds it to the
+// ordered name list if it is not in there yet.
+func (nfs *NamedFlagSets) FlagSet(name string) *pflag.FlagSet {
+	if nfs.FlagSets == nil {
+		nfs.FlagSets = map[string]*pflag.FlagSet{}
+	}
+	if _, ok := nfs.FlagSets[name]; !ok {
+		flagSet := pflag.NewFlagSet(name, pflag.ExitOnError)
+		flagSet.SetNormalizeFunc(pflag.CommandLine.GetNormalizeFunc())
+		if nfs.NormalizeNameFunc != nil {
+			flagSet.SetNormalizeFunc(nfs.NormalizeNameFunc)
+		}
+		nfs.FlagSets[name] = flagSet
+		nfs.Order = append(nfs.Order, name)
+	}
+	return nfs.FlagSets[name]
+}
+
+// PrintSections prints the given names flag sets in sections, with the maximal given column number.
+// If cols is zero, lines are not wrapped.
+func PrintSections(w io.Writer, fss NamedFlagSets, cols int) {
+	for _, name := range fss.Order {
+		fs := fss.FlagSets[name]
+		if !fs.HasFlags() {
+			continue
+		}
+
+		wideFS := pflag.NewFlagSet("", pflag.ExitOnError)
+		wideFS.AddFlagSet(fs)
+
+		var zzz string
+		if cols > 24 {
+			zzz = strings.Repeat("z", cols-24)
+			wideFS.Int(zzz, 0, strings.Repeat("z", cols-24))
+		}
+
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "\n%s flags:\n\n%s", strings.ToUpper(name[:1])+name[1:], wideFS.FlagUsagesWrapped(cols))
+
+		if cols > 24 {
+			i := strings.Index(buf.String(), zzz)
+			lines := strings.Split(buf.String()[:i], "\n")
+			fmt.Fprint(w, strings.Join(lines[:len(lines)-1], "\n"))
+			fmt.Fprintln(w)
+		} else {
+			fmt.Fprint(w, buf.String())
+		}
+	}
+}
+
+// SetUsageAndHelpFunc set both usage and help function.
+// Print the flag sets we need instead of all of them.
+func SetUsageAndHelpFunc(cmd *cobra.Command, fss NamedFlagSets, cols int) {
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		fmt.Fprintf(cmd.OutOrStderr(), usageFmt, cmd.UseLine())
+		PrintSections(cmd.OutOrStderr(), fss, cols)
+		return nil
+	})
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
+		PrintSections(cmd.OutOrStdout(), fss, cols)
+	})
+}

--- a/vendor/k8s.io/component-base/cli/flag/string_flag.go
+++ b/vendor/k8s.io/component-base/cli/flag/string_flag.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+// StringFlag is a string flag compatible with flags and pflags that keeps track of whether it had a value supplied or not.
+type StringFlag struct {
+	// If Set has been invoked this value is true
+	provided bool
+	// The exact value provided on the flag
+	value string
+}
+
+func NewStringFlag(defaultVal string) StringFlag {
+	return StringFlag{value: defaultVal}
+}
+
+func (f *StringFlag) Default(value string) {
+	f.value = value
+}
+
+func (f StringFlag) String() string {
+	return f.value
+}
+
+func (f StringFlag) Value() string {
+	return f.value
+}
+
+func (f *StringFlag) Set(value string) error {
+	f.value = value
+	f.provided = true
+
+	return nil
+}
+
+func (f StringFlag) Provided() bool {
+	return f.provided
+}
+
+func (f *StringFlag) Type() string {
+	return "string"
+}

--- a/vendor/k8s.io/component-base/cli/flag/string_slice_flag.go
+++ b/vendor/k8s.io/component-base/cli/flag/string_slice_flag.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	goflag "flag"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// StringSlice implements goflag.Value and plfag.Value,
+// and allows set to be invoked repeatedly to accumulate values.
+type StringSlice struct {
+	value   *[]string
+	changed bool
+}
+
+func NewStringSlice(s *[]string) *StringSlice {
+	return &StringSlice{value: s}
+}
+
+var _ goflag.Value = &StringSlice{}
+var _ pflag.Value = &StringSlice{}
+
+func (s *StringSlice) String() string {
+	if s == nil || s.value == nil {
+		return ""
+	}
+	return strings.Join(*s.value, " ")
+}
+
+func (s *StringSlice) Set(val string) error {
+	if s.value == nil {
+		return fmt.Errorf("no target (nil pointer to []string)")
+	}
+	if !s.changed {
+		*s.value = make([]string, 0)
+	}
+	*s.value = append(*s.value, val)
+	s.changed = true
+	return nil
+}
+
+func (StringSlice) Type() string {
+	return "sliceString"
+}

--- a/vendor/k8s.io/component-base/cli/flag/tristate.go
+++ b/vendor/k8s.io/component-base/cli/flag/tristate.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Tristate is a flag compatible with flags and pflags that
+// keeps track of whether it had a value supplied or not.
+type Tristate int
+
+const (
+	Unset Tristate = iota // 0
+	True
+	False
+)
+
+func (f *Tristate) Default(value bool) {
+	*f = triFromBool(value)
+}
+
+func (f Tristate) String() string {
+	b := boolFromTri(f)
+	return fmt.Sprintf("%t", b)
+}
+
+func (f Tristate) Value() bool {
+	b := boolFromTri(f)
+	return b
+}
+
+func (f *Tristate) Set(value string) error {
+	boolVal, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+
+	*f = triFromBool(boolVal)
+	return nil
+}
+
+func (f Tristate) Provided() bool {
+	if f != Unset {
+		return true
+	}
+	return false
+}
+
+func (f *Tristate) Type() string {
+	return "tristate"
+}
+
+func boolFromTri(t Tristate) bool {
+	if t == True {
+		return true
+	} else {
+		return false
+	}
+}
+
+func triFromBool(b bool) Tristate {
+	if b {
+		return True
+	} else {
+		return False
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -769,6 +769,7 @@ k8s.io/code-generator/pkg/util
 k8s.io/code-generator/third_party/forked/golang/reflect
 # k8s.io/component-base v0.26.3
 ## explicit; go 1.19
+k8s.io/component-base/cli/flag
 k8s.io/component-base/config
 k8s.io/component-base/config/v1alpha1
 k8s.io/component-base/version


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add a new functionality to the `diki report` command which allows the merge of multiple `json` reports into a single `html` report. To use this feature the `distinct-by` flag should be set with unique attributes which would be used for each provider to distinct the different reports.

TODO: write documentation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `diki report` command can now be used to merge `json` reports to a single `html` reports by setting the `distinct-by` flag.
```
