### PR TITLE
Use label selector instead of name prefix for rule `242414`

### DIFF
--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -21,13 +21,17 @@ providers:             # contains information about known providers
       #   justification: "whole rule is allowed"
       args:
         acceptedPods:
-        - podNamePrefix: "node-local-dns-"
-          namespacePrefix: "kube-system"
+        - podMatchLabels:
+            k8s-app: node-local-dns
+          namespaceMatchLabels:
+            kubernetes.io/metadata.name: kube-system
           justification: "node local dns is allowed because of special handling!"
           ports:
           - 53
-        - podNamePrefix: "network-problem-detector-"
-          namespacePrefix: "kube-system"
+        - podMatchLabels:
+            app: node-problem-detector
+          namespaceMatchLabels:
+            kubernetes.io/metadata.name: kube-system
           ports:
           - 1011
           - 1012

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -84,6 +84,21 @@ func GetNodes(ctx context.Context, c client.Client, limit int64) ([]corev1.Node,
 	}
 }
 
+// GetNamespaces returns a map containing all namespaces, where the names of the namespaces are used as a keys.
+func GetNamespaces(ctx context.Context, c client.Client) (map[string]corev1.Namespace, error) {
+	namespaceList := &corev1.NamespaceList{}
+
+	if err := c.List(ctx, namespaceList); err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]corev1.Namespace, len(namespaceList.Items))
+	for _, n := range namespaceList.Items {
+		res[n.Name] = n
+	}
+	return res, nil
+}
+
 // GetPodSecurityPolicies returns all pod security policies.
 // It retrieves policies by portions set by limit.
 func GetPodSecurityPolicies(ctx context.Context, c client.Client, limit int64) ([]policyv1beta1.PodSecurityPolicy, error) {

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -251,6 +251,53 @@ var _ = Describe("utils", func() {
 		})
 	})
 
+	Describe("#GetNamespaces", func() {
+		var (
+			fakeClient client.Client
+			ctx        = context.TODO()
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().Build()
+			for i := 0; i < 3; i++ {
+				namespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: strconv.Itoa(i),
+					},
+				}
+				Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
+			}
+		})
+
+		It("should return correct namespace map", func() {
+			namespaces, err := utils.GetNamespaces(ctx, fakeClient)
+
+			expectedNamespaces := map[string]corev1.Namespace{
+				"0": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "0",
+						ResourceVersion: "1",
+					},
+				},
+				"1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "1",
+						ResourceVersion: "1",
+					},
+				},
+				"2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "2",
+						ResourceVersion: "1",
+					},
+				},
+			}
+
+			Expect(namespaces).To(Equal(expectedNamespaces))
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Describe("#GetPodSecurityPolicies", func() {
 		var (
 			fakeClient client.Client

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -105,6 +105,21 @@ func Subset(s1, s2 []string) bool {
 	return true
 }
 
+// MatchLabels checks if all m2 keys and values are present in m1. If m1 or m2 is nil returns false.
+func MatchLabels(a, b map[string]string) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	for k, v := range b {
+		if a[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MatchFilePermissionsAndOwnersCases returns []rule.CheckResult for a given file and its permissions and owners  for a select expected values.
 func MatchFilePermissionsAndOwnersCases(
 	filePermissions,

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -106,13 +106,13 @@ func Subset(s1, s2 []string) bool {
 }
 
 // MatchLabels checks if all m2 keys and values are present in m1. If m1 or m2 is nil returns false.
-func MatchLabels(a, b map[string]string) bool {
-	if a == nil || b == nil {
+func MatchLabels(m1, m2 map[string]string) bool {
+	if m1 == nil || m2 == nil {
 		return false
 	}
 
-	for k, v := range b {
-		if a[k] != v {
+	for k, v := range m2 {
+		if m1[k] != v {
 			return false
 		}
 	}

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -220,6 +220,24 @@ var _ = Describe("utils", func() {
 			[]string{"foo", "bar", "foo-bar"}, []string{"foo", "bar"}, false),
 	)
 
+	DescribeTable("#MatchLabels",
+		func(m1, m2 map[string]string, expectedResult bool) {
+			result := utils.MatchLabels(m1, m2)
+
+			Expect(result).To(Equal(expectedResult))
+		},
+		Entry("should return true when m1 contains all keys and values of m2",
+			map[string]string{"foo": "bar", "key1": "value1", "key2": "value2"},
+			map[string]string{"key1": "value1", "key2": "value2"}, true),
+		Entry("should return false when m1 does not contain all keys and values of m2",
+			map[string]string{"key1": "value1", "key2": "value2"},
+			map[string]string{"key1": "value1", "foo": "bar"}, false),
+		Entry("should return false when m1 is nil",
+			nil, map[string]string{"key1": "value1", "foo": "bar"}, false),
+		Entry("should return false when m2 is nil",
+			map[string]string{"key1": "value1", "foo": "bar"}, nil, false),
+	)
+
 	Describe("#MatchFilePermissionsAndOwnersCases", func() {
 		var (
 			target = gardener.NewTarget()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes rule `242414` to use pod and namespace label selectors for accepting pods instead of pod name and namespace prefixes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Selecting accepted pods for rule `242414` in the config file has been changed to use pod and namespace label selectors instead of name prefixes.
```
