### PR TITLE
Add MatchFileOwnersCases() to internal utils

### DIFF
--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -157,7 +157,39 @@ func ExceedFilePermissions(filePermissions, filePermissionsMax string) (bool, er
 	return fileModePermission&^fileModePermissionsMax != 0, nil
 }
 
-// MatchFilePermissionsAndOwnersCases returns []rule.CheckResult for a given file and its permissions and owners  for a select expected values.
+// MatchFileOwnersCases returns []rule.CheckResult for a given file and its owners for a select expected values.
+func MatchFileOwnersCases(
+	fileOwnerUser,
+	fileOwnerGroup,
+	fileName string,
+	expectedFileOwnerUsers,
+	expectedFileOwnerGroups []string,
+	target rule.Target,
+) []rule.CheckResult {
+	checkResults := []rule.CheckResult{}
+	if len(expectedFileOwnerUsers) > 0 {
+		if !slices.Contains(expectedFileOwnerUsers, fileOwnerUser) {
+			detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerUser: %s, expectedOwnerUsers: %v", fileName, fileOwnerUser, expectedFileOwnerUsers))
+			checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner user", detailedTarget))
+		}
+	}
+
+	if len(expectedFileOwnerGroups) > 0 {
+		if !slices.Contains(expectedFileOwnerGroups, fileOwnerGroup) {
+			detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerGroup: %s, expectedOwnerGroups: %v", fileName, fileOwnerGroup, expectedFileOwnerGroups))
+			checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner group", detailedTarget))
+		}
+	}
+
+	if len(checkResults) == 0 {
+		detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerUser: %s, ownerGroup: %s", fileName, fileOwnerUser, fileOwnerGroup))
+		checkResults = append(checkResults, rule.PassedCheckResult("File has expected owners", detailedTarget))
+	}
+
+	return checkResults
+}
+
+// MatchFilePermissionsAndOwnersCases returns []rule.CheckResult for a given file and its permissions and owners for a select expected values.
 func MatchFilePermissionsAndOwnersCases(
 	filePermissions,
 	fileOwnerUser,

--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -167,18 +167,15 @@ func MatchFileOwnersCases(
 	target rule.Target,
 ) []rule.CheckResult {
 	checkResults := []rule.CheckResult{}
-	if len(expectedFileOwnerUsers) > 0 {
-		if !slices.Contains(expectedFileOwnerUsers, fileOwnerUser) {
-			detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerUser: %s, expectedOwnerUsers: %v", fileName, fileOwnerUser, expectedFileOwnerUsers))
-			checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner user", detailedTarget))
-		}
+
+	if !slices.Contains(expectedFileOwnerUsers, fileOwnerUser) {
+		detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerUser: %s, expectedOwnerUsers: %v", fileName, fileOwnerUser, expectedFileOwnerUsers))
+		checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner user", detailedTarget))
 	}
 
-	if len(expectedFileOwnerGroups) > 0 {
-		if !slices.Contains(expectedFileOwnerGroups, fileOwnerGroup) {
-			detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerGroup: %s, expectedOwnerGroups: %v", fileName, fileOwnerGroup, expectedFileOwnerGroups))
-			checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner group", detailedTarget))
-		}
+	if !slices.Contains(expectedFileOwnerGroups, fileOwnerGroup) {
+		detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerGroup: %s, expectedOwnerGroups: %v", fileName, fileOwnerGroup, expectedFileOwnerGroups))
+		checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner group", detailedTarget))
 	}
 
 	if len(checkResults) == 0 {

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -441,10 +441,11 @@ var _ = Describe("utils", func() {
 					rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 1000, expectedOwnerUsers: [0]")),
 					rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerGroup: 2000, expectedOwnerGroups: [0 1000]")),
 				}),
-			Entry("should return passed when expected owners are empty",
+			Entry("should return failed when expected owners are empty",
 				"1000", "2000", "/foo/bar/file.txt", []string{}, []string{}, target,
 				[]rule.CheckResult{
-					rule.PassedCheckResult("File has expected owners", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 1000, ownerGroup: 2000")),
+					rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 1000, expectedOwnerUsers: []")),
+					rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerGroup: 2000, expectedOwnerGroups: []")),
 				}),
 		)
 	})

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -419,6 +419,36 @@ var _ = Describe("utils", func() {
 			"0406", "0644", true, BeNil()),
 	)
 
+	Describe("#MatchFileOwnersCases", func() {
+		var (
+			target = rule.NewTarget()
+		)
+		DescribeTable("#MatchCases",
+			func(fileOwnerUser, fileOwnerGroup, fileName string, expectedFileOwnerUsers, expectedFileOwnerGroups []string, target rule.Target, expectedResults []rule.CheckResult) {
+				result := utils.MatchFileOwnersCases(fileOwnerUser, fileOwnerGroup, fileName, expectedFileOwnerUsers, expectedFileOwnerGroups, target)
+
+				Expect(result).To(Equal(expectedResults))
+			},
+			Entry("should return passed when all checks pass",
+				"0", "2000", "/foo/bar/file.txt", []string{"0"}, []string{"0", "2000"}, target,
+				[]rule.CheckResult{
+					rule.PassedCheckResult("File has expected owners", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 0, ownerGroup: 2000")),
+				}),
+			Entry("should return failed results when all checks fail",
+				"1000", "2000", "/foo/bar/file.txt", []string{"0"}, []string{"0", "1000"}, target,
+				[]rule.CheckResult{
+
+					rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 1000, expectedOwnerUsers: [0]")),
+					rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerGroup: 2000, expectedOwnerGroups: [0 1000]")),
+				}),
+			Entry("should return passed when expected owners are empty",
+				"1000", "2000", "/foo/bar/file.txt", []string{}, []string{}, target,
+				[]rule.CheckResult{
+					rule.PassedCheckResult("File has expected owners", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 1000, ownerGroup: 2000")),
+				}),
+		)
+	})
+
 	Describe("#MatchFilePermissionsAndOwnersCases", func() {
 		var (
 			target = rule.NewTarget()


### PR DESCRIPTION
**What this PR does / why we need it**:
Added new `MatchFileOwnersCases()` function to internal utils that will be used to check file owners in the new split rules from `node-files` and `pod-files`. The old `MatchFilePermissionsAndOwnersCases` will not be used in the new rules and will be removed with the removal of the `node-file` and `pod-file` rules.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
