### PR TITLE
Create `diki` pods only on nodes with free allocatable pod space for `pod-files` rule

### DIFF
--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -301,16 +301,16 @@ func SelectPodOfReferenceGroup(pods []corev1.Pod, nodesAllocatablePods map[strin
 			}
 		}
 
-		if maxAllocatablePods > 0 {
-			groupedPodsByNodes[podToUse.Spec.NodeName] = []corev1.Pod{podToUse}
+		if maxAllocatablePods <= 0 {
+			referenceGroupTarget := target.With("name", pods[0].OwnerReferences[0].Name, "uid", string((pods[0].OwnerReferences[0].UID)), "kind", "referenceGroup")
+			checkResults = append(
+				checkResults,
+				rule.WarningCheckResult("Reference group cannot be tested since all pods of the group are scheduled on a fully allocated node.", referenceGroupTarget),
+			)
 			continue
 		}
 
-		referenceGroupTarget := target.With("name", pods[0].OwnerReferences[0].Name, "uid", string((pods[0].OwnerReferences[0].UID)), "kind", "referenceGroup")
-		checkResults = append(
-			checkResults,
-			rule.WarningCheckResult("Reference group cannot be tested since all pods of the group are scheduled on a fully allocated node.", referenceGroupTarget),
-		)
+		groupedPodsByNodes[podToUse.Spec.NodeName] = []corev1.Pod{podToUse}
 	}
 	return groupedPodsByNodes, checkResults
 }

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -292,17 +292,17 @@ func SelectPodOfReferenceGroup(pods []corev1.Pod, nodesAllocatablePods map[strin
 		// if none of the pods match already selected node then
 		// select the node and add a single pod of the reference group for checking
 		maxAllocatablePods := 0
-		var podToUse *corev1.Pod
+		podToUse := corev1.Pod{}
 		for _, pod := range pods {
 			nodeName := pod.Spec.NodeName
 			if nodesAllocatablePods[nodeName] > maxAllocatablePods {
 				maxAllocatablePods = nodesAllocatablePods[nodeName]
-				podToUse = &pod
+				podToUse = pod
 			}
 		}
 
 		if maxAllocatablePods > 0 {
-			groupedPodsByNodes[podToUse.Spec.NodeName] = []corev1.Pod{*podToUse}
+			groupedPodsByNodes[podToUse.Spec.NodeName] = []corev1.Pod{podToUse}
 			continue
 		}
 

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -285,12 +285,12 @@ func SelectPodOfReferenceGroup(pods []corev1.Pod, nodesAllocatablePods map[strin
 		if podOnUsedNodeIdx >= 0 {
 			pod := pods[podOnUsedNodeIdx]
 			groupedPodsByNodes[pod.Spec.NodeName] = append(groupedPodsByNodes[pod.Spec.NodeName], pod)
-
 			continue
 		}
 
 		// if none of the pods match already selected node then
-		// select the node and add a single pod of the reference group for checking
+		// select the node and add a single pod of the reference group for checking.
+		// the selected node must have allocatable pod space
 		maxAllocatablePods := 0
 		podToUse := corev1.Pod{}
 		for _, pod := range pods {

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -214,9 +214,9 @@ func MatchFilePermissionsAndOwnersCases(
 	return checkResults
 }
 
-// GetNodesAllocatablePods return the number of free
+// GetNodesAllocatablePodsNum return the number of free
 // allocatable spots of pods for all nodes.
-func GetNodesAllocatablePods(pods []corev1.Pod, nodes []corev1.Node) map[string]int {
+func GetNodesAllocatablePodsNum(pods []corev1.Pod, nodes []corev1.Node) map[string]int {
 	nodesAllocatablePods := map[string]int{}
 
 	for _, node := range nodes {

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -223,7 +223,7 @@ func GetNodesAllocatablePods(pods []corev1.Pod, nodes []corev1.Node) map[string]
 		nodesAllocatablePods[node.Name] = int(node.Status.Allocatable.Pods().Value())
 	}
 	for _, pod := range pods {
-		if pod.Spec.NodeName != "" && pod.Status.Phase != corev1.PodFailed && pod.Status.Phase != corev1.PodSucceeded {
+		if pod.Spec.NodeName != "" {
 			nodesAllocatablePods[pod.Spec.NodeName]--
 		}
 	}

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -250,7 +250,7 @@ func SelectPodOfReferenceGroup(pods []corev1.Pod, nodesAllocatablePods map[strin
 					groupedPodsByNodes[pod.Spec.NodeName] = append(groupedPodsByNodes[pod.Spec.NodeName], pod)
 					continue
 				}
-				checkResults = append(checkResults, rule.WarningCheckResult("Pod cannon be tested, since it is scheduled on a fully allocated node.", podTarget.With("node", pod.Spec.NodeName)))
+				checkResults = append(checkResults, rule.WarningCheckResult("Pod cannot be tested since it is scheduled on a fully allocated node.", podTarget.With("node", pod.Spec.NodeName)))
 				continue
 			}
 
@@ -309,7 +309,7 @@ func SelectPodOfReferenceGroup(pods []corev1.Pod, nodesAllocatablePods map[strin
 		referenceGroupTarget := target.With("name", pods[0].OwnerReferences[0].Name, "uid", string((pods[0].OwnerReferences[0].UID)), "kind", "referenceGroup")
 		checkResults = append(
 			checkResults,
-			rule.WarningCheckResult("Reference group cannon be tested, since all pods of the group are scheduled on a fully allocated node.", referenceGroupTarget),
+			rule.WarningCheckResult("Reference group cannot be tested since all pods of the group are scheduled on a fully allocated node.", referenceGroupTarget),
 		)
 	}
 	return groupedPodsByNodes, checkResults

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -291,7 +291,7 @@ var _ = Describe("utils", func() {
 		)
 	})
 
-	Describe("#GetNodesAllocatablePods", func() {
+	Describe("#GetNodesAllocatablePodsNum", func() {
 		It("should correct number of allocatable pods", func() {
 			pod1 := &corev1.Pod{}
 			pod1.Name = "pod1"
@@ -341,7 +341,7 @@ var _ = Describe("utils", func() {
 				"node3": 9,
 			}
 
-			res := utils.GetNodesAllocatablePods(pods, nodes)
+			res := utils.GetNodesAllocatablePodsNum(pods, nodes)
 
 			Expect(res).To(Equal(expectedRes))
 		})
@@ -392,7 +392,7 @@ var _ = Describe("utils", func() {
 				"node3": 10,
 			}
 
-			res := utils.GetNodesAllocatablePods(pods, nodes)
+			res := utils.GetNodesAllocatablePodsNum(pods, nodes)
 
 			Expect(res).To(Equal(expectedRes))
 		})

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -673,17 +673,17 @@ var _ = Describe("utils", func() {
 			expectedCheckResults := []rule.CheckResult{
 				{
 					Status:  rule.Warning,
-					Message: "Pod cannon be tested, since it is scheduled on a fully allocated node.",
+					Message: "Pod cannot be tested since it is scheduled on a fully allocated node.",
 					Target:  gardener.NewTarget("name", "pod2", "namespace", "", "kind", "pod", "node", "node2"),
 				},
 				{
 					Status:  rule.Warning,
-					Message: "Pod cannon be tested, since it is scheduled on a fully allocated node.",
+					Message: "Pod cannot be tested since it is scheduled on a fully allocated node.",
 					Target:  gardener.NewTarget("name", "pod3", "namespace", "", "kind", "pod", "node", "node1"),
 				},
 				{
 					Status:  rule.Warning,
-					Message: "Reference group cannon be tested, since all pods of the group are scheduled on a fully allocated node.",
+					Message: "Reference group cannot be tested since all pods of the group are scheduled on a fully allocated node.",
 					Target:  gardener.NewTarget("name", "", "uid", "1", "kind", "referenceGroup"),
 				},
 			}

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -346,11 +346,9 @@ var _ = Describe("utils", func() {
 			Expect(res).To(Equal(expectedRes))
 		})
 
-		It("should correct number of allocatable pods when some pods are in failed or succeeded phase or not scheduled.", func() {
+		It("should correct number of allocatable pods when some pods are not scheduled.", func() {
 			pod1 := &corev1.Pod{}
 			pod1.Name = "pod1"
-			pod1.Spec.NodeName = "node1"
-			pod1.Status.Phase = corev1.PodFailed
 
 			pod2 := &corev1.Pod{}
 			pod2.Name = "pod2"
@@ -362,8 +360,6 @@ var _ = Describe("utils", func() {
 
 			pod4 := &corev1.Pod{}
 			pod4.Name = "pod4"
-			pod4.Spec.NodeName = "node2"
-			pod4.Status.Phase = corev1.PodSucceeded
 
 			pod5 := &corev1.Pod{}
 			pod5.Name = "pod5"

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -138,7 +138,7 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 }
 
 func (r *RulePodFiles) checkPods(ctx context.Context, clusterTarget gardener.Target, image string, c client.Client, podContext pod.PodContext, pods, selectedPods []corev1.Pod, nodes []corev1.Node, mandatoryComponents map[string][]string) []rule.CheckResult {
-	nodesAllocatablePods := utils.GetNodesAllocatablePods(pods, nodes)
+	nodesAllocatablePods := utils.GetNodesAllocatablePodsNum(pods, nodes)
 	groupedPods, checkResults := utils.SelectPodOfReferenceGroup(selectedPods, nodesAllocatablePods, clusterTarget)
 
 	for nodeName, pods := range groupedPods {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -141,14 +141,6 @@ func (r *RulePodFiles) checkPods(ctx context.Context, clusterTarget gardener.Tar
 	nodesAllocatablePods := utils.GetNodesAllocatablePods(pods, nodes)
 	groupedPods, checkResults := utils.SelectPodOfReferenceGroup(selectedPods, nodesAllocatablePods, clusterTarget)
 
-	for node, pods := range groupedPods {
-		out := fmt.Sprintf("%s: ", node)
-		for _, pod := range pods {
-			out = fmt.Sprintf("%s%s; ", out, pod.Name)
-		}
-		fmt.Printf("%s\n", out)
-	}
-
 	for nodeName, pods := range groupedPods {
 		checkResultsForNodePods := r.checkNodePods(ctx, clusterTarget, image, nodeName, c, podContext, pods, mandatoryComponents)
 		checkResults = append(checkResults, checkResultsForNodePods...)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix| user
DISA Kubernetes STIGs `pod-files` rule now creates `diki` pods only on nodes with free allocatable space.
```
