### PR TITLE
[Kubernetes STIG v1r10] pod-files rule: add check for 242467 rule

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner.go
@@ -322,8 +322,10 @@ func (r *RulePodFiles) checkContainerd(
 
 				if isMandatoryComponent && strings.HasSuffix(strings.Join(statSlice[3:], " "), ".key") {
 					// rule 242467
+					// Gardener control plane components run as `nonroot` user `65532`, since we can change the group owener but
+					// cannot easily change the user owner of secret files we do not check for `0600` permission but instead for `0640`.
 					checkResults = append(checkResults, utils.MatchFilePermissionsAndOwnersCases(statSlice[0], statSlice[1], statSlice[2], strings.Join(statSlice[3:], " "),
-						"600", expectedFileOwnerUsers, expectedFileOwnerGroups, fileTarget)...)
+						"640", expectedFileOwnerUsers, expectedFileOwnerGroups, fileTarget)...)
 					continue
 				}
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -49,6 +49,8 @@ var _ = Describe("#RulePodFiles", func() {
 ]`
 		compliantStats = `600 0 0 /destination/file1.txt
 644 0 65532 /destination/bar/file2.txt`
+		keyFileStats = `600 0 0 /destination/file1.key
+644 0 0 /destination/bar/file2.key`
 	)
 
 	var (
@@ -282,6 +284,13 @@ var _ = Describe("#RulePodFiles", func() {
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600, ownerUser: 0, ownerGroup: 0")),
 				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 644, expectedPermissionsMax: 600")),
 				rule.FailedCheckResult("Mandatory Component not found!", gardener.NewTarget("cluster", "seed", "details", "missing ETCD Main")),
+			}),
+		Entry("should return correct checkResult when checked files are *.key", "",
+			[][]string{{mounts, keyFileStats}}, [][]string{{emptyMounts}},
+			[][]error{{nil, nil}}, [][]error{{nil}}, nil,
+			[]rule.CheckResult{
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.key, permissions: 644, expectedPermissionsMax: 600")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -290,7 +290,7 @@ var _ = Describe("#RulePodFiles", func() {
 			[][]error{{nil, nil}}, [][]error{{nil}}, nil,
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 600, ownerUser: 0, ownerGroup: 0")),
-				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.key, permissions: 644, expectedPermissionsMax: 600")),
+				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.key, permissions: 644, expectedPermissionsMax: 640")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/pod_files_permissions_and_owner_test.go
@@ -49,7 +49,7 @@ var _ = Describe("#RulePodFiles", func() {
 ]`
 		compliantStats = `600 0 0 /destination/file1.txt
 644 0 65532 /destination/bar/file2.txt`
-		keyFileStats = `600 0 0 /destination/file1.key
+		keyFileStats = `640 0 0 /destination/file1.key
 644 0 0 /destination/bar/file2.key`
 	)
 
@@ -289,7 +289,7 @@ var _ = Describe("#RulePodFiles", func() {
 			[][]string{{mounts, keyFileStats}}, [][]string{{emptyMounts}},
 			[][]error{{nil, nil}}, [][]error{{nil}}, nil,
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 600, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected permissions and expected owner", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 640, ownerUser: 0, ownerGroup: 0")),
 				rule.FailedCheckResult("File has too wide permissions", gardener.NewTarget("cluster", "seed", "name", "1-seed-pod", "namespace", "foo", "kind", "pod", "details", "fileName: /destination/bar/file2.key, permissions: 644, expectedPermissionsMax: 640")),
 			}),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the *.key files checks required from `242467` rule in `pod-files` rule. *.key files in mandatory components are required to have max privilege of `640`. We do not enforce `600` because k8s does not provide a way to easily change the owner of a file and containers are expected to run as nonroot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
DISA Kubernetes STIGs `pod-files` rule now expects `0640` permission setting for `*.key` files of mandatory components. This change improves the `242467` rule which requires `0600` permissions for such files. `0600` is not enforced since k8s does not provide an easy way to change the owner of a file and containers are expected to run as nonroot. 
```
