### PR TITLE
Make `gardener.Target` implement `Stringer`

### DIFF
--- a/pkg/provider/gardener/targets.go
+++ b/pkg/provider/gardener/targets.go
@@ -5,7 +5,10 @@
 package gardener
 
 import (
+	"fmt"
 	"maps"
+	"slices"
+	"strings"
 )
 
 // StringTarget describes the targets which were checked during ruleset runs.
@@ -19,6 +22,25 @@ func (s StringTarget) String() string {
 // Target is a structure that can be represented as string.
 // It is used to describe the targets which were checked during ruleset runs.
 type Target map[string]string
+
+// Target implements Stringer.
+func (t Target) String() string {
+	var sb strings.Builder
+	sb.WriteString("[")
+
+	sortedKeys := []string{}
+	for key := range t {
+		sortedKeys = append(sortedKeys, key)
+	}
+	slices.Sort(sortedKeys)
+
+	for _, key := range sortedKeys {
+		sb.WriteString(fmt.Sprintf(" %s:%s", key, t[key]))
+	}
+
+	sb.WriteString(" ]")
+	return sb.String()
+}
 
 // NewTarget creates a new Target with the given key values.
 // Panics if the number of arguments is an odd number.


### PR DESCRIPTION
**What this PR does / why we need it**:
When running a single rule we require the used Target struct to implement Stringer in order for the output to contain the Target.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
