### PR TITLE
Output from single rule execution changed to `json` format

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -250,11 +250,12 @@ func runRule(ctx context.Context, p provider.Provider, rulesetID, rulesetVersion
 		return err
 	}
 
-	fmt.Printf("Rule: %s\n", res.RuleName)
-	for _, cr := range res.CheckResults {
-		fmt.Printf("- Status: %s %s Message: %s Target: %s\n", cr.Status, string(rule.GetStatusIcon(cr.Status)), cr.Message, StringOrDefault(cr.Target))
+	j, err := json.Marshal(res)
+	if err != nil {
+		return err
 	}
 
+	fmt.Print(string(j))
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the output of a single rule execution to be in `json` format.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The output of a single rule execution is not presented in `json` format.
```
