### PR TITLE
Create custom diki-ops image definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -20,6 +20,11 @@ diki:
             image: 'eu.gcr.io/gardener-project/gardener/diki'
             dockerfile: 'Dockerfile'
             target: diki
+          diki-pod:
+            registry: 'gcr-readwrite'
+            image: 'eu.gcr.io/gardener-project/gardener/diki-pod'
+            dockerfile: 'Dockerfile'
+            target: diki-pod
   jobs:
     head-update:
       traits:
@@ -51,4 +56,6 @@ diki:
         publish:
           dockerimages:
             diki:
+              tag_as_latest: true
+            diki-pod:
               tag_as_latest: true

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -20,11 +20,11 @@ diki:
             image: 'eu.gcr.io/gardener-project/gardener/diki'
             dockerfile: 'Dockerfile'
             target: diki
-          diki-pod:
+          diki-ops:
             registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/diki-pod'
+            image: 'eu.gcr.io/gardener-project/gardener/diki-ops'
             dockerfile: 'Dockerfile'
-            target: diki-pod
+            target: diki-ops
   jobs:
     head-update:
       traits:
@@ -57,5 +57,5 @@ diki:
           dockerimages:
             diki:
               tag_as_latest: true
-            diki-pod:
+            diki-ops:
               tag_as_latest: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=builder /workspace/diki .
 
 ENTRYPOINT ["/diki"]
 
-FROM alpine AS diki-ops
+FROM alpine:3.19.0 AS diki-ops
 RUN apk --no-cache add curl &&\
     curl -sLf https://github.com/containerd/nerdctl/releases/download/v1.6.0/nerdctl-1.6.0-linux-amd64.tar.gz -o /nerdctl.tar.gz &&\
     tar -C /usr/local/bin -xzvf nerdctl.tar.gz &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -ldflags="$(/workspace/hack/get-build-ld-flags.sh)" -o diki cmd/diki/main.go
 
-FROM gcr.io/distroless/static-debian11:nonroot AS diki
+FROM gcr.io/distroless/static-debian12:nonroot AS diki
 WORKDIR /
 COPY --from=builder /workspace/diki .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=builder /workspace/diki .
 
 ENTRYPOINT ["/diki"]
 
-FROM alpine AS diki-pod
+FROM alpine AS diki-ops
 RUN apk --no-cache add curl &&\
     curl -sLf https://github.com/containerd/nerdctl/releases/download/v1.6.0/nerdctl-1.6.0-linux-amd64.tar.gz -o /nerdctl.tar.gz &&\
     tar -C /usr/local/bin -xzvf nerdctl.tar.gz &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,11 @@ COPY --from=builder /workspace/diki .
 ENTRYPOINT ["/diki"]
 
 FROM alpine:3.19.0 AS diki-ops
+
+ARG TARGETARCH
+
 RUN apk --no-cache add curl &&\
-    curl -sLf https://github.com/containerd/nerdctl/releases/download/v1.6.0/nerdctl-1.6.0-linux-amd64.tar.gz -o /nerdctl.tar.gz &&\
+    curl -sLf https://github.com/containerd/nerdctl/releases/download/v1.7.2/nerdctl-1.7.2-linux-${TARGETARCH}.tar.gz -o /nerdctl.tar.gz &&\
     tar -C /usr/local/bin -xzvf nerdctl.tar.gz &&\
     rm -f nerdctl.tar.gz &&\
     mkdir /etc/nerdctl &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,12 @@ WORKDIR /
 COPY --from=builder /workspace/diki .
 
 ENTRYPOINT ["/diki"]
+
+FROM alpine AS diki-pod
+RUN apk --no-cache add curl &&\
+    curl -sLf https://github.com/containerd/nerdctl/releases/download/v1.6.0/nerdctl-1.6.0-linux-amd64.tar.gz -o /nerdctl.tar.gz &&\
+    tar -C /usr/local/bin -xzvf nerdctl.tar.gz &&\
+    rm -f nerdctl.tar.gz &&\
+    mkdir /etc/nerdctl &&\
+    echo address = "\"unix:///host/run/containerd/containerd.sock\"" >> /etc/nerdctl/nerdctl.toml &&\
+    echo namespace = "\"k8s.io\"" >> /etc/nerdctl/nerdctl.toml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `diki-ops` image to be used for diki pods and adds it to the pipeline definition file. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Upgraded diki base image: gcr.io/distroless/static-debian11 -> gcr.io/distroless/static-debian12
```
