### PR TITLE
[DISA K8s STIG] Fix typo in pod-files rule

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
@@ -321,7 +321,7 @@ func (r *RulePodFiles) checkContainerd(
 
 				if isMandatoryComponent && strings.HasSuffix(strings.Join(statSlice[3:], " "), ".key") {
 					// rule 242467
-					// Gardener control plane components run as `nonroot` user `65532`, since we can change the group owener but
+					// Gardener control plane components run as `nonroot` user `65532`, since we can change the group owner but
 					// cannot easily change the user owner of secret files we do not check for `0600` permission but instead for `0640`.
 					checkResults = append(checkResults, utils.MatchFilePermissionsAndOwnersCases(statSlice[0], statSlice[1], statSlice[2], strings.Join(statSlice[3:], " "),
 						"640", expectedFileOwnerUsers, expectedFileOwnerGroups, fileTarget)...)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a typo in pod-files rule

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
