### PR TITLE
Add `v1r10` to `FromGenericConfig`

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -95,6 +95,10 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, shootConfig, seedConf
 		if err := ruleset.registerV1R8Rules(ruleOptions); err != nil {
 			return nil, err
 		}
+	case "v1r10":
+		if err := ruleset.registerV1R10Rules(ruleOptions); err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("unknown ruleset %s version: %s", rulesetConfig.ID, rulesetConfig.Version)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Diki can now run DISA Kubernetes STIG version `v1r10` ruleset.
```
