### PR TITLE
[Kubernetes STIG v1r10] Kubelet rules: create pods only on nodes with allocatable spots

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242387_test.go
@@ -33,6 +33,18 @@ import (
 )
 
 var _ = Describe("#242387", func() {
+	const (
+		readOnlyPortAllowedConfig = `readOnlyPort: 0
+`
+		readOnlyPortNotAllowedConfig = `readOnlyPort: 10255
+`
+		readOnlyPortNotSetConfig = `maxPods: 100
+`
+		readOnlyPortAllowedNodeConfig    = `{"kubeletconfig":{"readOnlyPort":0}}`
+		readOnlyPortNotAllowedNodeConfig = `{"kubeletconfig":{"readOnlyPort":10255}}`
+		readOnlyPortNotSetNodeConfig     = `{"kubeletconfig":{"maxPods":100}}`
+	)
+
 	var (
 		fakeControlPlaneClient client.Client
 		fakeClusterClient      client.Client
@@ -70,7 +82,6 @@ var _ = Describe("#242387", func() {
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
 		plainAllocatableNode := &corev1.Node{
@@ -202,15 +213,3 @@ var _ = Describe("#242387", func() {
 			}),
 	)
 })
-
-const (
-	readOnlyPortAllowedConfig = `readOnlyPort: 0
-`
-	readOnlyPortNotAllowedConfig = `readOnlyPort: 10255
-`
-	readOnlyPortNotSetConfig = `maxPods: 100
-`
-	readOnlyPortAllowedNodeConfig    = `{"kubeletconfig":{"readOnlyPort":0}}`
-	readOnlyPortNotAllowedNodeConfig = `{"kubeletconfig":{"readOnlyPort":10255}}`
-	readOnlyPortNotSetNodeConfig     = `{"kubeletconfig":{"maxPods":100}}`
-)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242391.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242391.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,6 +51,11 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -60,8 +66,8 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	checkResults := []rule.CheckResult{}
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -70,6 +76,7 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	slices.Sort(workerGroups)
 
+	checkResults := []rule.CheckResult{}
 	for _, workerGroup := range workerGroups {
 		node, ok := workerGroupNodes[workerGroup]
 		if !ok {
@@ -112,10 +119,10 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242391) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242391) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242391_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242391_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -32,6 +33,22 @@ import (
 )
 
 var _ = Describe("#242391", func() {
+	const (
+		anonymousAuthAllowedConfig = `authentication:
+  anonymous:
+    enabled: false
+`
+		anonymousAuthNotAllowedConfig = `authentication:
+  anonymous:
+    enabled: true
+`
+		anonymousAuthNotSetConfig = `maxPods: 100
+`
+		anonymousAuthAllowedNodeConfig    = `{"kubeletconfig":{"authentication":{"anonymous":{"enabled":false}}}}`
+		anonymousAuthNotAllowedNodeConfig = `{"kubeletconfig":{"authentication":{"anonymous":{"enabled":true}}}}`
+		anonymousAuthNotSetNodeConfig     = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
+	)
+
 	var (
 		fakeControlPlaneClient client.Client
 		fakeClusterClient      client.Client
@@ -63,18 +80,17 @@ var _ = Describe("#242391", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -83,63 +99,39 @@ var _ = Describe("#242391", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -152,6 +144,8 @@ var _ = Describe("#242391", func() {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(anonymousAuthNotAllowedNodeConfig)))}, nil
 				case "https://localhost/nodes/node4/proxy/configz":
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(anonymousAuthNotSetNodeConfig)))}, nil
+				case "https://localhost/nodes/node5/proxy/configz":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(anonymousAuthAllowedNodeConfig)))}, nil
 				default:
 					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
 				}
@@ -166,6 +160,7 @@ var _ = Describe("#242391", func() {
 				rule.FailedCheckResult("Option authentication.anonymous.enabled set to not allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node2")),
 				rule.WarningCheckResult("Node is not in Ready state.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),
 				rule.FailedCheckResult("Option authentication.anonymous.enabled not set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node4")),
+				rule.PassedCheckResult("Option authentication.anonymous.enabled set to allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node5")),
 			}
 			expectedCheckResults = append(expectedCheckResults, alwaysExpectedCheckResults...)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
@@ -190,7 +185,8 @@ var _ = Describe("#242391", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Kubelet allowed anonymous authentication (or could not be probed).", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag anonymous-auth.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have authentication.anonymous.enabled set",
 			[][]string{{"Unauthorized", "--not-anonymous-auth=true --config=./config", anonymousAuthAllowedConfig}, {"Unauthorized", "--not-anonymous-auth=true --config=./config", anonymousAuthNotAllowedConfig}},
@@ -198,7 +194,8 @@ var _ = Describe("#242391", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option authentication.anonymous.enabled set to allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option authentication.anonymous.enabled set to not allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have authentication.anonymous.enabled set",
 			[][]string{{"Unauthorized", "--not-anonymous-auth=true --config=./config", anonymousAuthNotSetConfig}, {"Unauthorized", "--not-anonymous-auth=true, --config=./config", anonymousAuthNotSetConfig}},
@@ -206,7 +203,8 @@ var _ = Describe("#242391", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option authentication.anonymous.enabled not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option authentication.anonymous.enabled not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when execute errors",
 			[][]string{{""}, {"Unauthorized", ""}},
@@ -214,23 +212,8 @@ var _ = Describe("#242391", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.ErroredCheckResult("command stderr output: sh: 1: netstat: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-bbbbbbbbbb")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })
-
-const (
-	anonymousAuthAllowedConfig = `authentication:
-  anonymous:
-    enabled: false
-`
-	anonymousAuthNotAllowedConfig = `authentication:
-  anonymous:
-    enabled: true
-`
-	anonymousAuthNotSetConfig = `maxPods: 100
-`
-	anonymousAuthAllowedNodeConfig    = `{"kubeletconfig":{"authentication":{"anonymous":{"enabled":false}}}}`
-	anonymousAuthNotAllowedNodeConfig = `{"kubeletconfig":{"authentication":{"anonymous":{"enabled":true}}}}`
-	anonymousAuthNotSetNodeConfig     = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
-)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242392.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242392.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,6 +51,11 @@ func (r *Rule242392) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -61,7 +67,8 @@ func (r *Rule242392) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	checkResults := []rule.CheckResult{}
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -112,10 +119,10 @@ func (r *Rule242392) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242392) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242392) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242392_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242392_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -32,6 +33,20 @@ import (
 )
 
 var _ = Describe("#242392", func() {
+	const (
+		authorizationModeAllowedConfig = `authorization:
+  mode: Webhook
+`
+		authorizationModeNotAllowedConfig = `authorization:
+  mode: AlwaysAllow
+`
+		authorizationModeNotSetConfig = `maxPods: 100
+`
+		authorizationModeAllowedNodeConfig    = `{"kubeletconfig":{"authorization":{"mode":"Webhook"}}}`
+		authorizationModeNotAllowedNodeConfig = `{"kubeletconfig":{"authorization":{"mode":"AlwaysAllow"}}}`
+		authorizationModeNotSetNodeConfig     = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
+	)
+
 	var (
 		fakeControlPlaneClient client.Client
 		fakeClusterClient      client.Client
@@ -63,18 +78,17 @@ var _ = Describe("#242392", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -83,63 +97,39 @@ var _ = Describe("#242392", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -152,6 +142,8 @@ var _ = Describe("#242392", func() {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(authorizationModeNotAllowedNodeConfig)))}, nil
 				case "https://localhost/nodes/node4/proxy/configz":
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(authorizationModeNotSetNodeConfig)))}, nil
+				case "https://localhost/nodes/node5/proxy/configz":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(authorizationModeAllowedNodeConfig)))}, nil
 				default:
 					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
 				}
@@ -166,6 +158,7 @@ var _ = Describe("#242392", func() {
 				rule.FailedCheckResult("Option authorization.mode set to not allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node2", "details", "Authorization Mode set to AlwaysAllow")),
 				rule.WarningCheckResult("Node is not in Ready state.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),
 				rule.FailedCheckResult("Option authorization.mode not set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node4")),
+				rule.PassedCheckResult("Option authorization.mode set to allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node5")),
 			}
 			expectedCheckResults = append(expectedCheckResults, alwaysExpectedCheckResults...)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
@@ -190,7 +183,8 @@ var _ = Describe("#242392", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Kubelet always allows access (or could not be probed).", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag authorization-mode.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have authorization.mode set",
 			[][]string{{"Unauthorized", "--not-authorization-mode=Webhook --config=./config", authorizationModeAllowedConfig}, {"Unauthorized", "--not-authorization-mode=Webhook --config=./config", authorizationModeNotAllowedConfig}},
@@ -198,7 +192,8 @@ var _ = Describe("#242392", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option authorization.mode set to allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option authorization.mode set to not allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2", "details", "Authorization Mode set to AlwaysAllow")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have authorization.mode set",
 			[][]string{{"Unauthorized", "--not-authorization-mode=Webhook --config=./config", authorizationModeNotSetConfig}, {"Unauthorized", "--not-authorization-mode=Webhook, --config=./config", authorizationModeNotSetConfig}},
@@ -206,7 +201,8 @@ var _ = Describe("#242392", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option authorization.mode not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option authorization.mode not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when execute errors",
 			[][]string{{""}, {"Unauthorized", ""}},
@@ -214,21 +210,8 @@ var _ = Describe("#242392", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.ErroredCheckResult("command stderr output: sh: 1: netstat: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-bbbbbbbbbb")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })
-
-const (
-	authorizationModeAllowedConfig = `authorization:
-  mode: Webhook
-`
-	authorizationModeNotAllowedConfig = `authorization:
-  mode: AlwaysAllow
-`
-	authorizationModeNotSetConfig = `maxPods: 100
-`
-	authorizationModeAllowedNodeConfig    = `{"kubeletconfig":{"authorization":{"mode":"Webhook"}}}`
-	authorizationModeNotAllowedNodeConfig = `{"kubeletconfig":{"authorization":{"mode":"AlwaysAllow"}}}`
-	authorizationModeNotSetNodeConfig     = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
-)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242397.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242397.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"slices"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -49,6 +50,11 @@ func (r *Rule242397) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -60,7 +66,8 @@ func (r *Rule242397) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	checkResults := []rule.CheckResult{}
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -109,10 +116,10 @@ func (r *Rule242397) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242397) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242397) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242399.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242399.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -59,6 +60,11 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -69,8 +75,8 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	checkResults := []rule.CheckResult{}
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -79,6 +85,7 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	slices.Sort(workerGroups)
 
+	checkResults := []rule.CheckResult{}
 	for _, workerGroup := range workerGroups {
 		node, ok := workerGroupNodes[workerGroup]
 		if !ok {
@@ -124,10 +131,10 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242399) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242399) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242399_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242399_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,6 +34,20 @@ import (
 )
 
 var _ = Describe("#242399", func() {
+	const (
+		dynamicKubeletConfigAllowedConfig = `featureGates:
+  DynamicKubeletConfig: false
+`
+		dynamicKubeletConfigNotAllowedConfig = `featureGates:
+  DynamicKubeletConfig: true
+`
+		dynamicKubeletConfigNotSetConfig = `maxPods: 100
+`
+		dynamicKubeletConfigAllowedNodeConfig    = `{"kubeletconfig":{"featureGates":{"DynamicKubeletConfig":false}}}`
+		dynamicKubeletConfigNotAllowedNodeConfig = `{"kubeletconfig":{"featureGates":{"DynamicKubeletConfig":true}}}`
+		dynamicKubeletConfigNotSetNodeConfig     = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
+	)
+
 	var (
 		fakeControlPlaneClient client.Client
 		fakeClusterClient      client.Client
@@ -66,18 +81,17 @@ var _ = Describe("#242399", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -86,63 +100,39 @@ var _ = Describe("#242399", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -155,6 +145,8 @@ var _ = Describe("#242399", func() {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(dynamicKubeletConfigNotAllowedNodeConfig)))}, nil
 				case "https://localhost/nodes/node4/proxy/configz":
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(dynamicKubeletConfigNotSetNodeConfig)))}, nil
+				case "https://localhost/nodes/node5/proxy/configz":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(dynamicKubeletConfigAllowedNodeConfig)))}, nil
 				default:
 					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
 				}
@@ -186,6 +178,7 @@ var _ = Describe("#242399", func() {
 				rule.FailedCheckResult("Option featureGates.DynamicKubeletConfig set to not allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node2")),
 				rule.WarningCheckResult("Node is not in Ready state.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),
 				rule.PassedCheckResult("Option featureGates.DynamicKubeletConfig not set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node4")),
+				rule.PassedCheckResult("Option featureGates.DynamicKubeletConfig set to allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node5")),
 			}
 			expectedCheckResults = append(expectedCheckResults, alwaysExpectedCheckResults...)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
@@ -211,7 +204,8 @@ var _ = Describe("#242399", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag feature-gates.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have featureGates.DynamicKubeletConfig set",
 			[][]string{{"--not-feature-gates=DynamicKubeletConfig=true --config=./config", dynamicKubeletConfigAllowedConfig}, {"--not-feature-gates=DynamicKubeletConfig=true --config=./config", dynamicKubeletConfigNotAllowedConfig}},
@@ -219,7 +213,8 @@ var _ = Describe("#242399", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option featureGates.DynamicKubeletConfig set to allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option featureGates.DynamicKubeletConfig set to not allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have featureGates.DynamicKubeletConfig set",
 			[][]string{{"--not-feature-gates=DynamicKubeletConfig=true --config=./config", dynamicKubeletConfigNotSetConfig}, {"--not-feature-gates=DynamicKubeletConfig=true, --config=./config", dynamicKubeletConfigNotSetConfig}},
@@ -227,21 +222,8 @@ var _ = Describe("#242399", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option featureGates.DynamicKubeletConfig not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.PassedCheckResult("Option featureGates.DynamicKubeletConfig not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })
-
-const (
-	dynamicKubeletConfigAllowedConfig = `featureGates:
-  DynamicKubeletConfig: false
-`
-	dynamicKubeletConfigNotAllowedConfig = `featureGates:
-  DynamicKubeletConfig: true
-`
-	dynamicKubeletConfigNotSetConfig = `maxPods: 100
-`
-	dynamicKubeletConfigAllowedNodeConfig    = `{"kubeletconfig":{"featureGates":{"DynamicKubeletConfig":false}}}`
-	dynamicKubeletConfigNotAllowedNodeConfig = `{"kubeletconfig":{"featureGates":{"DynamicKubeletConfig":true}}}`
-	dynamicKubeletConfigNotSetNodeConfig     = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
-)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242404.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242404.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"slices"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -47,6 +48,11 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -60,7 +66,8 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	checkResults := []rule.CheckResult{}
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -87,10 +94,10 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242404) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242404) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242404_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242404_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -55,18 +56,17 @@ var _ = Describe("#242404", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -75,63 +75,39 @@ var _ = Describe("#242404", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 	})
 
 	DescribeTable("Run cases",
@@ -157,7 +133,8 @@ var _ = Describe("#242404", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.PassedCheckResult("Flag hostname-override not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when hostname-override flag is set",
 			[][]string{{"--hostname-override=/foo/bar --config=./config"}, {"--hostname-override --config=./config"}},
@@ -165,7 +142,8 @@ var _ = Describe("#242404", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Flag hostname-override set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Flag hostname-override set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242420.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242420.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,6 +51,11 @@ func (r *Rule242420) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -60,7 +66,8 @@ func (r *Rule242420) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -112,10 +119,10 @@ func (r *Rule242420) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242420) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242420) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242420_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242420_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -32,6 +33,22 @@ import (
 )
 
 var _ = Describe("#242420", func() {
+	const (
+		clientCaFileEmptyConfig = `authentication:
+  x509:
+    clientCAFile: ""
+`
+		clientCaFileSetConfig = `authentication:
+  x509:
+    clientCAFile: /foo/bar
+`
+		clientCaFileNotSetConfig = `maxPods: 100
+`
+		clientCaFileEmptyNodeConfig  = `{"kubeletconfig":{"authentication":{"x509":{"clientCAFile":""}}}}`
+		clientCaFileSetNodeConfig    = `{"kubeletconfig":{"authentication":{"x509":{"clientCAFile":"/foo/bar"}}}}`
+		clientCaFileNotSetNodeConfig = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
+	)
+
 	var (
 		fakeControlPlaneClient client.Client
 		fakeClusterClient      client.Client
@@ -63,18 +80,17 @@ var _ = Describe("#242420", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -83,63 +99,39 @@ var _ = Describe("#242420", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -152,6 +144,8 @@ var _ = Describe("#242420", func() {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(clientCaFileSetNodeConfig)))}, nil
 				case "https://localhost/nodes/node4/proxy/configz":
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(clientCaFileNotSetNodeConfig)))}, nil
+				case "https://localhost/nodes/node5/proxy/configz":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(clientCaFileEmptyNodeConfig)))}, nil
 				default:
 					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
 				}
@@ -166,6 +160,7 @@ var _ = Describe("#242420", func() {
 				rule.PassedCheckResult("Option authentication.x509.clientCAFile set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node2")),
 				rule.WarningCheckResult("Node is not in Ready state.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),
 				rule.FailedCheckResult("Option authentication.x509.clientCAFile not set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node4")),
+				rule.FailedCheckResult("Option authentication.x509.clientCAFile is empty.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node5")),
 			}
 			expectedCheckResults = append(expectedCheckResults, alwaysExpectedCheckResults...)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
@@ -190,7 +185,8 @@ var _ = Describe("#242420", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag client-ca-file.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have authentication.x509.clientCAFile set",
 			[][]string{{"--not-client-ca-file=/foo/bar --config=./config", clientCaFileEmptyConfig}, {"--not-client-ca-file=/foo/bar --config=./config", clientCaFileSetConfig}},
@@ -198,7 +194,8 @@ var _ = Describe("#242420", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option authentication.x509.clientCAFile is empty.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.PassedCheckResult("Option authentication.x509.clientCAFile set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have authentication.x509.clientCAFile set",
 			[][]string{{"--not-client-ca-file=/foo/bar --config=./config", clientCaFileNotSetConfig}, {"--not-client-ca-file=/foo/bar, --config=./config", clientCaFileNotSetConfig}},
@@ -206,23 +203,8 @@ var _ = Describe("#242420", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option authentication.x509.clientCAFile not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option authentication.x509.clientCAFile not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })
-
-const (
-	clientCaFileEmptyConfig = `authentication:
-  x509:
-    clientCAFile: ""
-`
-	clientCaFileSetConfig = `authentication:
-  x509:
-    clientCAFile: /foo/bar
-`
-	clientCaFileNotSetConfig = `maxPods: 100
-`
-	clientCaFileEmptyNodeConfig  = `{"kubeletconfig":{"authentication":{"x509":{"clientCAFile":""}}}}`
-	clientCaFileSetNodeConfig    = `{"kubeletconfig":{"authentication":{"x509":{"clientCAFile":"/foo/bar"}}}}`
-	clientCaFileNotSetNodeConfig = `{"kubeletconfig":{"authentication":{"webhook":{"enabled":true,"cacheTTL":"2m0s"}}}}`
-)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242424.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242424.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,11 @@ func (r *Rule242424) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -61,7 +67,8 @@ func (r *Rule242424) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -129,10 +136,10 @@ func (r *Rule242424) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242424) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242424) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242424_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242424_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -76,18 +77,17 @@ var _ = Describe("#242424", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -96,63 +96,39 @@ var _ = Describe("#242424", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -165,6 +141,8 @@ var _ = Describe("#242424", func() {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(tlsPrivateKeyFileEmptyNodeConfig)))}, nil
 				case "https://localhost/nodes/node4/proxy/configz":
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(tlsPrivateKeyFileNotSetNodeConfig)))}, nil
+				case "https://localhost/nodes/node5/proxy/configz":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(tlsPrivateKeyFileSetNodeConfig)))}, nil
 				default:
 					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
 				}
@@ -180,6 +158,7 @@ var _ = Describe("#242424", func() {
 				rule.FailedCheckResult("Option tlsPrivateKeyFile is empty.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node2")),
 				rule.WarningCheckResult("Node is not in Ready state.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),
 				rule.FailedCheckResult("Option tlsPrivateKeyFile not set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node4")),
+				rule.PassedCheckResult("Option tlsPrivateKeyFile set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node5")),
 			}
 			expectedCheckResults = append(expectedCheckResults, alwaysExpectedCheckResults...)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
@@ -204,7 +183,8 @@ var _ = Describe("#242424", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.PassedCheckResult("Kubelet rotates server certificates automatically itself.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have tlsPrivateKeyFile set",
 			[][]string{{"--not-tls-private-key-file=/foo/bar --config=./config", tlsPrivateKeyFileSetConfig}, {"--not-tls-private-key-file=/foo/bar --config=./config", tlsPrivateKeyFileEmptyConfig}},
@@ -212,7 +192,8 @@ var _ = Describe("#242424", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option tlsPrivateKeyFile set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option tlsPrivateKeyFile is empty.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have tlsPrivateKeyFile set",
 			[][]string{{"--not-tls-private-key-file=/foo/bar --config=./config", tlsPrivateKeyFileNotSetConfig}, {"--not-tls-private-key-file=/foo/bar, --config=./config", tlsPrivateKeyFileNotSetConfig}},
@@ -220,7 +201,8 @@ var _ = Describe("#242424", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option tlsPrivateKeyFile not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option tlsPrivateKeyFile not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when deprecated flags are used",
 			[][]string{{"--feature-gates=RotateKubeletServerCertificate=true"}, {"--tls-private-key-file=/foo/bar"}},
@@ -228,7 +210,8 @@ var _ = Describe("#242424", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Use of deprecated kubelet config flag feature-gates.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag tls-private-key-file.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242425.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242425.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,11 @@ func (r *Rule242425) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -61,7 +67,8 @@ func (r *Rule242425) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -129,10 +136,10 @@ func (r *Rule242425) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule242425) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule242425) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242434_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242434_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -75,18 +76,17 @@ var _ = Describe("#242434", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -95,63 +95,39 @@ var _ = Describe("#242434", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -164,6 +140,8 @@ var _ = Describe("#242434", func() {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(protectKernelDefaultsNotAllowedNodeConfig)))}, nil
 				case "https://localhost/nodes/node4/proxy/configz":
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(protectKernelDefaultsNotSetNodeConfig)))}, nil
+				case "https://localhost/nodes/node5/proxy/configz":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(protectKernelDefaultsAllowedNodeConfig)))}, nil
 				default:
 					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
 				}
@@ -178,6 +156,7 @@ var _ = Describe("#242434", func() {
 				rule.FailedCheckResult("Option protectKernelDefaults set to not allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node2")),
 				rule.WarningCheckResult("Node is not in Ready state.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),
 				rule.FailedCheckResult("Option protectKernelDefaults not set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node4")),
+				rule.PassedCheckResult("Option protectKernelDefaults set to allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node5")),
 			}
 			expectedCheckResults = append(expectedCheckResults, alwaysExpectedCheckResults...)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
@@ -202,7 +181,8 @@ var _ = Describe("#242434", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag protect-kernel-defaults.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have protectKernelDefaults set",
 			[][]string{{"--not-protect-kernel-defaults=true --config=./config", protectKernelDefaultsAllowedConfig}, {"--not-protect-kernel-defaults=true --config=./config", protectKernelDefaultsNotAllowedConfig}},
@@ -210,7 +190,8 @@ var _ = Describe("#242434", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option protectKernelDefaults set to allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option protectKernelDefaults set to not allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have protectKernelDefaults set",
 			[][]string{{"--not-protect-kernel-defaults=true --config=./config", protectKernelDefaultsNotSetConfig}, {"--not-protect-kernel-defaults=true, --config=./config", protectKernelDefaultsNotSetConfig}},
@@ -218,7 +199,8 @@ var _ = Describe("#242434", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option protectKernelDefaults not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option protectKernelDefaults not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/245541.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/245541.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"time"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,6 +51,11 @@ func (r *Rule245541) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -60,7 +66,8 @@ func (r *Rule245541) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -129,10 +136,10 @@ func (r *Rule245541) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule245541) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule245541) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/245541_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/245541_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -79,18 +80,17 @@ var _ = Describe("#245541", func() {
 					{
 						Name: "pool3",
 					},
+					{
+						Name: "pool4",
+					},
 				},
 			},
 		}
-
 		Expect(fakeControlPlaneClient.Create(ctx, workers)).To(Succeed())
 
-		node1 := &corev1.Node{
+		plainAllocatableNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool1",
-				},
+				Labels: map[string]string{},
 			},
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
@@ -99,63 +99,39 @@ var _ = Describe("#245541", func() {
 						Status: corev1.ConditionTrue,
 					},
 				},
+				Allocatable: corev1.ResourceList{
+					"pods": resource.MustParse("100.0"),
+				},
 			},
 		}
+
+		node1 := plainAllocatableNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		node1.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool1"
 		Expect(fakeClusterClient.Create(ctx, node1)).To(Succeed())
 
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node2 := plainAllocatableNode.DeepCopy()
+		node2.ObjectMeta.Name = "node2"
+		node2.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node2)).To(Succeed())
 
-		node3 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node3",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool3",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-		}
+		node3 := plainAllocatableNode.DeepCopy()
+		node3.ObjectMeta.Name = "node3"
+		node3.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool3"
+		node3.Status.Conditions[0].Type = corev1.NodeReady
+		node3.Status.Conditions[0].Status = corev1.ConditionFalse
 		Expect(fakeClusterClient.Create(ctx, node3)).To(Succeed())
 
-		node4 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node4",
-				Labels: map[string]string{
-					"worker.gardener.cloud/pool": "pool2",
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{
-					{
-						Type:   corev1.NodeReady,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-		}
+		node4 := plainAllocatableNode.DeepCopy()
+		node4.ObjectMeta.Name = "node4"
+		node4.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool2"
 		Expect(fakeClusterClient.Create(ctx, node4)).To(Succeed())
+
+		node5 := plainAllocatableNode.DeepCopy()
+		node5.ObjectMeta.Name = "node5"
+		node5.ObjectMeta.Labels["worker.gardener.cloud/pool"] = "pool4"
+		node5.Status.Allocatable["pods"] = resource.MustParse("0.0")
+		Expect(fakeClusterClient.Create(ctx, node5)).To(Succeed())
 
 		fakeClusterRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -168,6 +144,8 @@ var _ = Describe("#245541", func() {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(streamingConnectionIdleTimeoutNotAllowedNodeConfig)))}, nil
 				case "https://localhost/nodes/node4/proxy/configz":
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(streamingConnectionIdleTimeoutNotSetNodeConfig)))}, nil
+				case "https://localhost/nodes/node5/proxy/configz":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(streamingConnectionIdleTimeoutAllowedNodeConfig)))}, nil
 				default:
 					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
 				}
@@ -182,6 +160,7 @@ var _ = Describe("#245541", func() {
 				rule.FailedCheckResult("Option streamingConnectionIdleTimeout set to not allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node2", "details", "streamingConnectionIdleTimeout set to 30s.")),
 				rule.WarningCheckResult("Node is not in Ready state.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),
 				rule.FailedCheckResult("Option streamingConnectionIdleTimeout not set.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node4")),
+				rule.PassedCheckResult("Option streamingConnectionIdleTimeout set to allowed value.", gardener.NewTarget("cluster", "shoot", "kind", "node", "name", "node5")),
 			}
 			expectedCheckResults = append(expectedCheckResults, alwaysExpectedCheckResults...)
 			fakeClusterPodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
@@ -206,7 +185,8 @@ var _ = Describe("#245541", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("command stderr output: sh: 1: -c: not found", gardener.NewTarget("cluster", "shoot", "kind", "pod", "namespace", "kube-system", "name", "diki-node-files-aaaaaaaaaa")),
 				rule.FailedCheckResult("Use of deprecated kubelet config flag streaming-connection-idle-timeout.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes have streamingConnectionIdleTimeout set",
 			[][]string{{"--not-streaming-connection-idle-timeout=true --config=./config", streamingConnectionIdleTimeoutAllowedConfig}, {"--not-streaming-connection-idle-timeout=true --config=./config", streamingConnectionIdleTimeoutNotAllowedConfig}},
@@ -214,7 +194,8 @@ var _ = Describe("#245541", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("Option streamingConnectionIdleTimeout set to allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.FailedCheckResult("Option streamingConnectionIdleTimeout set to not allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2", "details", "streamingConnectionIdleTimeout set to 30s.")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have streamingConnectionIdleTimeout set or is set to not recommended value",
 			[][]string{{"--not-streaming-connection-idle-timeout=true --config=./config", streamingConnectionIdleTimeoutNotSetConfig}, {"--not-streaming-connection-idle-timeout=true, --config=./config", streamingConnectionIdleTimeoutNotRecommendedConfig}},
@@ -222,7 +203,8 @@ var _ = Describe("#245541", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option streamingConnectionIdleTimeout not set.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1")),
 				rule.PassedCheckResult("Option streamingConnectionIdleTimeout set to allowed, but not recommended value (should be 5m).", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2", "details", "streamingConnectionIdleTimeout set to 1h0m0s.")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 		Entry("should return correct checkResults when nodes do not have streamingConnectionIdleTimeout set or is set to not recommended value over 4 hours",
 			[][]string{{"--not-streaming-connection-idle-timeout=true --config=./config", streamingConnectionIdleTimeoutNotAllowedConfigOver4Hours}, {"--not-streaming-connection-idle-timeout=true, --config=./config", streamingConnectionIdleTimeoutNotRecommendedConfig}},
@@ -230,7 +212,8 @@ var _ = Describe("#245541", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("Option streamingConnectionIdleTimeout set to not allowed value.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool1", "details", "streamingConnectionIdleTimeout set to 5h0m0s.")),
 				rule.PassedCheckResult("Option streamingConnectionIdleTimeout set to allowed, but not recommended value (should be 5m).", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool2", "details", "streamingConnectionIdleTimeout set to 1h0m0s.")),
-				rule.WarningCheckResult("There are no nodes in Ready state for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool3")),
+				rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", "pool4")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/254801.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/254801.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -54,6 +55,11 @@ func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList"))), nil
 	}
 
+	clusterPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList"))), nil
+	}
+
 	clusterWorkers, err := utils.GetWorkers(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), gardener.NewTarget("cluster", "seed", "kind", "workerList"))), nil
@@ -64,7 +70,8 @@ func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
 	}
 
-	workerGroupNodes := utils.GetSingleRunningNodePerWorker(clusterWorkers, clusterNodes)
+	nodesAllocatablePodsNum := utils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)
+	workerGroupNodes := utils.GetSingleAllocatableNodePerWorker(clusterWorkers, clusterNodes, nodesAllocatablePodsNum)
 
 	// TODO use maps.Keys when released with go 1.21 or 1.22
 	workerGroups := make([]string, 0, len(workerGroupNodes))
@@ -123,10 +130,10 @@ func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (r *Rule254801) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.ReadyNode, privPodImage string) rule.CheckResult {
+func (r *Rule254801) checkWorkerGroup(ctx context.Context, workerGroup string, node utils.AllocatableNode, privPodImage string) rule.CheckResult {
 	target := gardener.NewTarget("cluster", "seed", "kind", "workerGroup", "name", workerGroup)
-	if !node.Ready {
-		return rule.WarningCheckResult("There are no nodes in Ready state for worker group.", target)
+	if !node.Allocatable {
+		return rule.WarningCheckResult("There are no ready nodes with at least 1 allocatable spot for worker group.", target)
 	}
 
 	podName := fmt.Sprintf("diki-%s-%s", IDNodeFiles, Generator.Generate(10))


### PR DESCRIPTION
**What this PR does / why we need it**:
Create pods only on nodes with allocatable spots for all Kubelet rules, as in #57.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
DISA Kubernetes STIGs Kubelet rules now creates `diki` pods only on nodes with free allocatable space.
```
