### PR TITLE
Always return all check results for `pod-files` rule

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -146,8 +146,6 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults = append(checkResults, shootCheckResults...)
 
 	if len(mandatoryComponentsSeed)+len(mandatoryComponentsShoot) > 0 {
-		checkResults = make([]rule.CheckResult, 0, len(mandatoryComponentsSeed)+len(mandatoryComponentsShoot))
-
 		for mandatoryComponentSeed := range mandatoryComponentsSeed {
 			checkResults = append(checkResults, rule.FailedCheckResult("Mandatory Component not found!", seedTarget.With("details", fmt.Sprintf("missing %s", mandatoryComponentSeed))))
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -275,5 +275,13 @@ var _ = Describe("#RulePodFiles", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Mandatory Component not found!", gardener.NewTarget("cluster", "seed", "details", "missing ETCD Main")),
 			}),
+		Entry("should return all checkResult when mandatory component not present", "not-etcd-main",
+			[][]string{{mountsWithETCD, compliantStats}}, [][]string{{emptyMounts}},
+			[][]error{{nil, nil}}, [][]error{{nil}}, nil,
+			[]rule.CheckResult{
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
+				rule.FailedCheckResult("Mandatory Component not found!", gardener.NewTarget("cluster", "seed", "details", "missing ETCD Main")),
+			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -269,9 +269,9 @@ var _ = Describe("#RulePodFiles", func() {
 				rule.ErroredCheckResult("foo", gardener.NewTarget("cluster", "seed", "name", "diki-pod-files-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.ErroredCheckResult("bar", gardener.NewTarget("cluster", "shoot", "name", "diki-pod-files-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
-		Entry("should return failed checkResults when mandatory component not present", "not-etcd-main",
-			[][]string{{mounts}}, [][]string{{mounts, compliantStats}},
-			[][]error{{errors.New("foo")}}, [][]error{{nil, errors.New("bar")}}, &v1r10.OptionsPodFiles{},
+		Entry("should return failed checkResult when mandatory component not present", "not-etcd-main",
+			[][]string{{emptyMounts}}, [][]string{{emptyMounts}},
+			[][]error{{nil}}, [][]error{{nil}}, nil,
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Mandatory Component not found!", gardener.NewTarget("cluster", "seed", "details", "missing ETCD Main")),
 			}),


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
NONE
```
