### PR TITLE
`pod-files` rule allow user and group ID `65532`

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -227,8 +227,8 @@ func (r *RulePodFiles) checkContainerd(
 		value := pair[1]
 		if metav1.HasLabel(pod.ObjectMeta, key) && pod.Labels[key] == value {
 			delete(mandatoryComponents, component)
-			expectedFileOwnerUsers = []string{"0"}
-			expectedFileOwnerGroups = []string{"0", "65534"}
+			expectedFileOwnerUsers = []string{"0", "65532"}
+			expectedFileOwnerGroups = []string{"0", "65532", "65534"}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
DISA Kubernetes STIGs `pod-files` rule now passes files with owner and/or group ID `65532`.
```
