### PR TITLE
[Kubernetes STIG v1r10] 242387:  create pods only on nodes with allocatable spot

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387.go
@@ -124,7 +124,7 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 func (r *Rule242387) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
 	if !node.Allocatable {
-		return rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", target)
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -51,6 +52,11 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -61,8 +67,8 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	checkResults := []rule.CheckResult{}
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -71,6 +77,7 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	slices.Sort(workerGroups)
 
+	checkResults := []rule.CheckResult{}
 	for _, workerGroup := range workerGroups {
 		node, ok := workerGroupNodes[workerGroup]
 		if !ok {
@@ -114,10 +121,10 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242387) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242387) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387_test.go
@@ -73,12 +73,9 @@ var _ = Describe("#242387", func() {
 
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -92,90 +89,33 @@ var _ = Describe("#242387", func() {
 				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-				Allocatable: corev1.ResourceList{
-					"pods": resource.MustParse("100.0"),
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-				Allocatable: corev1.ResourceList{
-					"pods": resource.MustParse("100.0"),
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-				Allocatable: corev1.ResourceList{
-					"pods": resource.MustParse("100.0"),
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
 
-		node5 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node5",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool4",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-				Allocatable: corev1.ResourceList{
-					"pods": resource.MustParse("0.0"),
-				},
-			},
-		}
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
 		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387_test.go
@@ -230,8 +230,8 @@ var _ = Describe("#242387", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Kubelet read-only port 10255 open.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag read-only-port.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have readOnlyPort set",
 			[][]string{{"", "--not-read-only-port=bar --config=./config", readOnlyPortAllowedConfig}, {"", "--not-read-only-port=bar --config=./config", readOnlyPortNotAllowedConfig}},
@@ -239,8 +239,8 @@ var _ = Describe("#242387", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option readOnlyPort set to allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option readOnlyPort set to not allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2", "details", "Read only port set to 10255")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have readOnlyPort set",
 			[][]string{{"", "--not-read-only-port=bar --config=./config", readOnlyPortNotSetConfig}, {"", "--not-read-only-port=bar, --config=./config", readOnlyPortNotSetConfig}},
@@ -248,8 +248,8 @@ var _ = Describe("#242387", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option readOnlyPort not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.PassedCheckResult("Option readOnlyPort not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when execute errors",
 			[][]string{{""}, {"", ""}},
@@ -257,8 +257,8 @@ var _ = Describe("#242387", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.ErroredCheckResult("command stderr output: sh: 1: netstat: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-bbbbbbbbbb")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
-				rule.WarningCheckResult("There are no nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `Kubelet` rules create a pod on the first `Ready` node found for a worker group. The first node might not have allocatable spots and the rule would return an error. This PR fixes the problem for rule 242387 by always using a node with allocatable spots or if there is none such node for a worker group the rule returns a warning.

If this PR is approved PRs with the same changes for the other `Kubelet` rules will be opened.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
