### PR TITLE
Add script to generate new `DISA k8s STIGs` dir and ruleset file

### DIFF
--- a/hack/gen-new-disak8sstig-version.sh
+++ b/hack/gen-new-disak8sstig-version.sh
@@ -7,30 +7,29 @@
 set -e
 
 old_version=${1}
-old_version_uppercase=$(echo ${old_version} | tr 'a-z' 'A-Z')
+old_version_uppercase=$(echo "${old_version}" | tr '[:lower:]' '[:upper:]')
 new_version=${2}
-new_version_uppercase=$(echo ${new_version} | tr 'a-z' 'A-Z')
+new_version_uppercase=$(echo "${new_version}" | tr '[:lower:]' '[:upper:]')
 
-cd "$(dirname "$0")"
-disak8sstig_path="../pkg/provider/gardener/ruleset/disak8sstig"
+disak8sstig_path="$(dirname "$0")/../pkg/provider/gardener/ruleset/disak8sstig"
 old_version_dir="${disak8sstig_path}/${old_version}"
 new_version_dir="${disak8sstig_path}/${new_version}"
 old_ruleset_file="${disak8sstig_path}/${old_version}_ruleset.go"
 new_ruleset_file="${disak8sstig_path}/${new_version}_ruleset.go"
 
-if [ -d ${new_version_dir} ]; then
+if [ -d "${new_version_dir}" ]; then
   echo "error: directory for ${new_version} already exists."
   exit 1
 fi
 
-if [ -f ${new_ruleset_file} ]; then
+if [ -f "${new_ruleset_file}" ]; then
   echo "error: ruleset file for ${new_version} already exists."
   exit 1
 fi
 
-cp -r ${old_version_dir} ${new_version_dir}
-cp ${old_ruleset_file} ${new_ruleset_file}
+cp -r "${old_version_dir}" "${new_version_dir}"
+cp "${old_ruleset_file}" "${new_ruleset_file}"
 
-find ${new_version_dir} -name '*.go' -exec sed -i -e "s/${old_version}/${new_version}/g" -e "s/${old_version_uppercase}/${new_version_uppercase}/g" {} \;
-sed -i -e "s/${old_version}/${new_version}/g" -e "s/${old_version_uppercase}/${new_version_uppercase}/g" ${new_ruleset_file}
-find ${new_version_dir} -name '*.go' -exec bash -c 'mv "$0" "$(echo "$0" | sed s/'"${old_version}/${new_version}"'/)" 2>/dev/null' {} \;
+find "${new_version_dir}" -name '*.go' -exec sed -i -e "s/${old_version}/${new_version}/g" -e "s/${old_version_uppercase}/${new_version_uppercase}/g" {} \;
+sed -i -e "s/${old_version}/${new_version}/g" -e "s/${old_version_uppercase}/${new_version_uppercase}/g" "${new_ruleset_file}"
+find "${new_version_dir}" -name '*.go' -exec bash -c 'mv "$0" "$(echo "$0" | sed s/'"${old_version}/${new_version}"'/)" 2>/dev/null' {} \;

--- a/hack/gen-new-disak8sstig-version.sh
+++ b/hack/gen-new-disak8sstig-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+old_version=${1}
+old_version_uppercase=$(echo ${old_version} | tr 'a-z' 'A-Z')
+new_version=${2}
+new_version_uppercase=$(echo ${new_version} | tr 'a-z' 'A-Z')
+
+cd "$(dirname "$0")"
+disak8sstig_path="../pkg/provider/gardener/ruleset/disak8sstig"
+old_version_dir="${disak8sstig_path}/${old_version}"
+new_version_dir="${disak8sstig_path}/${new_version}"
+old_ruleset_file="${disak8sstig_path}/${old_version}_ruleset.go"
+new_ruleset_file="${disak8sstig_path}/${new_version}_ruleset.go"
+
+if [ -d ${new_version_dir} ]; then
+  echo "error: directory for ${new_version} already exists."
+  exit 1
+fi
+
+if [ -f ${new_ruleset_file} ]; then
+  echo "error: ruleset file for ${new_version} already exists."
+  exit 1
+fi
+
+cp -r ${old_version_dir} ${new_version_dir}
+cp ${old_ruleset_file} ${new_ruleset_file}
+
+find ${new_version_dir} -name '*.go' -exec sed -i -e "s/${old_version}/${new_version}/g" -e "s/${old_version_uppercase}/${new_version_uppercase}/g" {} \;
+sed -i -e "s/${old_version}/${new_version}/g" -e "s/${old_version_uppercase}/${new_version_uppercase}/g" ${new_ruleset_file}
+find ${new_version_dir} -name '*.go' -exec bash -c 'mv "$0" "$(echo "$0" | sed s/'"${old_version}/${new_version}"'/)" 2>/dev/null' {} \;

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r8_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r8_ruleset.go
@@ -32,7 +32,7 @@ func parseV1R8Options[O v1r8.RuleOption](options any) (*O, error) {
 	return &parsedOptions, nil
 }
 
-func getOptionOrNil[O v1r8.RuleOption](options any) (*O, error) {
+func getV1R8OptionOrNil[O v1r8.RuleOption](options any) (*O, error) {
 	if options == nil {
 		return nil, nil
 	}
@@ -90,15 +90,15 @@ func (r *Ruleset) registerV1R8Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
-	opts242414, err := getOptionOrNil[v1r8.Options242414](ruleOptions[v1r8.ID242414].Args)
+	opts242414, err := getV1R8OptionOrNil[v1r8.Options242414](ruleOptions[v1r8.ID242414].Args)
 	if err != nil {
 		return err
 	}
-	opts245543, err := getOptionOrNil[v1r8.Options245543](ruleOptions[v1r8.ID245543].Args)
+	opts245543, err := getV1R8OptionOrNil[v1r8.Options245543](ruleOptions[v1r8.ID245543].Args)
 	if err != nil {
 		return err
 	}
-	opts254800, err := getOptionOrNil[v1r8.Options254800](ruleOptions[v1r8.ID254800].Args)
+	opts254800, err := getV1R8OptionOrNil[v1r8.Options254800](ruleOptions[v1r8.ID254800].Args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added script to generate new DISA k8s STIGs dir and `ruleset` file. The dir and file are generated by using the same components from an existing version.

Example use:
`./hack/gen-new-disak8sstig-version.sh v1r8 v1r10`

**Which issue(s) this PR fixes**:
Part of #9

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
NONE
```
