### PR TITLE
Reuse implementations across providers and rulesets

### DIFF
--- a/pkg/provider/gardener/provider.go
+++ b/pkg/provider/gardener/provider.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 
 	"k8s.io/client-go/rest"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/gardener/diki/pkg/provider"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
+	sharedprovider "github.com/gardener/diki/pkg/shared/provider"
 )
 
 // Provider is a Gardener Provider that can be used to implement rules
@@ -93,34 +93,7 @@ func validateAgrs(args Args) error {
 
 // RunAll executes all Rulesets registered with the Provider.
 func (p *Provider) RunAll(ctx context.Context) (provider.ProviderResult, error) {
-	if len(p.rulesets) == 0 {
-		return provider.ProviderResult{}, fmt.Errorf("no rulests are registered with the provider")
-	}
-
-	result := provider.ProviderResult{
-		ProviderName:   p.Name(),
-		ProviderID:     p.ID(),
-		Metadata:       maps.Clone(p.Metadata()),
-		RulesetResults: make([]ruleset.RulesetResult, 0, len(p.rulesets)),
-	}
-
-	var errAgg error
-	p.Logger().Info(fmt.Sprintf("provider will run %d rulesets", len(p.rulesets)))
-	for _, rs := range p.rulesets {
-		p.Logger().Info(fmt.Sprintf("starting run of ruleset %s version %s", rs.ID(), rs.Version()))
-		if res, err := rs.Run(ctx); err != nil {
-			errAgg = errors.Join(errAgg, fmt.Errorf("ruleset with id %s and version %s errored: %w", res.RulesetID, res.RulesetVersion, err))
-			p.Logger().Error(fmt.Sprintf("finished ruleset %s version %s run", rs.ID(), rs.Version()), "error", err)
-		} else {
-			result.RulesetResults = append(result.RulesetResults, res)
-			p.Logger().Info(fmt.Sprintf("finished ruleset %s version %s run", rs.ID(), rs.Version()))
-		}
-	}
-
-	if errAgg != nil {
-		return provider.ProviderResult{}, errAgg
-	}
-	return result, nil
+	return sharedprovider.RunAll(ctx, p, p.rulesets, p.Logger())
 }
 
 func rulesetKey(rulesetID, rulesetVersion string) string {

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -6,10 +6,8 @@ package disak8sstig
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"sync"
 
 	"github.com/google/uuid"
 	"k8s.io/client-go/rest"
@@ -17,6 +15,7 @@ import (
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
+	sharedruleset "github.com/gardener/diki/pkg/shared/ruleset"
 )
 
 const (
@@ -118,71 +117,7 @@ func (r *Ruleset) RunRule(ctx context.Context, id string) (rule.RuleResult, erro
 
 // Run executes all known Rules of the Ruleset.
 func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
-	if len(r.rules) == 0 {
-		return ruleset.RulesetResult{}, fmt.Errorf("no rules are registered in the ruleset")
-	}
-
-	result := ruleset.RulesetResult{
-		RulesetName:    r.Name(),
-		RulesetID:      r.ID(),
-		RulesetVersion: r.Version(),
-		RuleResults:    make([]rule.RuleResult, 0, len(r.rules)),
-	}
-
-	type run struct {
-		result rule.RuleResult
-		err    error
-	}
-
-	rulesCh := make(chan rule.Rule)
-	resultCh := make(chan run)
-	wg := sync.WaitGroup{}
-	r.Logger().Info(fmt.Sprintf("ruleset will run %d rules with %d concurrent workers", len(r.rules), r.numWorkers))
-	for i := 0; i < r.numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			for rule := range rulesCh {
-				r.Logger().Info(fmt.Sprintf("starting rule %s run", rule.ID()))
-				res, err := rule.Run(ctx)
-				res.RuleID = rule.ID()
-				res.RuleName = rule.Name()
-				resultCh <- run{result: res, err: err}
-			}
-			wg.Done()
-		}()
-	}
-
-	go func() {
-		for _, r := range r.rules {
-			rulesCh <- r
-		}
-		close(rulesCh)
-	}()
-
-	go func() {
-		wg.Wait()
-		close(resultCh)
-	}()
-
-	var err error
-	resultCount := 0
-	for run := range resultCh {
-		resultCount++
-		remaining := len(r.rules) - resultCount
-		finishMsg := fmt.Sprintf("finished rule %s run (%d remaining)", run.result.RuleID, remaining)
-		if run.err != nil {
-			r.Logger().Error(finishMsg, "error", run.err)
-			err = errors.Join(err, fmt.Errorf("rule with id %s errored: %w", run.result.RuleID, run.err))
-		} else {
-			r.Logger().Info(finishMsg)
-			result.RuleResults = append(result.RuleResults, run.result)
-		}
-	}
-	// TODO: maybe return both result and err
-	if err != nil {
-		return ruleset.RulesetResult{}, err
-	}
-	return result, nil
+	return sharedruleset.Run(ctx, r, r.rules, r.numWorkers, r.Logger())
 }
 
 // AddRules adds Rules to the Ruleset.

--- a/pkg/shared/provider/provider.go
+++ b/pkg/shared/provider/provider.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+
+	"github.com/gardener/diki/pkg/provider"
+	"github.com/gardener/diki/pkg/ruleset"
+)
+
+// Logger is a minimalistic logger interface.
+type Logger interface {
+	Info(string, ...any)
+	Error(string, ...any)
+}
+
+// RunAll is a sample implementation for a [provider.Provider].
+func RunAll(ctx context.Context, p provider.Provider, rulesets map[string]ruleset.Ruleset, log Logger) (provider.ProviderResult, error) {
+	if len(rulesets) == 0 {
+		return provider.ProviderResult{}, fmt.Errorf("no rulests are registered with the provider")
+	}
+
+	result := provider.ProviderResult{
+		ProviderName:   p.Name(),
+		ProviderID:     p.ID(),
+		Metadata:       maps.Clone(p.Metadata()),
+		RulesetResults: make([]ruleset.RulesetResult, 0, len(rulesets)),
+	}
+
+	var errAgg error
+	log.Info(fmt.Sprintf("provider will run %d rulesets", len(rulesets)))
+	for _, rs := range rulesets {
+		log.Info(fmt.Sprintf("starting run of ruleset %s version %s", rs.ID(), rs.Version()))
+		if res, err := rs.Run(ctx); err != nil {
+			errAgg = errors.Join(errAgg, fmt.Errorf("ruleset with id %s and version %s errored: %w", res.RulesetID, res.RulesetVersion, err))
+			log.Error(fmt.Sprintf("finished ruleset %s version %s run", rs.ID(), rs.Version()), "error", err)
+		} else {
+			result.RulesetResults = append(result.RulesetResults, res)
+			log.Info(fmt.Sprintf("finished ruleset %s version %s run", rs.ID(), rs.Version()))
+		}
+	}
+
+	if errAgg != nil {
+		return provider.ProviderResult{}, errAgg
+	}
+	return result, nil
+}

--- a/pkg/shared/ruleset/ruleset.go
+++ b/pkg/shared/ruleset/ruleset.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ruleset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/ruleset"
+)
+
+// Logger is a minimalistic logger interface.
+type Logger interface {
+	Info(string, ...any)
+	Error(string, ...any)
+}
+
+// Run is a sample implementation for a [ruleset.Ruleset].
+func Run(
+	ctx context.Context,
+	r ruleset.Ruleset,
+	rules map[string]rule.Rule,
+	numWorkers int,
+	log Logger,
+) (ruleset.RulesetResult, error) {
+	if len(rules) == 0 {
+		return ruleset.RulesetResult{}, fmt.Errorf("no rules are registered in the ruleset")
+	}
+
+	workers := 1
+	if numWorkers > 0 {
+		workers = numWorkers
+	}
+
+	result := ruleset.RulesetResult{
+		RulesetName:    r.Name(),
+		RulesetID:      r.ID(),
+		RulesetVersion: r.Version(),
+		RuleResults:    make([]rule.RuleResult, 0, len(rules)),
+	}
+
+	type run struct {
+		result rule.RuleResult
+		err    error
+	}
+
+	rulesCh := make(chan rule.Rule)
+	resultCh := make(chan run)
+	wg := sync.WaitGroup{}
+	log.Info(fmt.Sprintf("ruleset will run %d rules with %d concurrent workers", len(rules), workers))
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			for rule := range rulesCh {
+				log.Info(fmt.Sprintf("starting rule %s run", rule.ID()))
+				res, err := rule.Run(ctx)
+				res.RuleID = rule.ID()
+				res.RuleName = rule.Name()
+				resultCh <- run{result: res, err: err}
+			}
+			wg.Done()
+		}()
+	}
+
+	go func() {
+		for _, r := range rules {
+			rulesCh <- r
+		}
+		close(rulesCh)
+	}()
+
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	var err error
+	resultCount := 0
+	for run := range resultCh {
+		resultCount++
+		remaining := len(rules) - resultCount
+		finishMsg := fmt.Sprintf("finished rule %s run (%d remaining)", run.result.RuleID, remaining)
+		if run.err != nil {
+			log.Error(finishMsg, "error", run.err)
+			err = errors.Join(err, fmt.Errorf("rule with id %s errored: %w", run.result.RuleID, run.err))
+		} else {
+			log.Info(finishMsg)
+			result.RuleResults = append(result.RuleResults, run.result)
+		}
+	}
+	// TODO: maybe return both result and err
+	if err != nil {
+		return ruleset.RulesetResult{}, err
+	}
+	return result, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We can reuse some implementations across providers and rulesets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
