### PR TITLE
[Kubernetes STIG v1r10] 242415 rule: add new option to select pods to accept

### DIFF
--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -35,6 +35,16 @@ providers:             # contains information about known providers
           ports:
           - 1011
           - 1012
+    # - ruleID: "242415"
+    #   args:
+    #     acceptedPods:
+    #     - podMatchLabels:
+    #         label: foo
+    #       namespaceMatchLabels:
+    #         label: foo
+    #       justification: "justification"
+    #       environmentVariables:
+    #       - FOO_BAR
     - ruleID: "245543"
       args:
         acceptedTokens:

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242414.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242414.go
@@ -90,21 +90,19 @@ func (r *Rule242414) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 		target := clusterTarget.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 		for _, container := range pod.Spec.Containers {
 			uses := false
-			if container.Ports != nil {
-				for _, port := range container.Ports {
-					if port.HostPort != 0 && port.HostPort < 1024 {
-						target = target.With("details", fmt.Sprintf("containerName: %s, port: %d", container.Name, port.HostPort))
-						if accepted, justification := r.accepted(pod, namespaces[pod.Namespace], port.HostPort); accepted {
-							msg := "Container accepted to use hostPort < 1024."
-							if justification != "" {
-								msg = justification
-							}
-							checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
-						} else {
-							checkResults = append(checkResults, rule.FailedCheckResult("Container may not use hostPort < 1024.", target))
+			for _, port := range container.Ports {
+				if port.HostPort != 0 && port.HostPort < 1024 {
+					target = target.With("details", fmt.Sprintf("containerName: %s, port: %d", container.Name, port.HostPort))
+					if accepted, justification := r.accepted(pod, namespaces[pod.Namespace], port.HostPort); accepted {
+						msg := "Container accepted to use hostPort < 1024."
+						if justification != "" {
+							msg = justification
 						}
-						uses = true
+						checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
+					} else {
+						checkResults = append(checkResults, rule.FailedCheckResult("Container may not use hostPort < 1024.", target))
 					}
+					uses = true
 				}
 			}
 			if !uses {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242414.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242414.go
@@ -116,6 +116,10 @@ func (r *Rule242414) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 }
 
 func (r *Rule242414) accepted(pod corev1.Pod, namespace corev1.Namespace, hostPort int32) (bool, string) {
+	if r.Options == nil {
+		return false, ""
+	}
+
 	for _, acceptedPod := range r.Options.AcceptedPods {
 		if utils.MatchLabels(pod.Labels, acceptedPod.PodMatchLabels) &&
 			utils.MatchLabels(namespace.Labels, acceptedPod.NamespaceMatchLabels) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242415.go
@@ -86,21 +86,19 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 		target := clusterTarget.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 		passed := true
 		for _, container := range pod.Spec.Containers {
-			if container.Env != nil {
-				for _, env := range container.Env {
-					if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
-						target = target.With("details", fmt.Sprintf("containerName: %s, variableName: %s, keyRef: %s", container.Name, env.Name, env.ValueFrom.SecretKeyRef.Key))
-						if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace], env.Name); accepted {
-							msg := "Pod accepted to use environment to inject secret."
-							if justification != "" {
-								msg = justification
-							}
-							checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
-						} else {
-							checkResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
+			for _, env := range container.Env {
+				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+					target = target.With("details", fmt.Sprintf("containerName: %s, variableName: %s, keyRef: %s", container.Name, env.Name, env.ValueFrom.SecretKeyRef.Key))
+					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace], env.Name); accepted {
+						msg := "Pod accepted to use environment to inject secret."
+						if justification != "" {
+							msg = justification
 						}
-						passed = false
+						checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
+					} else {
+						checkResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
 					}
+					passed = false
 				}
 			}
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/242415.go
@@ -15,6 +15,7 @@ import (
 
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener"
+	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
 	"github.com/gardener/diki/pkg/rule"
 )
 
@@ -24,7 +25,19 @@ type Rule242415 struct {
 	ClusterClient         client.Client
 	ControlPlaneClient    client.Client
 	ControlPlaneNamespace string
+	Options               *Options242415
 	Logger                *slog.Logger
+}
+
+type Options242415 struct {
+	AcceptedPods []AcceptedPods242415 `json:"acceptedPods" yaml:"acceptedPods"`
+}
+
+type AcceptedPods242415 struct {
+	PodMatchLabels       map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
+	NamespaceMatchLabels map[string]string `json:"namespaceMatchLabels" yaml:"namespaceMatchLabels"`
+	Justification        string            `json:"justification" yaml:"justification"`
+	EnvironmentVariables []string          `json:"environmentVariables" yaml:"environmentVariables "`
 }
 
 func (r *Rule242415) ID() string {
@@ -43,14 +56,22 @@ func (r *Rule242415) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), seedTarget.With("namespace", r.ControlPlaneNamespace, "kind", "podList"))), nil
 	}
 
-	checkResults := r.checkPods(seedPods, seedTarget)
+	seedNamespaces, err := kubeutils.GetNamespaces(ctx, r.ControlPlaneClient)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), seedTarget.With("kind", "namespaceList"))), nil
+	}
+	checkResults := r.checkPods(seedPods, seedNamespaces, seedTarget)
 
 	shootPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("namespace", r.ControlPlaneNamespace, "kind", "podList"))), nil
 	}
 
-	checkResults = append(checkResults, r.checkPods(shootPods, shootTarget)...)
+	shootNamespaces, err := kubeutils.GetNamespaces(ctx, r.ClusterClient)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "namespaceList"))), nil
+	}
+	checkResults = append(checkResults, r.checkPods(shootPods, shootNamespaces, shootTarget)...)
 
 	return rule.RuleResult{
 		RuleID:       r.ID(),
@@ -59,17 +80,25 @@ func (r *Rule242415) Run(ctx context.Context) (rule.RuleResult, error) {
 	}, nil
 }
 
-func (*Rule242415) checkPods(pods []corev1.Pod, clusterTarget gardener.Target) []rule.CheckResult {
+func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.Namespace, clusterTarget gardener.Target) []rule.CheckResult {
 	checkResults := []rule.CheckResult{}
 	for _, pod := range pods {
 		target := clusterTarget.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 		passed := true
 		for _, container := range pod.Spec.Containers {
-			if container.Ports != nil && container.Env != nil {
+			if container.Env != nil {
 				for _, env := range container.Env {
 					if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
-						target = target.With("details", fmt.Sprintf("containerName: %s, keyRef: %s", container.Name, env.ValueFrom.SecretKeyRef.Key))
-						checkResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
+						target = target.With("details", fmt.Sprintf("containerName: %s, variableName: %s, keyRef: %s", container.Name, env.Name, env.ValueFrom.SecretKeyRef.Key))
+						if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace], env.Name); accepted {
+							msg := "Pod accepted to use environment to inject secret."
+							if justification != "" {
+								msg = justification
+							}
+							checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
+						} else {
+							checkResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
+						}
 						passed = false
 					}
 				}
@@ -84,4 +113,23 @@ func (*Rule242415) checkPods(pods []corev1.Pod, clusterTarget gardener.Target) [
 		}
 	}
 	return checkResults
+}
+
+func (r *Rule242415) accepted(podLabels map[string]string, namespace corev1.Namespace, environmentVariable string) (bool, string) {
+	if r.Options == nil {
+		return false, ""
+	}
+
+	for _, acceptedPod := range r.Options.AcceptedPods {
+		if utils.MatchLabels(podLabels, acceptedPod.PodMatchLabels) &&
+			utils.MatchLabels(namespace.Labels, acceptedPod.NamespaceMatchLabels) {
+			for _, acceptedEnvironmentVariable := range acceptedPod.EnvironmentVariables {
+				if acceptedEnvironmentVariable == environmentVariable {
+					return true, acceptedPod.Justification
+				}
+			}
+		}
+	}
+
+	return false, ""
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10/options.go
@@ -103,5 +103,5 @@ const (
 )
 
 type RuleOption interface {
-	Options242414 | Options245543 | Options254800 | OptionsPodFiles
+	Options242414 | Options242415 | Options245543 | Options254800 | OptionsPodFiles
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r10_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r10_ruleset.go
@@ -94,6 +94,10 @@ func (r *Ruleset) registerV1R10Rules(ruleOptions map[string]config.RuleOptionsCo
 	if err != nil {
 		return err
 	}
+	opts242415, err := getV1R10OptionOrNil[v1r10.Options242415](ruleOptions[v1r10.ID242415].Args)
+	if err != nil {
+		return err
+	}
 	opts245543, err := getV1R10OptionOrNil[v1r10.Options245543](ruleOptions[v1r10.ID245543].Args)
 	if err != nil {
 		return err
@@ -202,7 +206,13 @@ func (r *Ruleset) registerV1R10Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneNamespace: r.shootNamespace,
 			Options:               opts242414,
 		},
-		&v1r10.Rule242415{Logger: r.Logger().With("rule", v1r10.ID242415), ClusterClient: shootClient, ControlPlaneClient: seedClient, ControlPlaneNamespace: r.shootNamespace},
+		&v1r10.Rule242415{
+			Logger:                r.Logger().With("rule", v1r10.ID242415),
+			ClusterClient:         shootClient,
+			ControlPlaneClient:    seedClient,
+			ControlPlaneNamespace: r.shootNamespace,
+			Options:               opts242415,
+		},
 		&v1r10.Rule242417{Logger: r.Logger().With("rule", v1r10.ID242417), Client: shootClient},
 		&v1r10.Rule242418{Logger: r.Logger().With("rule", v1r10.ID242418), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r10.Rule242419{Logger: r.Logger().With("rule", v1r10.ID242419), Client: seedClient, Namespace: r.shootNamespace},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added new option `acceptedPods` to DISA Kubernetes STIGS `242415` rule which allows the user to configure environment variables for selected pods to be accepted.
```
```bugfix user
A bug causing rule `242414` to crash when no options for the rule were set was fixed.
```
