### PR TITLE
Add GetSingleAllocatableNodePerWorker function to internal utils

### DIFF
--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -42,7 +42,7 @@ func GetWorkers(ctx context.Context, c client.Client, namespace string, limit in
 }
 
 // AllocatableNode contains a single Node and whether it is in allocatable or not.
-// A allocatable node is a node that is in ready state and has at least 1 allocatable spot.
+// An allocatable node is a node that is in ready state and has at least 1 allocatable spot.
 type AllocatableNode struct {
 	Node        *corev1.Node
 	Allocatable bool
@@ -62,7 +62,7 @@ func GetSingleAllocatableNodePerWorker(workers []extensionsv1alpha1.Worker, node
 			var allocatableNode *corev1.Node
 			maxAllocatablePods := 0
 			for _, node := range nodes {
-				// find a allocatable node with the most allocatable spots for pods
+				// find an allocatable node with the most allocatable spots for pods
 				if node.ObjectMeta.Labels[v1beta1constants.LabelWorkerPool] == workerGroup.Name && kubeutils.NodeReadyStatus(node) &&
 					maxAllocatablePods < nodesAllocatablePods[node.Name] {
 					maxAllocatablePods = nodesAllocatablePods[node.Name]
@@ -73,7 +73,7 @@ func GetSingleAllocatableNodePerWorker(workers []extensionsv1alpha1.Worker, node
 
 			result[workerGroup.Name] = AllocatableNode{
 				Node:        allocatableNode,
-				Allocatable: allocatableNode != nil, // assign a nil not allocatable entry for the worker group if we could not find a allocatable node
+				Allocatable: allocatableNode != nil, // assign a nil not allocatable entry for the worker group if we could not find an allocatable node
 			}
 		}
 	}

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -41,6 +41,46 @@ func GetWorkers(ctx context.Context, c client.Client, namespace string, limit in
 	}
 }
 
+// AllocatableNode contains a single Node and whether it is in allocatable or not.
+// A allocatable node is a node that is in ready state and has at least 1 allocatable spot.
+type AllocatableNode struct {
+	Node        *corev1.Node
+	Allocatable bool
+}
+
+// GetSingleAllocatableNodePerWorker returns a map where the keys are the names of the worker pool and the values is a
+// allocatable node of the worker pool. If no allocatable nodes are present for a given worker pool the value equals nil.
+func GetSingleAllocatableNodePerWorker(workers []extensionsv1alpha1.Worker, nodes []corev1.Node, nodesAllocatablePods map[string]int) map[string]AllocatableNode {
+	result := map[string]AllocatableNode{}
+
+	for _, worker := range workers {
+		for _, workerGroup := range worker.Spec.Pools {
+			if workerGroup.Minimum == 0 && !anyNodesForWorkerGroup(workerGroup.Name, nodes) {
+				continue
+			}
+
+			var allocatableNode *corev1.Node
+			maxAllocatablePods := 0
+			for _, node := range nodes {
+				// find a allocatable node with the most allocatable spots for pods
+				if node.ObjectMeta.Labels[v1beta1constants.LabelWorkerPool] == workerGroup.Name && kubeutils.NodeReadyStatus(node) &&
+					maxAllocatablePods < nodesAllocatablePods[node.Name] {
+					maxAllocatablePods = nodesAllocatablePods[node.Name]
+					node := node
+					allocatableNode = &node
+				}
+			}
+
+			result[workerGroup.Name] = AllocatableNode{
+				Node:        allocatableNode,
+				Allocatable: allocatableNode != nil, // assign a nil not allocatable entry for the worker group if we could not find a allocatable node
+			}
+		}
+	}
+
+	return result
+}
+
 // ReadyNode contains a single Node and whether it is in Ready state or not
 type ReadyNode struct {
 	Node  *corev1.Node


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `GetSingleAllocatableNodePerWorker()` to internal utils, which is an improved version of `GetSingleRunningNodePerWorker()`. `GetSingleAllocatableNodePerWorker()` also checks if the node has at least 1 allocatable spot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
