### PR TITLE
Shrink size of `html` reports

### DIFF
--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -87,7 +87,7 @@
                                                     {{ range $id, $targets := .ReportsTargets }}<li>
                                                         <span class="font-semibold">{{ $id }}</span>
                                                         <ul class="list-disc list-inside pl-5">
-                                                            {{ range $targets }}{{ if . }}<li>{{ range $key, $value := . }}<span class="font-medium">{{ $key }}</span>: {{ $value }} {{ end }}</li>
+                                                            {{ range $targets }}{{ if . }}<li>{{ range $key, $value := . }}{{ $key }}: {{ $value }} {{ end }}</li>
                                                             {{ end }}{{ end }}
                                                         </ul>
                                                     </li>{{ end }}

--- a/pkg/report/templates/html/report.html
+++ b/pkg/report/templates/html/report.html
@@ -83,7 +83,7 @@
                                                         class="arrow right"></i></button>
                                                 <span class="font-medium">{{ .Message }}</span>
                                                 <ul class="list-disc list-inside pl-5 hidden">
-                                                    {{ range .Targets }}{{ if . }}<li>{{ range $key, $value := . }}<span class="font-medium">{{ $key }}</span>: {{ $value }};{{ end }}</li>
+                                                    {{ range .Targets }}{{ if . }}<li>{{ range $key, $value := . }}{{ $key }}: {{ $value }};{{ end }}</li>
                                                     {{ end }}{{ end }}
                                                 </ul>
                                             </li>{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lowers the size of `html` reports by removing overused font spans.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
