### PR TITLE
`SimplePodExecutor` `Execute()` return `stderr` before error code

### DIFF
--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -142,17 +142,17 @@ func (spe *SimplePodExecutor) Execute(ctx context.Context, command string, comma
 		Stderr: &stderr,
 		Tty:    false,
 	})
-	if err != nil {
-		return "", err
-	}
-
-	stderrByte, err := io.ReadAll(&stderr)
-	if err != nil {
-		return "", err
+	stderrByte, otherErr := io.ReadAll(&stderr)
+	if otherErr != nil {
+		return "", otherErr
 	}
 
 	if len(stderrByte) > 0 {
 		return "", fmt.Errorf("command stderr output: %s", string(stderrByte))
+	}
+
+	if err != nil {
+		return "", err
 	}
 
 	result, err := io.ReadAll(&stdout)

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -148,11 +148,11 @@ func (spe *SimplePodExecutor) Execute(ctx context.Context, command string, comma
 	}
 
 	if len(stderrByte) > 0 {
-		return "", fmt.Errorf("command stderr output: %s", string(stderrByte))
+		return "", fmt.Errorf("command %s %s stderr output: %s", command, commandArg, string(stderrByte))
 	}
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("command %s %s errored: %s", command, commandArg, err.Error())
 	}
 
 	result, err := io.ReadAll(&stdout)


### PR DESCRIPTION
**What this PR does / why we need it**:
When bash commands error they sometimes output an error message on stderr, exit with an exit code or do both. This PR changes the `SimplePodExecutor` `Execute` method to return the stderr first, if there is one, since it is more  descriptive.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
