### PR TITLE
Add `expectedFileOwner` option to `pod-files` rule

### DIFF
--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -51,7 +51,6 @@ providers:             # contains information about known providers
         # `kube-controller-manager` and `kube-proxy`
         expectedFileOwner:
           # users and groups default to ["0"]
-          # when set to empty array [] allow all
           #
           # Gardener images use distroless nonroot user with ID 65532
           # https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -44,6 +44,19 @@ providers:             # contains information about known providers
     - ruleID: "254800"
       args:
         minPodSecurityLevel: "baseline"
+    - ruleID: "pod-files"
+      args:
+        # expecedFileOwner for mandatory components:
+        # `etcd`, `kube-apiserver` , `kube-scheduler`,
+        # `kube-controller-manager` and `kube-proxy`
+        expectedFileOwner:
+          # users and groups default to ["0"]
+          # when set to empty array [] allow all
+          #
+          # Gardener images use distroless nonroot user with ID 65532
+          # https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8
+          users: ["0", "65532"]
+          groups: ["0", "65532"]
 output:
   path: /tmp/test-output.json          #  optional, path to summary json report
   minStatus: Passed

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/options.go
@@ -103,5 +103,5 @@ const (
 )
 
 type RuleOption interface {
-	Options242414 | Options245543 | Options254800
+	Options242414 | Options245543 | Options254800 | OptionsPodFiles
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -45,7 +45,7 @@ type RulePodFiles struct {
 }
 
 type OptionsPodFiles struct {
-	ExpectedFileOwner *ExpectedFileOwner `yaml:"expectedFileOwner"`
+	ExpectedFileOwner ExpectedFileOwner `yaml:"expectedFileOwner"`
 }
 
 type ExpectedFileOwner struct {
@@ -75,11 +75,11 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 	if r.Options == nil {
 		r.Options = &OptionsPodFiles{}
 	}
-	if r.Options.ExpectedFileOwner == nil {
-		r.Options.ExpectedFileOwner = &ExpectedFileOwner{
-			Users:  []string{"0"},
-			Groups: []string{"0"},
-		}
+	if len(r.Options.ExpectedFileOwner.Users) == 0 {
+		r.Options.ExpectedFileOwner.Users = []string{"0"}
+	}
+	if len(r.Options.ExpectedFileOwner.Groups) == 0 {
+		r.Options.ExpectedFileOwner.Groups = []string{"0"}
 	}
 
 	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -40,7 +40,17 @@ type RulePodFiles struct {
 	ControlPlanePodContext pod.PodContext
 	ClusterClient          client.Client
 	ClusterPodContext      pod.PodContext
+	Options                *OptionsPodFiles
 	Logger                 *slog.Logger
+}
+
+type OptionsPodFiles struct {
+	ExpectedFileOwner *ExpectedFileOwner `yaml:"expectedFileOwner"`
+}
+
+type ExpectedFileOwner struct {
+	Users  []string `yaml:"users"`
+	Groups []string `yaml:"groups"`
 }
 
 func (r *RulePodFiles) ID() string {
@@ -62,6 +72,16 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 	mandatoryComponentsShoot := map[string][]string{
 		"Kube Proxy": {"role", "proxy"}, // rules 242447, 242448
 	}
+	if r.Options == nil {
+		r.Options = &OptionsPodFiles{}
+	}
+	if r.Options.ExpectedFileOwner == nil {
+		r.Options.ExpectedFileOwner = &ExpectedFileOwner{
+			Users:  []string{"0"},
+			Groups: []string{"0"},
+		}
+	}
+
 	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
@@ -251,10 +271,8 @@ func (r *RulePodFiles) checkContainerd(
 		value := pair[1]
 		if metav1.HasLabel(pod.ObjectMeta, key) && pod.Labels[key] == value {
 			delete(mandatoryComponents, component)
-			// Gardener images use distroless nonroot user with ID 65532
-			// https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8
-			expectedFileOwnerUsers = []string{"0", "65532"}
-			expectedFileOwnerGroups = []string{"0", "65532"}
+			expectedFileOwnerUsers = r.Options.ExpectedFileOwner.Users
+			expectedFileOwnerGroups = r.Options.ExpectedFileOwner.Groups
 		}
 	}
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -189,7 +189,7 @@ var _ = Describe("#RulePodFiles", func() {
 	})
 
 	DescribeTable("Run cases",
-		func(etcdMainPodLabelInstance string, controlPlaneExecuteReturnString, clusterExecuteReturnString [][]string, controlPlaneExecuteReturnError, clusterExecuteReturnError [][]error, expectedCheckResults []rule.CheckResult) {
+		func(etcdMainPodLabelInstance string, controlPlaneExecuteReturnString, clusterExecuteReturnString [][]string, controlPlaneExecuteReturnError, clusterExecuteReturnError [][]error, options *v1r10.OptionsPodFiles, expectedCheckResults []rule.CheckResult) {
 			clusterExecuteReturnString[0] = append(clusterExecuteReturnString[0], emptyMounts)
 			clusterExecuteReturnError[0] = append(clusterExecuteReturnError[0], nil)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(clusterExecuteReturnString, clusterExecuteReturnError)
@@ -206,6 +206,7 @@ var _ = Describe("#RulePodFiles", func() {
 				ControlPlaneNamespace:  controlPlaneNamespace,
 				ClusterPodContext:      fakeClusterPodContext,
 				ControlPlanePodContext: fakeControlPlanePodContext,
+				Options:                options,
 			}
 
 			Expect(fakeClusterClient.Create(ctx, clusterNode)).To(Succeed())
@@ -230,32 +231,56 @@ var _ = Describe("#RulePodFiles", func() {
 			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 		},
 
-		Entry("should return passed checkResults when all files comply", "",
+		Entry("should return correct checkResults when all files comply", "",
 			[][]string{{mounts, compliantStats}}, [][]string{{mounts, compliantStats}},
-			[][]error{{nil, nil}}, [][]error{{nil, nil}},
+			[][]error{{nil, nil}}, [][]error{{nil, nil}}, &v1r10.OptionsPodFiles{&v1r10.ExpectedFileOwner{}},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65532")),
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65532")),
 			}),
+		Entry("should return correct checkResults when options are used", "",
+			[][]string{{mounts, compliantStats}}, [][]string{{mounts, compliantStats}},
+			[][]error{{nil, nil}}, [][]error{{nil, nil}},
+			&v1r10.OptionsPodFiles{
+				ExpectedFileOwner: &v1r10.ExpectedFileOwner{
+					Users:  []string{"0", "65532"},
+					Groups: []string{"0", "65532"},
+				},
+			},
+			[]rule.CheckResult{
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65532")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65532")),
+			}),
+		Entry("should return correct checkResults when options are nil", "",
+			[][]string{{mounts, compliantStats}}, [][]string{{mounts, compliantStats}},
+			[][]error{{nil, nil}}, [][]error{{nil, nil}}, nil,
+			[]rule.CheckResult{
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.FailedCheckResult("File has unexpected owner group", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, ownerGroup: 65532, expectedOwnerGroups: [0]")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65532")),
+			}),
 		Entry("should return correct checkResult when container is etcd", "",
 			[][]string{{mountsWithETCD, compliantStats}}, [][]string{{emptyMounts}},
-			[][]error{{nil, nil}}, [][]error{{nil}},
+			[][]error{{nil, nil}}, [][]error{{nil}}, &v1r10.OptionsPodFiles{&v1r10.ExpectedFileOwner{}},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
 				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
 			}),
 		Entry("should return errored checkResults when podExecutor errors", "",
 			[][]string{{mounts}}, [][]string{{mounts, compliantStats}},
-			[][]error{{errors.New("foo")}}, [][]error{{nil, errors.New("bar")}},
+			[][]error{{errors.New("foo")}}, [][]error{{nil, errors.New("bar")}}, &v1r10.OptionsPodFiles{},
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("foo", gardener.NewTarget("cluster", "seed", "name", "diki-pod-files-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.ErroredCheckResult("bar", gardener.NewTarget("cluster", "shoot", "name", "diki-pod-files-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
 		Entry("should return failed checkResults when mandatory component not present", "not-etcd-main",
 			[][]string{{mounts}}, [][]string{{mounts, compliantStats}},
-			[][]error{{errors.New("foo")}}, [][]error{{nil, errors.New("bar")}},
+			[][]error{{errors.New("foo")}}, [][]error{{nil, errors.New("bar")}}, &v1r10.OptionsPodFiles{},
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Mandatory Component not found!", gardener.NewTarget("cluster", "seed", "details", "missing ETCD Main")),
 			}),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -230,21 +230,11 @@ var _ = Describe("#RulePodFiles", func() {
 
 			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 		},
-
-		Entry("should return correct checkResults when all files comply", "",
-			[][]string{{mounts, compliantStats}}, [][]string{{mounts, compliantStats}},
-			[][]error{{nil, nil}}, [][]error{{nil, nil}}, &v1r10.OptionsPodFiles{&v1r10.ExpectedFileOwner{}},
-			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65532")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "shoot", "name", "1-shoot-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, ownerUser: 0, ownerGroup: 65532")),
-			}),
 		Entry("should return correct checkResults when options are used", "",
 			[][]string{{mounts, compliantStats}}, [][]string{{mounts, compliantStats}},
 			[][]error{{nil, nil}}, [][]error{{nil, nil}},
 			&v1r10.OptionsPodFiles{
-				ExpectedFileOwner: &v1r10.ExpectedFileOwner{
+				ExpectedFileOwner: v1r10.ExpectedFileOwner{
 					Users:  []string{"0", "65532"},
 					Groups: []string{"0", "65532"},
 				},
@@ -266,10 +256,11 @@ var _ = Describe("#RulePodFiles", func() {
 			}),
 		Entry("should return correct checkResult when container is etcd", "",
 			[][]string{{mountsWithETCD, compliantStats}}, [][]string{{emptyMounts}},
-			[][]error{{nil, nil}}, [][]error{{nil}}, &v1r10.OptionsPodFiles{&v1r10.ExpectedFileOwner{}},
+			[][]error{{nil, nil}}, [][]error{{nil}}, &v1r10.OptionsPodFiles{},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
 				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
+				rule.FailedCheckResult("File has unexpected owner group", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, ownerGroup: 65532, expectedOwnerGroups: [0]")),
 			}),
 		Entry("should return errored checkResults when podExecutor errors", "",
 			[][]string{{mounts}}, [][]string{{mounts, compliantStats}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10_ruleset.go
@@ -103,6 +103,11 @@ func (r *Ruleset) registerV1R10Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
+	optsPodFiles, err := getV1R10OptionOrNil[v1r10.OptionsPodFiles](ruleOptions[v1r10.IDPodFiles].Args)
+	if err != nil {
+		return err
+	}
+
 	rules := []rule.Rule{
 		&v1r10.Rule242376{Logger: r.Logger().With("rule", v1r10.ID242376), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r10.Rule242377{Logger: r.Logger().With("rule", v1r10.ID242377), Client: seedClient, Namespace: r.shootNamespace},
@@ -323,6 +328,7 @@ func (r *Ruleset) registerV1R10Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlanePodContext: seedPodContext,
 			ClusterPodContext:      shootPodContext,
 			ControlPlaneNamespace:  r.shootNamespace,
+			Options:                optsPodFiles,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new option `expectedFileOwner` to DISA Kubernetes STIGS `pod-files` rule which allows the user to select which `users `and `groups` are expected in the config file. The options defaults to expecting only ID `0` for `users` and `groups`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added new option `expectedFileOwner` to DISA Kubernetes STIGS `pod-files` rule which allows the user to select which `users `and `groups` are expected. The options defaults to expecting only ID `0` for `users` and `groups`.
```
