### PR TITLE
[Kubernetes STIG v1r10] 242442: check only Gardener managed pods in shoot

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"strings"
 
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -17,7 +18,6 @@ import (
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener"
 	"github.com/gardener/diki/pkg/rule"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 var _ rule.Rule = &Rule242442{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442.go
@@ -11,11 +11,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener"
 	"github.com/gardener/diki/pkg/rule"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 var _ rule.Rule = &Rule242442{}
@@ -45,7 +47,13 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	checkResults := r.checkImages(seedPods, images, reportedImages)
 
-	shootPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	managedByGardenerReq, err := labels.NewRequirement(resourcesv1alpha1.ManagedBy, selection.Equals, []string{"gardener"})
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget())), nil
+	}
+
+	managedByGardenerSelector := labels.NewSelector().Add(*managedByGardenerReq)
+	shootPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", managedByGardenerSelector, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "shoot", "kind", "podList"))), nil
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442_test.go
@@ -55,6 +55,9 @@ var _ = Describe("#242442", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "shoot-pod",
 				Namespace: namespace,
+				Labels: map[string]string{
+					"resources.gardener.cloud/managed-by": "gardener",
+				},
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
DISA Kubernetes STIGs `242442` rule no longer checks shoot pods that are not managed by Gardener.
```
