### PR TITLE
`pod-files` checks only files with paths part of the `volumeMounts` of the container

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -286,12 +286,13 @@ func (r *RulePodFiles) checkContainerd(
 
 func (r *RulePodFiles) isMountRequiredByContainer(destination, containerName string, pod *corev1.Pod) bool {
 	for _, container := range pod.Spec.Containers {
-		if container.Name == containerName {
-			if containsDestination := slices.ContainsFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
-				return volumeMount.MountPath == destination
-			}); containsDestination {
-				return true
-			}
+		if container.Name != containerName {
+			continue
+		}
+		if containsDestination := slices.ContainsFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+			return volumeMount.MountPath == destination
+		}); containsDestination {
+			return true
 		}
 	}
 	return false

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -29,6 +29,10 @@ var _ = Describe("#RulePodFiles", func() {
   {
     "destination": "/destination",
     "source": "/source"
+  }, 
+  {
+    "destination": "/destination",
+    "source": "/foo"
   }
 ]`
 		emptyMounts    = `[]`
@@ -38,8 +42,8 @@ var _ = Describe("#RulePodFiles", func() {
     "source": "/source"
   }
 ]`
-		compliantStats = `600 0 0 /compliant/file1.txt
-644 0 65534 /foo/bar/file2.txt`
+		compliantStats = `600 0 0 /source/file1.txt
+644 0 65534 /source/bar/file2.txt`
 	)
 
 	var (
@@ -80,6 +84,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -107,6 +116,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -133,6 +147,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -159,6 +178,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -185,6 +209,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -212,6 +241,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -235,6 +269,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -260,6 +299,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -283,6 +327,11 @@ var _ = Describe("#RulePodFiles", func() {
 				Containers: []corev1.Container{
 					{
 						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/source",
+							},
+						},
 					},
 				},
 			},
@@ -340,17 +389,17 @@ var _ = Describe("#RulePodFiles", func() {
 			[][]string{{mounts, compliantStats}}, [][]string{{mounts, compliantStats}},
 			[][]error{{nil, nil}}, [][]error{{nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /compliant/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /foo/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /compliant/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /foo/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /source/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /source/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
 			}),
 		Entry("should return correct checkResult when container is etcd", "",
 			[][]string{{mountsWithETCD, compliantStats}}, [][]string{{emptyMounts}},
 			[][]error{{nil, nil}}, [][]error{{nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /compliant/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /foo/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
 			}),
 		Entry("should return errored checkResults when podExecutor errors", "",
 			[][]string{{mounts}}, [][]string{{mounts, compliantStats}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -31,8 +31,12 @@ var _ = Describe("#RulePodFiles", func() {
     "source": "/source"
   }, 
   {
-    "destination": "/destination",
-    "source": "/foo"
+    "destination": "/foo",
+    "source": "/source"
+  },
+  {
+    "destination": "/bar",
+    "source": "/source"
   }
 ]`
 		emptyMounts    = `[]`
@@ -42,8 +46,8 @@ var _ = Describe("#RulePodFiles", func() {
     "source": "/source"
   }
 ]`
-		compliantStats = `600 0 0 /source/file1.txt
-644 0 65534 /source/bar/file2.txt`
+		compliantStats = `600 0 0 /destination/file1.txt
+644 0 65534 /destination/bar/file2.txt`
 	)
 
 	var (
@@ -86,7 +90,24 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
+							},
+							{
+								Name:      "bar",
+								MountPath: "/bar",
+							},
+							{
+								MountPath: "/destination/etcd/data",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "bar",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/lib/modules",
 							},
 						},
 					},
@@ -118,7 +139,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -149,7 +170,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -180,7 +201,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -211,7 +232,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -243,7 +264,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -271,7 +292,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -301,7 +322,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -329,7 +350,7 @@ var _ = Describe("#RulePodFiles", func() {
 						Name: "test",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								MountPath: "/source",
+								MountPath: "/destination",
 							},
 						},
 					},
@@ -389,17 +410,17 @@ var _ = Describe("#RulePodFiles", func() {
 			[][]string{{mounts, compliantStats}}, [][]string{{mounts, compliantStats}},
 			[][]error{{nil, nil}}, [][]error{{nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /source/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /source/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65534")),
 			}),
 		Entry("should return correct checkResult when container is etcd", "",
 			[][]string{{mountsWithETCD, compliantStats}}, [][]string{{emptyMounts}},
 			[][]error{{nil, nil}}, [][]error{{nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /source/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
 			}),
 		Entry("should return errored checkResults when podExecutor errors", "",
 			[][]string{{mounts}}, [][]string{{mounts, compliantStats}},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
DISA Kubernetes STIGS `pod-files` rule now checks only files with paths part of the `volumeMounts` for the specific container. It also excludes directories of no interest like `/var/log/journal`.
```
