### PR TITLE
[Kubernetes STIG v1r10] 242442: use imageID instead of image name for comparison

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242442.go
@@ -7,6 +7,7 @@ package v1r10
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"strings"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -45,7 +46,7 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "namespace", r.ControlPlaneNamespace, "kind", "podList"))), nil
 	}
 
-	checkResults := r.checkImages(seedPods, images, reportedImages)
+	checkResults := r.checkImages("seed", seedPods, images, reportedImages)
 
 	managedByGardenerReq, err := labels.NewRequirement(resourcesv1alpha1.ManagedBy, selection.Equals, []string{"gardener"})
 	if err != nil {
@@ -58,7 +59,7 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "shoot", "kind", "podList"))), nil
 	}
 
-	checkResults = append(checkResults, r.checkImages(shootPods, images, reportedImages)...)
+	checkResults = append(checkResults, r.checkImages("shoot", shootPods, images, reportedImages)...)
 
 	if len(checkResults) == 0 {
 		return rule.SingleCheckResult(r, rule.PassedCheckResult("All found images use current versions.", &gardener.Target{})), nil
@@ -71,11 +72,20 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (*Rule242442) checkImages(pods []corev1.Pod, images map[string]string, reportedImages map[string]struct{}) []rule.CheckResult {
+func (*Rule242442) checkImages(cluster string, pods []corev1.Pod, images map[string]string, reportedImages map[string]struct{}) []rule.CheckResult {
 	checkResults := []rule.CheckResult{}
 	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
-			imageRef := container.Image
+			containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+				return containerStatus.Name == container.Name
+			})
+
+			if containerStatusIdx < 0 {
+				checkResults = append(checkResults, rule.ErroredCheckResult("containerStatus not found for container", gardener.NewTarget("cluster", cluster, "name", pod.Name, "container", container.Name, "kind", "pod")))
+				continue
+			}
+
+			imageRef := pod.Status.ContainerStatuses[containerStatusIdx].ImageID
 			imageBase := strings.Split(strings.Split(imageRef, ":")[0], "@")[0]
 			if _, ok := images[imageBase]; ok {
 				if images[imageBase] != imageRef {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
