### PR TITLE
Improve provider meta sorting

### DIFF
--- a/pkg/report/merged_report.go
+++ b/pkg/report/merged_report.go
@@ -243,7 +243,8 @@ func metadataTextForMergedProvider(mp MergedProvider) map[string]string {
 	for id, metadata := range mp.Metadata {
 		var sb strings.Builder
 		empty := true
-		for key, value := range metadata {
+		keys := sortedKeys(metadata)
+		for _, key := range keys {
 			if key == mp.DistinctBy {
 				continue
 			}
@@ -251,7 +252,7 @@ func metadataTextForMergedProvider(mp MergedProvider) map[string]string {
 				sb.WriteString("(")
 				empty = false
 			}
-			sb.WriteString(fmt.Sprintf("%s: %s, ", key, value))
+			sb.WriteString(fmt.Sprintf("%s: %s, ", key, metadata[key]))
 		}
 
 		metadataText := sb.String()

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -45,6 +45,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 		"Time":               convTimeFunc,
 		"RulesetSummaryText": rulesetSummaryText,
 		"RulesWithStatus":    rulesWithStatus,
+		"SortedMapKeys":      sortedKeys[string],
 	}).ParseFS(files, tmplReportPath, tmplStylesPath)
 	if err != nil {
 		return nil, err
@@ -58,6 +59,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 		"MergedMetadataTexts":      metadataTextForMergedProvider,
 		"MergedRulesetSummaryText": mergedRulesetSummaryText,
 		"MergedRulesWithStatus":    mergedRulesWithStatus,
+		"SortedMapKeys":            sortedKeys[string],
 	}).ParseFS(files, tmplMergedReportPath, tmplStylesPath)
 	if err != nil {
 		return nil, err

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -210,3 +210,12 @@ func getChecks(checkResults []rule.CheckResult, opts *ReportOptions) []Check {
 	}
 	return checks
 }
+
+func sortedKeys[T any](m map[string]T) []string {
+	res := make([]string, 0, len(m))
+	for k := range m {
+		res = append(res, k)
+	}
+	slices.Sort(res)
+	return res
+}

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -59,7 +59,9 @@
             {{ range .Providers }}<div>
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label>
                 <ul class="list-disc  list-inside">
-                    {{ range $id, $metadataText := MergedMetadataTexts . }}<li><span class="font-bold">{{ $id }}</span> {{ $metadataText }}</li>
+                    {{ $meta := MergedMetadataTexts . }}
+                    {{ $keys := SortedMapKeys $meta }}
+                    {{ range $id := $keys }}<li><span class="font-bold">{{ $id }}</span> {{ index $meta $id }}</li>
                     {{ end }}
                 </ul>
                 <ul class="list-none list-inside">

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -59,10 +59,11 @@
             {{ range .Providers }}<div>
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label>
                 <ul class="list-disc  list-inside">
-                    {{ $meta := MergedMetadataTexts . }}
-                    {{ $keys := SortedMapKeys $meta }}
-                    {{ range $id := $keys }}<li><span class="font-bold">{{ $id }}</span> {{ index $meta $id }}</li>
-                    {{ end }}
+                    {{- $meta := MergedMetadataTexts . }}
+                    {{- $keys := SortedMapKeys $meta }}
+                    {{- range $id := $keys }}
+                    <li><span class="font-bold">{{ $id }}</span> {{ index $meta $id }}</li>
+                    {{- end }}
                 </ul>
                 <ul class="list-none list-inside">
                     {{ range .Rulesets }}{{ $statuses := Statuses }}{{ $ruleset := . }}<li>

--- a/pkg/report/templates/html/report.html
+++ b/pkg/report/templates/html/report.html
@@ -59,10 +59,11 @@
             {{ range .Providers }}<div>
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label>
                 <ul class="list-disc  list-inside">
-                    {{ $keys := SortedMapKeys .Metadata }}
-                    {{ $meta := .Metadata }}
-                    {{ range $key := $keys }}<li><span class="font-semibold">{{ $key }}</span>: {{ index $meta $key }}</li>
-                    {{ end }}
+                    {{- $keys := SortedMapKeys .Metadata }}
+                    {{- $meta := .Metadata }}
+                    {{- range $key := $keys }}
+                    <li><span class="font-semibold">{{ $key }}</span>: {{ index $meta $key }}</li>
+                    {{- end }}
                 </ul>
                 <ul class="list-none list-inside">
                     {{ range .Rulesets }}{{ $statuses := Statuses }}{{ $ruleset := . }}<li>

--- a/pkg/report/templates/html/report.html
+++ b/pkg/report/templates/html/report.html
@@ -59,7 +59,9 @@
             {{ range .Providers }}<div>
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label>
                 <ul class="list-disc  list-inside">
-                    {{ range $key, $value := .Metadata }}<li><span class="font-semibold">{{ $key }}</span>: {{ $value }}</li>
+                    {{ $keys := SortedMapKeys .Metadata }}
+                    {{ $meta := .Metadata }}
+                    {{ range $key := $keys }}<li><span class="font-semibold">{{ $key }}</span>: {{ index $meta $key }}</li>
                     {{ end }}
                 </ul>
                 <ul class="list-none list-inside">


### PR DESCRIPTION
**What this PR does / why we need it**:
Sorts the metadata keys and providers in order to generate more consistent reports.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Metadata and providers are now sorted when generating a report in order to improve consistency and readability.
```
