### PR TITLE
[DISA K8s STIG] Share, Skip and implement most of the virtual garden provider rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,10 @@ issues:
       linters:
         - revive
       text: "exported: exported"
+    - path: 'pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/'
+      linters:
+        - revive
+      text: "exported: exported"
     - path: 'pkg/shared/ruleset/disak8sstig/v1r11/'
       linters:
         - revive

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242407.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242407.go
@@ -19,7 +19,7 @@ func (r *Rule242407) ID() string {
 }
 
 func (r *Rule242407) Name() string {
-	return "Kubernetes kubelet configuration files must have file permissions set to 644 or more restrictive (MEDIUM 242407)"
+	return "The Kubernetes KubeletConfiguration files must have file permissions set to 644 or more restrictive  (MEDIUM 242407)"
 }
 
 func (r *Rule242407) Run(_ context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242408.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242408.go
@@ -19,7 +19,7 @@ func (r *Rule242408) ID() string {
 }
 
 func (r *Rule242408) Name() string {
-	return "Kubernetes manifests must have least privileges (MEDIUM 242408)"
+	return "The Kubernetes manifest files must have least privileges  (MEDIUM 242408)"
 }
 
 func (r *Rule242408) Run(_ context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242410.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242410.go
@@ -19,7 +19,7 @@ func (r *Rule242410) ID() string {
 }
 
 func (r *Rule242410) Name() string {
-	return "Kubernetes API Server must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242410)"
+	return "The Kubernetes API Server must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242410)"
 }
 
 func (r *Rule242410) Run(_ context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242411.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242411.go
@@ -19,7 +19,7 @@ func (r *Rule242411) ID() string {
 }
 
 func (r *Rule242411) Name() string {
-	return "Kubernetes Scheduler must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242411)"
+	return "The Kubernetes Scheduler must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242411)"
 }
 
 func (r *Rule242411) Run(_ context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242412.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242412.go
@@ -19,7 +19,7 @@ func (r *Rule242412) ID() string {
 }
 
 func (r *Rule242412) Name() string {
-	return "Kubernetes Controllers must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242412)"
+	return "The Kubernetes Controllers must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242412)"
 }
 
 func (r *Rule242412) Run(_ context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242413.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242413.go
@@ -19,7 +19,7 @@ func (r *Rule242413) ID() string {
 }
 
 func (r *Rule242413) Name() string {
-	return "Kubernetes etcd must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242413)"
+	return "The Kubernetes etcd must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242413)"
 }
 
 func (r *Rule242413) Run(_ context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242414.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242414.go
@@ -44,7 +44,7 @@ func (r *Rule242414) ID() string {
 }
 
 func (r *Rule242414) Name() string {
-	return "Kubernetes cluster must use non-privileged host ports for user pods (MEDIUM 242414)"
+	return "The Kubernetes cluster must use non-privileged host ports for user pods (MEDIUM 242414)"
 }
 
 func (r *Rule242414) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242427_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242427_test.go
@@ -21,6 +21,16 @@ import (
 )
 
 var _ = Describe("#242427", func() {
+	const (
+		ctsCertAuthNotSetConfig = `
+client-transport-security:`
+		ctsCertAuthSetFalseConfig = `
+client-transport-security:
+  client-cert-auth: false`
+		ctsCertAuthSetTrueConfig = `
+client-transport-security:
+  client-cert-auth: true`
+	)
 	var (
 		fakeClient client.Client
 		ctx        = context.TODO()

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242428_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242428_test.go
@@ -21,6 +21,16 @@ import (
 )
 
 var _ = Describe("#242428", func() {
+	const (
+		ctsCertAuthNotSetConfig = `
+client-transport-security:`
+		ctsCertAuthSetFalseConfig = `
+client-transport-security:
+  client-cert-auth: false`
+		ctsCertAuthSetTrueConfig = `
+client-transport-security:
+  client-cert-auth: true`
+	)
 	var (
 		fakeClient client.Client
 		ctx        = context.TODO()

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242443.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242443.go
@@ -23,5 +23,5 @@ func (r *Rule242443) Name() string {
 }
 
 func (r *Rule242443) Run(_ context.Context) (rule.RuleResult, error) {
-	return rule.SingleCheckResult(r, rule.SkippedCheckResult(`Scanning/patching security vulnerabilities should be enforced organizationally. Security vulnerability scanning should be automated and maintainers should be informed by automatically.`, rule.NewTarget())), nil
+	return rule.SingleCheckResult(r, rule.SkippedCheckResult(`Scanning/patching security vulnerabilities should be enforced organizationally. Security vulnerability scanning should be automated and maintainers should be informed automatically.`, rule.NewTarget())), nil
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242443_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242443_test.go
@@ -28,7 +28,7 @@ var _ = Describe("#242443", func() {
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
 			{
 				Status:  rule.Skipped,
-				Message: `Scanning/patching security vulnerabilities should be enforced organizationally. Security vulnerability scanning should be automated and maintainers should be informed by automatically.`,
+				Message: `Scanning/patching security vulnerabilities should be enforced organizationally. Security vulnerability scanning should be automated and maintainers should be informed automatically.`,
 				Target:  rule.NewTarget(),
 			},
 		},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
@@ -42,7 +42,7 @@ func (r *Rule254801) ID() string {
 }
 
 func (r *Rule254801) Name() string {
-	return "Kubernetes must have a Pod Security Admission feature gate set (HIGH 254801)"
+	return "Kubernetes must enable PodSecurity admission controller on static pods and Kubelets (HIGH 254801)"
 }
 
 func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
@@ -105,5 +105,5 @@ const (
 )
 
 type RuleOption interface {
-	Options242414 | Options242415 | sharedv1r11.Options245543 | Options254800 | OptionsPodFiles
+	Options242414 | Options242415 | sharedv1r11.Options245543 | sharedv1r11.Options254800 | OptionsPodFiles
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
@@ -4,6 +4,10 @@
 
 package v1r11
 
+import (
+	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
+)
+
 const (
 	ID242376    = "242376"
 	ID242377    = "242377"
@@ -101,5 +105,5 @@ const (
 )
 
 type RuleOption interface {
-	Options242414 | Options242415 | Options245543 | Options254800 | OptionsPodFiles
+	Options242414 | Options242415 | sharedv1r11.Options245543 | Options254800 | OptionsPodFiles
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -291,7 +291,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&v1r11.Rule242457{},
 		&v1r11.Rule242459{},
 		&v1r11.Rule242460{},
-		&v1r11.Rule242461{},
+		&sharedv1r11.Rule242461{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242462{Logger: r.Logger().With("rule", v1r11.ID242462), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242463{Logger: r.Logger().With("rule", v1r11.ID242463), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242464{Logger: r.Logger().With("rule", v1r11.ID242464), Client: seedClient, Namespace: r.shootNamespace},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -249,7 +249,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242426{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242427{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242428{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242429{Logger: r.Logger().With("rule", v1r11.ID242429), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242429{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242430{Logger: r.Logger().With("rule", v1r11.ID242430), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242431{Logger: r.Logger().With("rule", v1r11.ID242431), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242432{Logger: r.Logger().With("rule", v1r11.ID242432), Client: seedClient, Namespace: r.shootNamespace},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -226,7 +226,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
 		&sharedv1r11.Rule242421{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242422{Logger: r.Logger().With("rule", v1r11.ID242422), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242422{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242423{Logger: r.Logger().With("rule", v1r11.ID242423), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242424{
 			Logger:                  r.Logger().With("rule", v1r11.ID242424),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -293,7 +293,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&v1r11.Rule242460{},
 		&sharedv1r11.Rule242461{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242462{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242463{Logger: r.Logger().With("rule", v1r11.ID242463), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242463{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242464{Logger: r.Logger().With("rule", v1r11.ID242464), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242465{},
 		&v1r11.Rule242466{},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -307,7 +307,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ClusterPodContext:       shootPodContext,
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
-		&v1r11.Rule245542{Logger: r.Logger().With("rule", v1r11.ID245542), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule245542{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule245543{Logger: r.Logger().With("rule", v1r11.ID245543), Client: seedClient, Namespace: r.shootNamespace, Options: opts245543},
 		&v1r11.Rule245544{Logger: r.Logger().With("rule", v1r11.ID245544), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule254800{Logger: r.Logger().With("rule", v1r11.ID254800), Client: seedClient, Namespace: r.shootNamespace, Options: opts254800},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -251,7 +251,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242428{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242429{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242430{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242431{Logger: r.Logger().With("rule", v1r11.ID242431), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242431{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242432{Logger: r.Logger().With("rule", v1r11.ID242432), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242433{Logger: r.Logger().With("rule", v1r11.ID242433), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242434{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -99,7 +99,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	if err != nil {
 		return err
 	}
-	opts245543, err := getV1R11OptionOrNil[v1r11.Options245543](ruleOptions[v1r11.ID245543].Args)
+	opts245543, err := getV1R11OptionOrNil[sharedv1r11.Options245543](ruleOptions[v1r11.ID245543].Args)
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
 		&sharedv1r11.Rule245542{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule245543{Logger: r.Logger().With("rule", v1r11.ID245543), Client: seedClient, Namespace: r.shootNamespace, Options: opts245543},
+		&sharedv1r11.Rule245543{Client: seedClient, Namespace: r.shootNamespace, Options: opts245543},
 		&v1r11.Rule245544{Logger: r.Logger().With("rule", v1r11.ID245544), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule254800{Logger: r.Logger().With("rule", v1r11.ID254800), Client: seedClient, Namespace: r.shootNamespace, Options: opts254800},
 		&v1r11.Rule254801{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -263,7 +263,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ClusterPodContext:       shootPodContext,
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
-		&v1r11.Rule242436{Logger: r.Logger().With("rule", v1r11.ID242436), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242436{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242437{
 			Logger:                r.Logger().With("rule", v1r11.ID242437),
 			ClusterClient:         shootClient,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -225,7 +225,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ClusterPodContext:       shootPodContext,
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
-		&v1r11.Rule242421{Logger: r.Logger().With("rule", v1r11.ID242421), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242421{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242422{Logger: r.Logger().With("rule", v1r11.ID242422), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242423{Logger: r.Logger().With("rule", v1r11.ID242423), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242424{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -194,7 +194,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&v1r11.Rule242406{},
 		&v1r11.Rule242407{},
 		&v1r11.Rule242408{},
-		&v1r11.Rule242409{Logger: r.Logger().With("rule", v1r11.ID242409), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242409{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242410{},
 		&v1r11.Rule242411{},
 		&v1r11.Rule242412{},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -294,7 +294,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242461{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242462{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242463{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242464{Logger: r.Logger().With("rule", v1r11.ID242464), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242464{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242465{},
 		&v1r11.Rule242466{},
 		&v1r11.Rule242467{},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -250,7 +250,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242427{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242428{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242429{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242430{Logger: r.Logger().With("rule", v1r11.ID242430), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242430{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242431{Logger: r.Logger().With("rule", v1r11.ID242431), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242432{Logger: r.Logger().With("rule", v1r11.ID242432), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242433{Logger: r.Logger().With("rule", v1r11.ID242433), Client: seedClient, Namespace: r.shootNamespace},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -292,7 +292,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&v1r11.Rule242459{},
 		&v1r11.Rule242460{},
 		&sharedv1r11.Rule242461{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242462{Logger: r.Logger().With("rule", v1r11.ID242462), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242462{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242463{Logger: r.Logger().With("rule", v1r11.ID242463), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242464{Logger: r.Logger().With("rule", v1r11.ID242464), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242465{},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -214,7 +214,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Options:               opts242415,
 		},
 		&v1r11.Rule242417{Logger: r.Logger().With("rule", v1r11.ID242417), Client: shootClient},
-		&v1r11.Rule242418{Logger: r.Logger().With("rule", v1r11.ID242418), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242418{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242419{Logger: r.Logger().With("rule", v1r11.ID242419), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242420{
 			Logger:                  r.Logger().With("rule", v1r11.ID242420),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -246,7 +246,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ClusterPodContext:       shootPodContext,
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
-		&v1r11.Rule242426{Logger: r.Logger().With("rule", v1r11.ID242426), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242426{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242427{Logger: r.Logger().With("rule", v1r11.ID242427), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242428{Logger: r.Logger().With("rule", v1r11.ID242428), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242429{Logger: r.Logger().With("rule", v1r11.ID242429), Client: seedClient, Namespace: r.shootNamespace},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -248,7 +248,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		},
 		&sharedv1r11.Rule242426{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242427{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242428{Logger: r.Logger().With("rule", v1r11.ID242428), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242428{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242429{Logger: r.Logger().With("rule", v1r11.ID242429), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242430{Logger: r.Logger().With("rule", v1r11.ID242430), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242431{Logger: r.Logger().With("rule", v1r11.ID242431), Client: seedClient, Namespace: r.shootNamespace},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -215,7 +215,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		},
 		&v1r11.Rule242417{Logger: r.Logger().With("rule", v1r11.ID242417), Client: shootClient},
 		&sharedv1r11.Rule242418{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242419{Logger: r.Logger().With("rule", v1r11.ID242419), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242419{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242420{
 			Logger:                  r.Logger().With("rule", v1r11.ID242420),
 			InstanceID:              r.instanceID,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -272,7 +272,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneVersion:   semverSeedKubernetesVersion,
 			ControlPlaneNamespace: r.shootNamespace,
 		},
-		&v1r11.Rule242438{Logger: r.Logger().With("rule", v1r11.ID242438), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242438{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242442{Logger: r.Logger().With("rule", v1r11.ID242442), ClusterClient: shootClient, ControlPlaneClient: seedClient, ControlPlaneNamespace: r.shootNamespace},
 		&v1r11.Rule242443{},
 		&v1r11.Rule242444{},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -253,7 +253,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242430{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242431{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242432{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242433{Logger: r.Logger().With("rule", v1r11.ID242433), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242433{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242434{
 			Logger:                  r.Logger().With("rule", v1r11.ID242434),
 			InstanceID:              r.instanceID,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -227,7 +227,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		},
 		&sharedv1r11.Rule242421{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242422{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242423{Logger: r.Logger().With("rule", v1r11.ID242423), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242423{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242424{
 			Logger:                  r.Logger().With("rule", v1r11.ID242424),
 			InstanceID:              r.instanceID,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -103,7 +103,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	if err != nil {
 		return err
 	}
-	opts254800, err := getV1R11OptionOrNil[v1r11.Options254800](ruleOptions[v1r11.ID254800].Args)
+	opts254800, err := getV1R11OptionOrNil[sharedv1r11.Options254800](ruleOptions[v1r11.ID254800].Args)
 	if err != nil {
 		return err
 	}
@@ -310,7 +310,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule245542{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule245543{Client: seedClient, Namespace: r.shootNamespace, Options: opts245543},
 		&sharedv1r11.Rule245544{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule254800{Logger: r.Logger().With("rule", v1r11.ID254800), Client: seedClient, Namespace: r.shootNamespace, Options: opts254800},
+		&sharedv1r11.Rule254800{Client: seedClient, Namespace: r.shootNamespace, Options: opts254800},
 		&v1r11.Rule254801{
 			Logger:                  r.Logger().With("rule", v1r11.ID254801),
 			InstanceID:              r.instanceID,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -309,7 +309,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		},
 		&sharedv1r11.Rule245542{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule245543{Client: seedClient, Namespace: r.shootNamespace, Options: opts245543},
-		&v1r11.Rule245544{Logger: r.Logger().With("rule", v1r11.ID245544), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule245544{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule254800{Logger: r.Logger().With("rule", v1r11.ID254800), Client: seedClient, Namespace: r.shootNamespace, Options: opts254800},
 		&v1r11.Rule254801{
 			Logger:                  r.Logger().With("rule", v1r11.ID254801),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -247,7 +247,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
 		&sharedv1r11.Rule242426{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242427{Logger: r.Logger().With("rule", v1r11.ID242427), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242427{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242428{Logger: r.Logger().With("rule", v1r11.ID242428), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242429{Logger: r.Logger().With("rule", v1r11.ID242429), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242430{Logger: r.Logger().With("rule", v1r11.ID242430), Client: seedClient, Namespace: r.shootNamespace},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -252,7 +252,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242429{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242430{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242431{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242432{Logger: r.Logger().With("rule", v1r11.ID242432), Client: seedClient, Namespace: r.shootNamespace},
+		&sharedv1r11.Rule242432{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242433{Logger: r.Logger().With("rule", v1r11.ID242433), Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242434{
 			Logger:                  r.Logger().With("rule", v1r11.ID242434),

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242442.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242442.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1r11
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
+	"github.com/gardener/diki/pkg/rule"
+	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
+)
+
+var _ rule.Rule = &Rule242442{}
+
+type Rule242442 struct {
+	Client    client.Client
+	Namespace string
+}
+
+func (r *Rule242442) ID() string {
+	return sharedv1r11.ID242442
+}
+
+func (r *Rule242442) Name() string {
+	return "Kubernetes must remove old components after updated versions have been installed (MEDIUM 242442)"
+}
+
+func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
+	images := map[string]string{}
+	reportedImages := map[string]struct{}{}
+	pods, err := kubeutils.GetPods(ctx, r.Client, r.Namespace, labels.NewSelector(), 300)
+	if err != nil {
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("namespace", r.Namespace, "kind", "podList"))), nil
+	}
+
+	checkResults := r.checkImages(pods, images, reportedImages)
+	if len(checkResults) == 0 {
+		return rule.SingleCheckResult(r, rule.PassedCheckResult("All found images use current versions.", rule.Target{})), nil
+	}
+
+	return rule.RuleResult{
+		RuleID:       r.ID(),
+		RuleName:     r.Name(),
+		CheckResults: checkResults,
+	}, nil
+}
+
+func (*Rule242442) checkImages(pods []corev1.Pod, images map[string]string, reportedImages map[string]struct{}) []rule.CheckResult {
+	checkResults := []rule.CheckResult{}
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+				return containerStatus.Name == container.Name
+			})
+
+			if containerStatusIdx < 0 {
+				checkResults = append(checkResults, rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("name", pod.Name, "container", container.Name, "kind", "pod")))
+				continue
+			}
+
+			imageRef := pod.Status.ContainerStatuses[containerStatusIdx].ImageID
+			imageBase := strings.Split(strings.Split(imageRef, ":")[0], "@")[0]
+			if _, ok := images[imageBase]; ok {
+				if images[imageBase] != imageRef {
+					if _, reported := reportedImages[imageBase]; !reported {
+						target := rule.NewTarget("image", imageBase)
+						checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target))
+						reportedImages[imageBase] = struct{}{}
+					}
+				}
+			} else {
+				images[imageBase] = imageRef
+			}
+		}
+	}
+	return checkResults
+}

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242442_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242442_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1r11_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#242442", func() {
+	var (
+		fakeClient client.Client
+		pod        *corev1.Pod
+		ctx        = context.TODO()
+		namespace  = "foo"
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().Build()
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+					{
+						Name: "foobar",
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+					{
+						Name: "foobar",
+					},
+				},
+			},
+		}
+	})
+
+	It("should return correct results when all images use only 1 version", func() {
+		r := &v1r11.Rule242442{Client: fakeClient, Namespace: namespace}
+		pod.Status.ContainerStatuses[0].ImageID = "eu.gcr.io/image1@sha256:foobar"
+		pod.Status.ContainerStatuses[1].ImageID = "eu.gcr.io/image2@sha256:foo"
+		pod.Status.ContainerStatuses[2].ImageID = "eu.gcr.io/image3@sha256:bar"
+		Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+		ruleResult, err := r.Run(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedCheckResults := []rule.CheckResult{
+			rule.PassedCheckResult("All found images use current versions.", rule.Target{}),
+		}
+
+		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+	})
+	It("should return correct results when a image uses more than 1 version", func() {
+		r := &v1r11.Rule242442{Client: fakeClient, Namespace: namespace}
+		pod.Status.ContainerStatuses[0].ImageID = "eu.gcr.io/image1@sha256:foobar"
+		pod.Status.ContainerStatuses[1].ImageID = "eu.gcr.io/image2@sha256:foo"
+		pod.Status.ContainerStatuses[2].ImageID = "eu.gcr.io/image2@sha256:bar"
+		Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+		ruleResult, err := r.Run(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedCheckResults := []rule.CheckResult{
+			rule.FailedCheckResult("Image is used with more than one versions.", rule.NewTarget("image", "eu.gcr.io/image2")),
+		}
+
+		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+	})
+	It("should return errored results when containerStatus cannot be found for a given container", func() {
+		r := &v1r11.Rule242442{Client: fakeClient, Namespace: namespace}
+		pod.Status.ContainerStatuses[0].Name = "not-foo"
+		pod.Status.ContainerStatuses[1].ImageID = "eu.gcr.io/image2@sha256:foo"
+		pod.Status.ContainerStatuses[2].ImageID = "eu.gcr.io/image3@sha256:bar"
+		Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+		ruleResult, err := r.Run(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedCheckResults := []rule.CheckResult{
+			rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("container", "foo", "name", "pod", "kind", "pod")),
+		}
+
+		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+	})
+})

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/options.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1r11
+
+import (
+	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
+)
+
+type RuleOption interface {
+	sharedv1r11.Options245543
+}

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/options.go
@@ -9,5 +9,5 @@ import (
 )
 
 type RuleOption interface {
-	sharedv1r11.Options245543
+	sharedv1r11.Options245543 | sharedv1r11.Options254800
 }

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/v1r11_suite_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/v1r11_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1r11_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1R11(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DISA Kubernetes STIG V1R11 Test Suite")
+}

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -437,6 +437,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noPodsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242449,
+			"The Kubernetes Kubelet certificate authority file must have file permissions set to 644 or more restrictive (MEDIUM 242449)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -551,6 +551,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		&sharedv1r11.Rule245542{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -209,6 +209,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Gardener does not deploy any control plane component as systemd processes or static pod.",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242406,
+			"Kubernetes kubelet configuration file must be owned by root (MEDIUM 242406)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -449,6 +449,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242451,
+			"The Kubernetes component PKI must be owned by root (MEDIUM 242451)",
+			"",
+			rule.NotImplemented,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -372,6 +372,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			StatefulSetETCDMain:   etcdMain,
 			StatefulSetETCDEvents: etcdEvents,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID242434,
+			"Kubernetes Kubelet must enable kernel protection (HIGH 242434)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -324,6 +324,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		&sharedv1r11.Rule242426{
+			Client:                runtimeClient,
+			Namespace:             ns,
+			StatefulSetETCDMain:   etcdMain,
+			StatefulSetETCDEvents: etcdEvents,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -233,6 +233,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: kcmDeploymentName,
 			ContainerName:  kcmContainerName,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID242410,
+			"The Kubernetes API Server must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242410)",
+			"Cannot be tested and should be enforced organizationally. Gardener uses a minimum of known and automatically opened/used/created ports/protocols/services (PPSM stands for Ports, Protocols, Service Management).",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -5,6 +5,8 @@
 package disak8sstig
 
 import (
+	"encoding/json"
+
 	kubernetesgardener "github.com/gardener/gardener/pkg/client/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -21,6 +23,11 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	}
 
 	_, err = client.New(r.GardenConfig, client.Options{Scheme: kubernetesgardener.GardenScheme})
+	if err != nil {
+		return err
+	}
+
+	opts245543, err := getV1R11OptionOrNil[sharedv1r11.Options245543](ruleOptions[sharedv1r11.ID245543].Args)
 	if err != nil {
 		return err
 	}
@@ -557,6 +564,13 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule245543{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			Options:        opts245543,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {
@@ -567,4 +581,25 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	}
 
 	return r.AddRules(rules...)
+}
+
+func parseV1R11Options[O v1r11.RuleOption](options any) (*O, error) { //nolint:unused
+	optionsByte, err := json.Marshal(options)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsedOptions O
+	if err := json.Unmarshal(optionsByte, &parsedOptions); err != nil {
+		return nil, err
+	}
+
+	return &parsedOptions, nil
+}
+
+func getV1R11OptionOrNil[O v1r11.RuleOption](options any) (*O, error) { //nolint:unused
+	if options == nil {
+		return nil, nil
+	}
+	return parseV1R11Options[O](options)
 }

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -342,6 +342,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			StatefulSetETCDMain:   etcdMain,
 			StatefulSetETCDEvents: etcdEvents,
 		},
+		&sharedv1r11.Rule242429{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -461,6 +461,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242453,
+			"The Kubernetes kubelet KubeConfig file must be owned by root (MEDIUM 242453)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -588,6 +588,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID254801,
+			"Kubernetes must enable PodSecurity admission controller on static pods and Kubelets (HIGH 254801)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -467,6 +467,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242454,
+			"The Kubernetes kubeadm.conf must be owned by root (MEDIUM 242454)",
+			"Gardener does not use kubeadm and also does not store any main config anywhere (flow/component logic built-in/in-code).",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -539,6 +539,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"",
 			rule.NotImplemented,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242467,
+			"The Kubernetes PKI keys must have file permissions set to 600 or more restrictive (MEDIUM 242467)",
+			"",
+			rule.NotImplemented,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -396,6 +396,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID242442,
+			"Kubernetes must remove old components after updated versions have been installed (MEDIUM 242442)",
+			noPodsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -527,6 +527,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID242465,
+			"The Kubernetes API Server audit log path must be set (MEDIUM 242465)",
+			"Rule is duplicate of 242402.",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -300,6 +300,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: kcmDeploymentName,
 			ContainerName:  kcmContainerName,
 		},
+		&sharedv1r11.Rule242422{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -348,6 +348,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242430{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -294,6 +294,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		&sharedv1r11.Rule242421{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: kcmDeploymentName,
+			ContainerName:  kcmContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -571,6 +571,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule245544{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -276,6 +276,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noPodsMsg,
 			rule.Skipped,
 		),
+		&sharedv1r11.Rule242418{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -306,6 +306,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242423{
+			Client:                runtimeClient,
+			Namespace:             ns,
+			StatefulSetETCDMain:   etcdMain,
+			StatefulSetETCDEvents: etcdEvents,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -408,6 +408,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Scanning/patching security vulnerabilities should be enforced organizationally. Security vulnerability scanning should be automated and maintainers should be informed automatically.",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242444,
+			"Kubernetes component manifests must be owned by root (MEDIUM 242444)",
+			"Rule is duplicate of 242405. Gardener does not deploy any control plane component as systemd processes or static pod.",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -521,6 +521,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242464{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -491,6 +491,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Duplicate of 242453. "+noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242459,
+			"The Kubernetes etcd must have file permissions set to 644 or more restrictive (MEDIUM 242459)",
+			"",
+			rule.NotImplemented,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -366,6 +366,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			StatefulSetETCDMain:   etcdMain,
 			StatefulSetETCDEvents: etcdEvents,
 		},
+		&sharedv1r11.Rule242433{
+			Client:                runtimeClient,
+			Namespace:             ns,
+			StatefulSetETCDMain:   etcdMain,
+			StatefulSetETCDEvents: etcdEvents,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -330,6 +330,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			StatefulSetETCDMain:   etcdMain,
 			StatefulSetETCDEvents: etcdEvents,
 		},
+		&sharedv1r11.Rule242427{
+			Client:                runtimeClient,
+			Namespace:             ns,
+			StatefulSetETCDMain:   etcdMain,
+			StatefulSetETCDEvents: etcdEvents,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -455,6 +455,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"",
 			rule.NotImplemented,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242452,
+			"The Kubernetes kubelet KubeConfig must have file permissions set to 644 or more restrictive (MEDIUM 242452)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -354,6 +354,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242431{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -425,6 +425,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"",
 			rule.NotImplemented,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242447,
+			"The Kubernetes Kube Proxy kubeconfig must have file permissions set to 644 or more restrictive (MEDIUM 242447)",
+			noPodsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -318,6 +318,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242425,
+			"Kubernetes Kubelet must enable tlsCertFile for client authentication to secure service (MEDIUM 242425)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -360,6 +360,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242432{
+			Client:                runtimeClient,
+			Namespace:             ns,
+			StatefulSetETCDMain:   etcdMain,
+			StatefulSetETCDEvents: etcdEvents,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -312,6 +312,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			StatefulSetETCDMain:   etcdMain,
 			StatefulSetETCDEvents: etcdEvents,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID242424,
+			"Kubernetes Kubelet must enable tlsPrivateKeyFile for client authentication to secure service (MEDIUM 242424)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -239,6 +239,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Cannot be tested and should be enforced organizationally. Gardener uses a minimum of known and automatically opened/used/created ports/protocols/services (PPSM stands for Ports, Protocols, Service Management).",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242411,
+			"The Kubernetes Scheduler must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242411)",
+			"The Virtual Garden cluster does not make use of a Kubernetes Scheduler.",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -390,6 +390,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"PSPs are removed in K8s version 1.25.",
 			rule.Skipped,
 		),
+		&sharedv1r11.Rule242438{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -264,6 +264,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noPodsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242415,
+			"Secrets in Kubernetes must not be stored as environment variables (HIGH 242415)",
+			noPodsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -431,6 +431,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noPodsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242448,
+			"The Kubernetes Kube Proxy kubeconfig must be owned by root (MEDIUM 242448)",
+			noPodsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -215,6 +215,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242407,
+			"The Kubernetes KubeletConfiguration files must have file permissions set to 644 or more restrictive (MEDIUM 242407)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -251,6 +251,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Cannot be tested and should be enforced organizationally. Gardener uses a minimum of known and automatically opened/used/created ports/protocols/services (PPSM stands for Ports, Protocols, Service Management).",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242413,
+			"The Kubernetes etcd must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242413)",
+			"Cannot be tested and should be enforced organizationally. Gardener uses a minimum of known and automatically opened/used/created ports/protocols/services (PPSM stands for Ports, Protocols, Service Management).",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -545,6 +545,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"",
 			rule.NotImplemented,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID245541,
+			"Kubernetes Kubelet must not disable timeouts (MEDIUM 245541)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -384,6 +384,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID242437,
+			"Kubernetes must have a pod security policy set (HIGH 242437)",
+			"PSPs are removed in K8s version 1.25.",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -270,6 +270,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noPodsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242417,
+			"Kubernetes must separate user functionality (MEDIUM 242417)",
+			noPodsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -443,6 +443,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242450,
+			"The Kubernetes Kubelet certificate authority must be owned by root (MEDIUM 242450)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -282,6 +282,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242419{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -470,7 +470,13 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		rule.NewSkipRule(
 			sharedv1r11.ID242454,
 			"The Kubernetes kubeadm.conf must be owned by root (MEDIUM 242454)",
-			"Gardener does not use kubeadm and also does not store any main config anywhere (flow/component logic built-in/in-code).",
+			`Gardener does not use kubeadm and also does not store any "main config" anywhere (flow/component logic built-in/in-code).`,
+			rule.Skipped,
+		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242455,
+			"The Kubernetes kubeadm.conf must have file permissions set to 644 or more restrictive (MEDIUM 242455)",
+			`Gardener does not use kubeadm and also does not store any "main config" anywhere (flow/component logic built-in/in-code).`,
 			rule.Skipped,
 		),
 	}

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -485,6 +485,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Duplicate of 242452. "+noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242457,
+			"The Kubernetes kubelet config must be owned by root (MEDIUM 242457)",
+			"Duplicate of 242453. "+noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -245,6 +245,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"The Virtual Garden cluster does not make use of a Kubernetes Scheduler.",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242412,
+			"The Kubernetes Controllers must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242412)",
+			"Cannot be tested and should be enforced organizationally. Gardener uses a minimum of known and automatically opened/used/created ports/protocols/services (PPSM stands for Ports, Protocols, Service Management).",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -31,6 +31,10 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	if err != nil {
 		return err
 	}
+	opts254800, err := getV1R11OptionOrNil[sharedv1r11.Options254800](ruleOptions[sharedv1r11.ID254800].Args)
+	if err != nil {
+		return err
+	}
 
 	const (
 		ns                      = "garden"
@@ -574,6 +578,13 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule245544{
 			Client:         runtimeClient,
 			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
+		&sharedv1r11.Rule254800{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			Options:        opts254800,
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -336,6 +336,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			StatefulSetETCDMain:   etcdMain,
 			StatefulSetETCDEvents: etcdEvents,
 		},
+		&sharedv1r11.Rule242428{
+			Client:                runtimeClient,
+			Namespace:             ns,
+			StatefulSetETCDMain:   etcdMain,
+			StatefulSetETCDEvents: etcdEvents,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -479,6 +479,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			`Gardener does not use kubeadm and also does not store any "main config" anywhere (flow/component logic built-in/in-code).`,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242456,
+			"The Kubernetes kubelet config must have file permissions set to 644 or more restrictive (MEDIUM 242456)",
+			"Duplicate of 242452. "+noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -33,6 +33,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		apiserverDeploymentName = "virtual-garden-kube-apiserver"
 		apiserverContainerName  = "kube-apiserver"
 		noKubeletsMsg           = "The Virtual Garden cluster does not have any nodes therefore there are no kubelets to check."
+		noPodsMsg               = "The Virtual Garden cluster does not have any nodes therefore there cluster does not have any pods."
 	)
 	rules := []rule.Rule{
 		&sharedv1r11.Rule242376{
@@ -255,6 +256,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			sharedv1r11.ID242413,
 			"The Kubernetes etcd must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL) (MEDIUM 242413)",
 			"Cannot be tested and should be enforced organizationally. Gardener uses a minimum of known and automatically opened/used/created ports/protocols/services (PPSM stands for Ports, Protocols, Service Management).",
+			rule.Skipped,
+		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242414,
+			"The Kubernetes cluster must use non-privileged host ports for user pods (MEDIUM 242414)",
+			noPodsMsg,
 			rule.Skipped,
 		),
 	}

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -503,6 +503,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"",
 			rule.NotImplemented,
 		),
+		&sharedv1r11.Rule242461{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -533,6 +533,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Rule is duplicate of 242402.",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242466,
+			"The Kubernetes PKI CRT must have file permissions set to 644 or more restrictive (MEDIUM 242466)",
+			"",
+			rule.NotImplemented,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -414,6 +414,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Rule is duplicate of 242405. Gardener does not deploy any control plane component as systemd processes or static pod.",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242445,
+			"Kubernetes component etcd must be owned by etcd (MEDIUM 242445)",
+			"Gardener does not deploy any control plane component as systemd processes or static pod.",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -515,6 +515,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242463{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -378,6 +378,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		&sharedv1r11.Rule242436{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
@@ -396,12 +397,10 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
-		rule.NewSkipRule(
-			sharedv1r11.ID242442,
-			"Kubernetes must remove old components after updated versions have been installed (MEDIUM 242442)",
-			noPodsMsg,
-			rule.Skipped,
-		),
+		&v1r11.Rule242442{
+			Client:    runtimeClient,
+			Namespace: ns,
+		},
 		rule.NewSkipRule(
 			sharedv1r11.ID242443,
 			"Kubernetes must contain the latest updates as authorized by IAVMs, CTOs, DTMs, and STIGs (MEDIUM 242443)",

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -288,6 +288,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		rule.NewSkipRule(
+			sharedv1r11.ID242420,
+			"Kubernetes Kubelet must have the SSL Certificate Authority set (MEDIUM 242420)",
+			noKubeletsMsg,
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -509,6 +509,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
 		},
+		&sharedv1r11.Rule242462{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: apiserverDeploymentName,
+			ContainerName:  apiserverContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -419,6 +419,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Gardener does not deploy any control plane component as systemd processes or static pod.",
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242446,
+			"The Kubernetes conf files must be owned by root (MEDIUM 242446)",
+			"",
+			rule.NotImplemented,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -227,6 +227,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"Gardener does not deploy any control plane component as systemd processes or static pod.",
 			rule.Skipped,
 		),
+		&sharedv1r11.Rule242409{
+			Client:         runtimeClient,
+			Namespace:      ns,
+			DeploymentName: kcmDeploymentName,
+			ContainerName:  kcmContainerName,
+		},
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -497,6 +497,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			"",
 			rule.NotImplemented,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242460,
+			"The Kubernetes admin kubeconfig must have file permissions set to 644 or more restrictive (MEDIUM 242460)",
+			"",
+			rule.NotImplemented,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -221,6 +221,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noKubeletsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242408,
+			"The Kubernetes manifest files must have least privileges (MEDIUM 242408)",
+			"Gardener does not deploy any control plane component as systemd processes or static pod.",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -402,6 +402,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			noPodsMsg,
 			rule.Skipped,
 		),
+		rule.NewSkipRule(
+			sharedv1r11.ID242443,
+			"Kubernetes must contain the latest updates as authorized by IAVMs, CTOs, DTMs, and STIGs (MEDIUM 242443)",
+			"Scanning/patching security vulnerabilities should be enforced organizationally. Security vulnerability scanning should be automated and maintainers should be informed automatically.",
+			rule.Skipped,
+		),
 	}
 
 	for i, r := range rules {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242403_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242403_test.go
@@ -50,7 +50,7 @@ rules:
 		namespace  = "foo"
 
 		kapiDeployment *appsv1.Deployment
-		target         = rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-apiserver", "namespace", namespace)
+		target         = rule.NewTarget("kind", "deployment", "name", "kube-apiserver", "namespace", namespace)
 	)
 
 	BeforeEach(func() {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242409.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242409.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,9 +17,10 @@ import (
 var _ rule.Rule = &Rule242409{}
 
 type Rule242409 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242409) ID() string {
@@ -32,13 +32,20 @@ func (r *Rule242409) Name() string {
 }
 
 func (r *Rule242409) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kcmName = "kube-controller-manager"
-		option  = "profiling"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kcmName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "profiling"
+	deploymentName := "kube-controller-manager"
+	containerName := "kube-controller-manager"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kcmName, kcmName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242409_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242409_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242409", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242409", func() {
 		namespace  = "foo"
 
 		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("cluster", "seed", "name", "kube-controller-manager", "namespace", namespace, "kind", "deployment")
+		target        = rule.NewTarget("name", "kube-controller-manager", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242409", func() {
 	})
 
 	It("should error when kube-controller-manager is not found", func() {
-		r := &v1r11.Rule242409{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242409{Client: fakeClient, Namespace: namespace}
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = Describe("#242409", func() {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242409{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242409{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242418_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242418_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242418", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242418", func() {
 		namespace  = "foo"
 
 		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target        = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242418", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242418{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242418{Client: fakeClient, Namespace: namespace}
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = Describe("#242418", func() {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242418{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242418{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242419.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242419.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242419{}
 
 type Rule242419 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242419) ID() string {
@@ -33,13 +33,20 @@ func (r *Rule242419) Name() string {
 }
 
 func (r *Rule242419) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "client-ca-file"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "client-ca-file"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242419_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242419_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242419", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242419", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242419", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242419{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242419{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#242419", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242419{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242419{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242421_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242421_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242421", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242421", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-controller-manager", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-controller-manager", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242421", func() {
 	})
 
 	It("should error when kube-controller-manager is not found", func() {
-		r := &v1r11.Rule242421{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242421{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#242421", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242421{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242421{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242422_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242422_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242422", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242422", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242422", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242422{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242422{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#242422", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242422{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242422{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242426.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242426.go
@@ -6,7 +6,6 @@ package v1r11
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -22,9 +21,10 @@ import (
 var _ rule.Rule = &Rule242426{}
 
 type Rule242426 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client                client.Client
+	Namespace             string
+	StatefulSetETCDMain   string
+	StatefulSetETCDEvents string
 }
 
 func (r *Rule242426) ID() string {
@@ -37,9 +37,18 @@ func (r *Rule242426) Name() string {
 
 func (r *Rule242426) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
+	etcdMain := "etcd-main"
+	etcdEvents := "etcd-events"
 
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-main"))
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-events"))
+	if r.StatefulSetETCDMain != "" {
+		etcdMain = r.StatefulSetETCDMain
+	}
+
+	if r.StatefulSetETCDEvents != "" {
+		etcdEvents = r.StatefulSetETCDEvents
+	}
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdMain))
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdEvents))
 
 	return rule.RuleResult{
 		RuleID:       r.ID(),
@@ -56,7 +65,7 @@ func (r *Rule242426) checkStatefulSet(ctx context.Context, statefulSetName strin
 		},
 	}
 
-	target := rule.NewTarget("cluster", "seed", "name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
+	target := rule.NewTarget("name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
 
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet); err != nil {
 		return rule.ErroredCheckResult(err.Error(), target)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242426_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242426_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242426", func() {
@@ -46,8 +46,8 @@ peer-transport-security:
 
 		etcdMainStatefulSet   *appsv1.StatefulSet
 		etcdEventsStatefulSet *appsv1.StatefulSet
-		targetEtcdMain        = rule.NewTarget("cluster", "seed", "name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
-		targetEtcdEvents      = rule.NewTarget("cluster", "seed", "name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdMain        = rule.NewTarget("name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdEvents      = rule.NewTarget("name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
 	)
 
 	BeforeEach(func() {
@@ -81,7 +81,7 @@ peer-transport-security:
 	})
 
 	It("should return error check results when etcd-main and etcd-events are not found", func() {
-		r := &v1r11.Rule242426{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242426{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,7 +112,7 @@ peer-transport-security:
 			Expect(fakeClient.Create(ctx, etcdMainSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, etcdEventsSecret)).To(Succeed())
 
-			r := &v1r11.Rule242426{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242426{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242427.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242427.go
@@ -6,7 +6,6 @@ package v1r11
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -22,9 +21,10 @@ import (
 var _ rule.Rule = &Rule242427{}
 
 type Rule242427 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client                client.Client
+	Namespace             string
+	StatefulSetETCDMain   string
+	StatefulSetETCDEvents string
 }
 
 func (r *Rule242427) ID() string {
@@ -37,9 +37,18 @@ func (r *Rule242427) Name() string {
 
 func (r *Rule242427) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
+	etcdMain := "etcd-main"
+	etcdEvents := "etcd-events"
 
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-main"))
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-events"))
+	if r.StatefulSetETCDMain != "" {
+		etcdMain = r.StatefulSetETCDMain
+	}
+
+	if r.StatefulSetETCDEvents != "" {
+		etcdEvents = r.StatefulSetETCDEvents
+	}
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdMain))
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdEvents))
 
 	return rule.RuleResult{
 		RuleID:       r.ID(),
@@ -56,7 +65,7 @@ func (r *Rule242427) checkStatefulSet(ctx context.Context, statefulSetName strin
 		},
 	}
 
-	target := rule.NewTarget("cluster", "seed", "name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
+	target := rule.NewTarget("name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
 
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet); err != nil {
 		return rule.ErroredCheckResult(err.Error(), target)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242427_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242427_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242427", func() {
@@ -30,7 +30,16 @@ client-transport-security:
 		ctsCertAuthSetTrueConfig = `
 client-transport-security:
   client-cert-auth: true`
+		ctsKeyFileNotSetConfig = `
+client-transport-security:`
+		ctsKeyFileSetConfig = `
+client-transport-security:
+  key-file: set`
+		ctsKeyFileSetEmptyConfig = `
+client-transport-security:
+  key-file: ""`
 	)
+
 	var (
 		fakeClient client.Client
 		ctx        = context.TODO()
@@ -38,8 +47,8 @@ client-transport-security:
 
 		etcdMainStatefulSet   *appsv1.StatefulSet
 		etcdEventsStatefulSet *appsv1.StatefulSet
-		targetEtcdMain        = rule.NewTarget("cluster", "seed", "name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
-		targetEtcdEvents      = rule.NewTarget("cluster", "seed", "name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdMain        = rule.NewTarget("name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdEvents      = rule.NewTarget("name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
 	)
 
 	BeforeEach(func() {
@@ -73,7 +82,7 @@ client-transport-security:
 	})
 
 	It("should return error check results when etcd-main and etcd-events are not found", func() {
-		r := &v1r11.Rule242427{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242427{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -104,7 +113,7 @@ client-transport-security:
 			Expect(fakeClient.Create(ctx, etcdMainSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, etcdEventsSecret)).To(Succeed())
 
-			r := &v1r11.Rule242427{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242427{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 
@@ -167,14 +176,3 @@ client-transport-security:
 			BeNil()),
 	)
 })
-
-const (
-	ctsKeyFileNotSetConfig = `
-client-transport-security:`
-	ctsKeyFileSetConfig = `
-client-transport-security:
-  key-file: set`
-	ctsKeyFileSetEmptyConfig = `
-client-transport-security:
-  key-file: ""`
-)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242429.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242429.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242429{}
 
 type Rule242429 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242429) ID() string {
@@ -33,13 +33,20 @@ func (r *Rule242429) Name() string {
 }
 
 func (r *Rule242429) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "etcd-cafile"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "etcd-cafile"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242429_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242429_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242429", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242429", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242429", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242429{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242429{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#242429", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242429{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242429{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242430.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242430.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242430{}
 
 type Rule242430 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242430) ID() string {
@@ -33,13 +33,20 @@ func (r *Rule242430) Name() string {
 }
 
 func (r *Rule242430) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "etcd-certfile"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "etcd-certfile"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242430_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242430_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242430", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242430", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242430", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242430{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242430{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#242430", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242430{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242430{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242431.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242431.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242431{}
 
 type Rule242431 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242431) ID() string {
@@ -33,13 +33,20 @@ func (r *Rule242431) Name() string {
 }
 
 func (r *Rule242431) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "etcd-keyfile"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "etcd-keyfile"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242431_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242431_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242431", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242431", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242431", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242431{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242431{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#242431", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242431{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242431{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242432.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242432.go
@@ -6,7 +6,6 @@ package v1r11
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -22,9 +21,10 @@ import (
 var _ rule.Rule = &Rule242432{}
 
 type Rule242432 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client                client.Client
+	Namespace             string
+	StatefulSetETCDMain   string
+	StatefulSetETCDEvents string
 }
 
 func (r *Rule242432) ID() string {
@@ -37,9 +37,18 @@ func (r *Rule242432) Name() string {
 
 func (r *Rule242432) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
+	etcdMain := "etcd-main"
+	etcdEvents := "etcd-events"
 
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-main"))
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-events"))
+	if r.StatefulSetETCDMain != "" {
+		etcdMain = r.StatefulSetETCDMain
+	}
+
+	if r.StatefulSetETCDEvents != "" {
+		etcdEvents = r.StatefulSetETCDEvents
+	}
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdMain))
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdEvents))
 
 	return rule.RuleResult{
 		RuleID:       r.ID(),
@@ -56,7 +65,7 @@ func (r *Rule242432) checkStatefulSet(ctx context.Context, statefulSetName strin
 		},
 	}
 
-	target := rule.NewTarget("cluster", "seed", "name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
+	target := rule.NewTarget("name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
 
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet); err != nil {
 		return rule.ErroredCheckResult(err.Error(), target)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242432_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242432_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242432", func() {
@@ -46,8 +46,8 @@ peer-transport-security:
 
 		etcdMainStatefulSet   *appsv1.StatefulSet
 		etcdEventsStatefulSet *appsv1.StatefulSet
-		targetEtcdMain        = rule.NewTarget("cluster", "seed", "name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
-		targetEtcdEvents      = rule.NewTarget("cluster", "seed", "name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdMain        = rule.NewTarget("name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdEvents      = rule.NewTarget("name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
 	)
 
 	BeforeEach(func() {
@@ -81,7 +81,7 @@ peer-transport-security:
 	})
 
 	It("should return error check results when etcd-main and etcd-events are not found", func() {
-		r := &v1r11.Rule242432{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242432{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,7 +112,7 @@ peer-transport-security:
 			Expect(fakeClient.Create(ctx, etcdMainSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, etcdEventsSecret)).To(Succeed())
 
-			r := &v1r11.Rule242432{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242432{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242433.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242433.go
@@ -6,7 +6,6 @@ package v1r11
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -22,9 +21,10 @@ import (
 var _ rule.Rule = &Rule242433{}
 
 type Rule242433 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client                client.Client
+	Namespace             string
+	StatefulSetETCDMain   string
+	StatefulSetETCDEvents string
 }
 
 func (r *Rule242433) ID() string {
@@ -37,9 +37,18 @@ func (r *Rule242433) Name() string {
 
 func (r *Rule242433) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
+	etcdMain := "etcd-main"
+	etcdEvents := "etcd-events"
 
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-main"))
-	checkResults = append(checkResults, r.checkStatefulSet(ctx, "etcd-events"))
+	if r.StatefulSetETCDMain != "" {
+		etcdMain = r.StatefulSetETCDMain
+	}
+
+	if r.StatefulSetETCDEvents != "" {
+		etcdEvents = r.StatefulSetETCDEvents
+	}
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdMain))
+	checkResults = append(checkResults, r.checkStatefulSet(ctx, etcdEvents))
 
 	return rule.RuleResult{
 		RuleID:       r.ID(),
@@ -56,7 +65,7 @@ func (r *Rule242433) checkStatefulSet(ctx context.Context, statefulSetName strin
 		},
 	}
 
-	target := rule.NewTarget("cluster", "seed", "name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
+	target := rule.NewTarget("name", statefulSetName, "namespace", r.Namespace, "kind", "statefulSet")
 
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet); err != nil {
 		return rule.ErroredCheckResult(err.Error(), target)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242433_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242433_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242433", func() {
@@ -46,8 +46,8 @@ peer-transport-security:
 
 		etcdMainStatefulSet   *appsv1.StatefulSet
 		etcdEventsStatefulSet *appsv1.StatefulSet
-		targetEtcdMain        = rule.NewTarget("cluster", "seed", "name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
-		targetEtcdEvents      = rule.NewTarget("cluster", "seed", "name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdMain        = rule.NewTarget("name", "etcd-main", "namespace", namespace, "kind", "statefulSet")
+		targetEtcdEvents      = rule.NewTarget("name", "etcd-events", "namespace", namespace, "kind", "statefulSet")
 	)
 
 	BeforeEach(func() {
@@ -81,7 +81,7 @@ peer-transport-security:
 	})
 
 	It("should return error check results when etcd-main and etcd-events are not found", func() {
-		r := &v1r11.Rule242433{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242433{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,7 +112,7 @@ peer-transport-security:
 			Expect(fakeClient.Create(ctx, etcdMainSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, etcdEventsSecret)).To(Succeed())
 
-			r := &v1r11.Rule242433{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242433{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242436_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242436_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242436", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242436", func() {
 		namespace  = "foo"
 
 		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target        = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242436", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242436{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242436{Client: fakeClient, Namespace: namespace}
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = Describe("#242436", func() {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242436{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242436{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242438.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242438.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242438{}
 
 type Rule242438 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242438) ID() string {
@@ -33,13 +33,20 @@ func (r *Rule242438) Name() string {
 }
 
 func (r *Rule242438) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "request-timeout"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "request-timeout"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242438_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242438_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242438", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242438", func() {
 		namespace  = "foo"
 
 		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target        = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242438", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242438{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242438{Client: fakeClient, Namespace: namespace}
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = Describe("#242438", func() {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242438{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242438{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242461.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242461.go
@@ -29,7 +29,7 @@ func (r *Rule242461) ID() string {
 }
 
 func (r *Rule242461) Name() string {
-	return "Kubernetes API Server audit logs must be enabled (MEDIUM 242461)"
+	return "The Kubernetes API Server audit logs must be enabled (MEDIUM 242461)"
 }
 
 func (r *Rule242461) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242461.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242461.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242461{}
 
 type Rule242461 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242461) ID() string {
@@ -33,13 +33,20 @@ func (r *Rule242461) Name() string {
 }
 
 func (r *Rule242461) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "audit-policy-file"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "audit-policy-file"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242461_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242461_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242461", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242461", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242461", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242461{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242461{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#242461", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242461{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242461{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242462.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242462.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strconv"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242462{}
 
 type Rule242462 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242462) ID() string {
@@ -33,13 +33,20 @@ func (r *Rule242462) Name() string {
 }
 
 func (r *Rule242462) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "audit-log-maxsize"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "audit-log-maxsize"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242462.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242462.go
@@ -29,7 +29,7 @@ func (r *Rule242462) ID() string {
 }
 
 func (r *Rule242462) Name() string {
-	return "Kubernetes API Server must be set to audit log max size (MEDIUM 242462)"
+	return "The Kubernetes API Server must be set to audit log max size (MEDIUM 242462)"
 }
 
 func (r *Rule242462) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242462_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242462_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242462", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242462", func() {
 		namespace  = "foo"
 
 		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target        = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242462", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242462{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242462{Client: fakeClient, Namespace: namespace}
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = Describe("#242462", func() {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242462{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242462{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242463_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242463_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242463", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242463", func() {
 		namespace  = "foo"
 
 		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target        = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242463", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242463{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242463{Client: fakeClient, Namespace: namespace}
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = Describe("#242463", func() {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242463{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242463{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242464.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242464.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strconv"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule242464{}
 
 type Rule242464 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule242464) ID() string {
@@ -29,17 +29,24 @@ func (r *Rule242464) ID() string {
 }
 
 func (r *Rule242464) Name() string {
-	return "Kubernetes API Server audit log retention must be set (MEDIUM 242464)"
+	return "The Kubernetes API Server audit log retention must be set (MEDIUM 242464)"
 }
 
 func (r *Rule242464) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		option   = "audit-log-maxage"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const option = "audit-log-maxage"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, option)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	optSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, option)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242464_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242464_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#242464", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#242464", func() {
 		namespace  = "foo"
 
 		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target        = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#242464", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule242464{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule242464{Client: fakeClient, Namespace: namespace}
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = Describe("#242464", func() {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
-			r := &v1r11.Rule242464{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule242464{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/245542.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/245542.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,9 +17,10 @@ import (
 var _ rule.Rule = &Rule245542{}
 
 type Rule245542 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule245542) ID() string {
@@ -32,13 +32,20 @@ func (r *Rule245542) Name() string {
 }
 
 func (r *Rule245542) Run(ctx context.Context) (rule.RuleResult, error) {
-	const (
-		kapiName = "kube-apiserver"
-		optName  = "basic-auth-file"
-	)
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	const optName = "basic-auth-file"
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	basicAuthFileOptionSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, optName)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	basicAuthFileOptionSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, optName)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/245542_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/245542_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#245542", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#245542", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#245542", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule245542{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule245542{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#245542", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule245542{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule245542{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/245543_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/245543_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#245543", func() {
@@ -39,7 +39,7 @@ bar,for,bar,`
 		namespace  = "foo"
 
 		kapiDeployment *appsv1.Deployment
-		target         = rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-apiserver", "namespace", namespace)
+		target         = rule.NewTarget("kind", "deployment", "name", "kube-apiserver", "namespace", namespace)
 		options        = v1r11.Options245543{
 			AcceptedTokens: []struct {
 				User   string `yaml:"user"`
@@ -95,7 +95,7 @@ bar,for,bar,`
 	})
 
 	It("should return error check results when kube-apiserver is not found", func() {
-		r := &v1r11.Rule245543{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule245543{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -118,7 +118,7 @@ bar,for,bar,`
 
 			Expect(fakeClient.Create(ctx, staticTokenSecret)).To(Succeed())
 
-			r := &v1r11.Rule245543{Logger: testLogger, Client: fakeClient, Namespace: namespace, Options: options}
+			r := &v1r11.Rule245543{Client: fakeClient, Namespace: namespace, Options: options}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/245544.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/245544.go
@@ -7,7 +7,6 @@ package v1r11
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,9 +18,10 @@ import (
 var _ rule.Rule = &Rule245544{}
 
 type Rule245544 struct {
-	Client    client.Client
-	Namespace string
-	Logger    *slog.Logger
+	Client         client.Client
+	Namespace      string
+	DeploymentName string
+	ContainerName  string
 }
 
 func (r *Rule245544) ID() string {
@@ -34,14 +34,23 @@ func (r *Rule245544) Name() string {
 
 func (r *Rule245544) Run(ctx context.Context) (rule.RuleResult, error) {
 	const (
-		kapiName    = "kube-apiserver"
 		certOptName = "kubelet-client-certificate"
 		keyOptName  = "kubelet-client-key"
 	)
-	checkResults := []rule.CheckResult{}
-	target := rule.NewTarget("cluster", "seed", "name", kapiName, "namespace", r.Namespace, "kind", "deployment")
+	deploymentName := "kube-apiserver"
+	containerName := "kube-apiserver"
 
-	kubeletClientCertificateOptionSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, certOptName)
+	if r.DeploymentName != "" {
+		deploymentName = r.DeploymentName
+	}
+
+	if r.ContainerName != "" {
+		containerName = r.ContainerName
+	}
+	checkResults := []rule.CheckResult{}
+	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+
+	kubeletClientCertificateOptionSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, certOptName)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}
@@ -57,7 +66,7 @@ func (r *Rule245544) Run(ctx context.Context) (rule.RuleResult, error) {
 		checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s set.", certOptName), target))
 	}
 
-	kubeletClientKeyOptionSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, kapiName, kapiName, r.Namespace, keyOptName)
+	kubeletClientKeyOptionSlice, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, keyOptName)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), target)), nil
 	}

--- a/pkg/shared/ruleset/disak8sstig/v1r11/245544_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/245544_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#245544", func() {
@@ -27,7 +27,7 @@ var _ = Describe("#245544", func() {
 		namespace  = "foo"
 
 		ksDeployment *appsv1.Deployment
-		target       = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		target       = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("#245544", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule245544{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule245544{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("#245544", func() {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
 
-			r := &v1r11.Rule245544{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+			r := &v1r11.Rule245544{Client: fakeClient, Namespace: namespace}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/254800_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/254800_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
 var _ = Describe("#254800", func() {
@@ -30,9 +30,9 @@ var _ = Describe("#254800", func() {
 		configMapData     = "configMapData"
 		deployment        *appsv1.Deployment
 		configMap         *corev1.ConfigMap
-		deployTarget      = rule.NewTarget("cluster", "seed", "name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
-		podSecurityTarget = rule.NewTarget("cluster", "shoot", "kind", "PodSecurityConfiguration")
-		genericTarget     = rule.NewTarget("cluster", "shoot")
+		deployTarget      = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		podSecurityTarget = rule.NewTarget("kind", "PodSecurityConfiguration")
+		genericTarget     = rule.NewTarget()
 	)
 
 	BeforeEach(func() {
@@ -86,7 +86,7 @@ var _ = Describe("#254800", func() {
 	})
 
 	It("should error when kube-apiserver is not found", func() {
-		r := &v1r11.Rule254800{Logger: testLogger, Client: fakeClient, Namespace: namespace}
+		r := &v1r11.Rule254800{Client: fakeClient, Namespace: namespace}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -108,7 +108,7 @@ var _ = Describe("#254800", func() {
 			configMap.Data = configMapData
 			Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
 
-			r := &v1r11.Rule254800{Logger: testLogger, Client: fakeClient, Namespace: namespace, Options: options}
+			r := &v1r11.Rule254800{Client: fakeClient, Namespace: namespace, Options: options}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of #68 Some of the rules are skipped with `NotImplemented` status. This is primary because we want to refactor these rules and separate them from the `node-files` and `pod-files` combined rules which right now are not reusable across providers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
