### PR TITLE
Add GetPodMountedFileStatResults utils func

### DIFF
--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/gardener/diki/pkg/kubernetes/config"
+	"github.com/gardener/diki/pkg/kubernetes/pod"
+)
+
+// FileStats contains single file stats
+type FileStats struct {
+	Path                  string
+	Permissions           string
+	UserOwner, GroupOwner string
+	FileType              string
+	ContainerName         string
+}
+
+// NewFileStats creates a new FileStats object from the result of
+// stat command called with `-c "%a %u %g %F %n"` flag and value
+func NewFileStats(stats, pathUsedToFindFile, containerName string) (*FileStats, error) {
+	statsSlice := strings.Split(stats, " ")
+
+	if len(statsSlice) < 5 {
+		return &FileStats{}, fmt.Errorf("stats: %s, not in correct format: '${permissions} ${userOwner} ${groupOwner} ${fileType} ${filePath}'", stats)
+	}
+
+	fileType := statsSlice[3]
+	var filePath string
+
+	// the file type %F can have " " characters. Ex: "regular file"
+	for i := 4; i < len(statsSlice); i++ {
+		if strings.HasPrefix(statsSlice[i], pathUsedToFindFile) {
+			filePath = strings.Join(statsSlice[i:], " ")
+			break
+		}
+		fileType = fmt.Sprintf("%s %s", fileType, statsSlice[i])
+	}
+
+	if len(filePath) == 0 {
+		return &FileStats{}, fmt.Errorf("stats: %s, not in correct format: '${permissions} ${userOwner} ${groupOwner} ${fileType} ${filePath}'", stats)
+	}
+
+	fileStats := &FileStats{
+		Path:          filePath,
+		Permissions:   statsSlice[0],
+		UserOwner:     statsSlice[1],
+		GroupOwner:    statsSlice[2],
+		FileType:      fileType,
+		ContainerName: containerName,
+	}
+
+	return fileStats, nil
+}
+
+// Name returns the base name of the file
+func (fs *FileStats) Name() string {
+	return filepath.Base(fs.Path)
+}
+
+// Dir returns the dir of the file
+func (fs *FileStats) Dir() string {
+	return filepath.Dir(fs.Path)
+}
+
+// GetPodMountedFileStatResults returns a string containing the stat results of all
+// mounted files of a podwith the exception of file mounted at `/dev/termination-log`
+func GetPodMountedFileStatResults(
+	ctx context.Context,
+	podExecutor pod.PodExecutor,
+	pod corev1.Pod,
+	execContainerPath string,
+	excludedSources []string,
+) ([]FileStats, error) {
+	stats := []FileStats{}
+	var err error
+
+	for _, container := range pod.Spec.Containers {
+		containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+			return containerStatus.Name == container.Name
+		})
+
+		if containerStatusIdx < 0 {
+			err = errors.Join(err, fmt.Errorf("container with Name %s not (yet) in status", container.Name))
+			continue
+		}
+
+		containerID := pod.Status.ContainerStatuses[containerStatusIdx].ContainerID
+		switch {
+		case len(containerID) == 0:
+			err = errors.Join(err, fmt.Errorf("container with Name %s not (yet) running", container.Name))
+		case strings.HasPrefix(containerID, "containerd://"):
+			baseContainerID := strings.Split(containerID, "//")[1]
+			containerStats, err2 := getContainerMountedFileStatResults(ctx,
+				podExecutor,
+				pod,
+				container.Name,
+				baseContainerID,
+				execContainerPath,
+				excludedSources,
+			)
+			if err2 != nil {
+				err = errors.Join(err, err2)
+			}
+
+			stats = append(stats, containerStats...)
+		default:
+			err = errors.Join(err, fmt.Errorf("cannot handle container with Name %s", container.Name))
+		}
+	}
+	return stats, err
+}
+
+func getContainerMountedFileStatResults(
+	ctx context.Context,
+	podExecutor pod.PodExecutor,
+	pod corev1.Pod,
+	containerName, containerID, execContainerPath string,
+	excludedSources []string,
+) ([]FileStats, error) {
+	stats := []FileStats{}
+	var err error
+
+	commandResult, err := podExecutor.Execute(ctx, "/bin/sh", fmt.Sprintf(`%s/usr/local/bin/nerdctl --namespace k8s.io inspect --mode=native %s | jq -r .[0].Spec.mounts`, execContainerPath, containerID))
+	if err != nil {
+		return stats, err
+	}
+
+	mounts := []config.Mount{}
+	err = json.Unmarshal([]byte(commandResult), &mounts)
+	if err != nil {
+		return stats, err
+	}
+	excludedSourcesSet := sets.New(excludedSources...)
+
+	for _, mount := range mounts {
+		if strings.HasPrefix(mount.Source, "/") &&
+			!matchHostPathSources(excludedSourcesSet, mount.Destination, containerName, &pod) &&
+			isMountRequiredByContainer(mount.Destination, containerName, &pod) &&
+			mount.Destination != "/dev/termination-log" {
+			mountStats, err2 := podExecutor.Execute(ctx, "/bin/sh", fmt.Sprintf(`find %s -type f -exec stat -Lc "%%a %%u %%g %%F %%n" {} \;`, mount.Source))
+
+			if err2 != nil {
+				err = errors.Join(err, err2)
+				continue
+			}
+
+			mountStatsSlice := strings.Split(strings.TrimSpace(mountStats), "\n")
+			for _, mountStats := range mountStatsSlice {
+				mountStatsFile, err2 := NewFileStats(mountStats, mount.Source, containerName)
+				if err2 != nil {
+					err = errors.Join(err, err2)
+					continue
+				}
+
+				stats = append(stats, *mountStatsFile)
+			}
+
+		}
+	}
+	return stats, err
+}
+
+func isMountRequiredByContainer(destination, containerName string, pod *corev1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+		if containsDestination := slices.ContainsFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+			return volumeMount.MountPath == destination
+		}); containsDestination {
+			return true
+		}
+	}
+	return false
+}
+
+func matchHostPathSources(sources sets.Set[string], destination, containerName string, pod *corev1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+		volumeMountIdx := slices.IndexFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+			return volumeMount.MountPath == destination
+		})
+
+		if volumeMountIdx < 0 {
+			return false
+		}
+
+		volumeIdx := slices.IndexFunc(pod.Spec.Volumes, func(volume corev1.Volume) bool {
+			return volume.Name == container.VolumeMounts[volumeMountIdx].Name
+		})
+
+		if volumeIdx < 0 {
+			return false
+		}
+
+		volume := pod.Spec.Volumes[volumeIdx]
+
+		return volume.HostPath != nil && sources.Has(volume.HostPath.Path)
+	}
+	return false
+}

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/diki/pkg/internal/utils"
+	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
+)
+
+var _ = Describe("utils", func() {
+	Describe("#NewFileStats", func() {
+
+		DescribeTable("#MatchCases",
+			func(stats, pathUsedToFindFile, containerName string, expectedFileStats *utils.FileStats, errorMatcher gomegatypes.GomegaMatcher) {
+				result, err := utils.NewFileStats(stats, pathUsedToFindFile, containerName)
+
+				Expect(err).To(errorMatcher)
+				Expect(result).To(Equal(expectedFileStats))
+			},
+			Entry("Should return correct FileStats object",
+				"600 0 1000 regular file /destination/file 1.txt", "/destination", "test",
+				&utils.FileStats{Path: "/destination/file 1.txt", Permissions: "600", UserOwner: "0", GroupOwner: "1000", FileType: "regular file", ContainerName: "test"}, BeNil()),
+			Entry("Should return error when stats are not full",
+				"600 0 1000 /destination/file1.txt", "/destination", "test",
+				&utils.FileStats{}, MatchError("stats: 600 0 1000 /destination/file1.txt, not in correct format: '${permissions} ${userOwner} ${groupOwner} ${fileType} ${filePath}'")),
+			Entry("Should return error when file path is not found",
+				"600 0 1000 regular file /destination/file 1.txt", "/foo", "test",
+				&utils.FileStats{}, MatchError("stats: 600 0 1000 regular file /destination/file 1.txt, not in correct format: '${permissions} ${userOwner} ${groupOwner} ${fileType} ${filePath}'")),
+		)
+	})
+	Describe("#GetPodMountedFileStatResults", func() {
+		const (
+			mounts = `[
+  {
+    "destination": "/destination",
+    "source": "/destination"
+  }, 
+  {
+    "destination": "/foo",
+    "source": "/foo"
+  },
+  {
+    "destination": "/bar",
+    "source": "/source"
+  }
+]`
+			destinationStats = "600 0 0 regular file /destination/file1.txt\n"
+			fooStats         = "644 0 65532 regular file /foo/file2.txt\n"
+		)
+		var (
+			fakePodExecutor      *fakepod.FakePodExecutor
+			destinationFileStats *utils.FileStats
+			fooFileStats         *utils.FileStats
+			ctx                  context.Context
+			pod                  corev1.Pod
+		)
+		BeforeEach(func() {
+			destinationFileStats = &utils.FileStats{
+				Path:          "/destination/file1.txt",
+				Permissions:   "600",
+				UserOwner:     "0",
+				GroupOwner:    "0",
+				FileType:      "regular file",
+				ContainerName: "test",
+			}
+			fooFileStats = &utils.FileStats{
+				Path:          "/foo/file2.txt",
+				Permissions:   "644",
+				UserOwner:     "0",
+				GroupOwner:    "65532",
+				FileType:      "regular file",
+				ContainerName: "test",
+			}
+			pod = corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: "/destination",
+								},
+								{
+									Name:      "bar",
+									MountPath: "/bar",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "bar",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/lib/modules",
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:        "test",
+							ContainerID: "containerd://bar",
+						},
+					},
+				},
+			}
+
+			ctx = context.TODO()
+		})
+
+		It("Should return correct single stats", func() {
+			executeReturnString := []string{mounts, destinationStats}
+			executeReturnError := []error{nil, nil}
+			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
+			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal([]utils.FileStats{*destinationFileStats}))
+		})
+
+		It("Should return correct multiple stats", func() {
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+				MountPath: "/foo",
+			})
+			executeReturnString := []string{mounts, destinationStats, fooStats}
+			executeReturnError := []error{nil, nil, nil}
+			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
+			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal([]utils.FileStats{*destinationFileStats, *fooFileStats}))
+		})
+
+		It("Should error when there are problems with container", func() {
+			pod.Spec.Containers = []corev1.Container{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+				{
+					Name: "baz",
+				},
+			}
+			pod.Status = corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:        "bar",
+						ContainerID: "",
+					},
+					{
+						Name:        "baz",
+						ContainerID: "fake",
+					},
+				},
+			}
+			executeReturnString := []string{}
+			executeReturnError := []error{}
+			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
+			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+
+			Expect(err).To(MatchError("container with Name foo not (yet) in status\ncontainer with Name bar not (yet) running\ncannot handle container with Name baz"))
+			Expect(result).To(Equal([]utils.FileStats{}))
+		})
+
+		It("Should error when first command errors", func() {
+			executeReturnString := []string{mounts}
+			executeReturnError := []error{errors.New("command error")}
+			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
+			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+
+			Expect(err).To(MatchError("command error"))
+			Expect(result).To(Equal([]utils.FileStats{}))
+		})
+
+		It("Should return stats when a command errors", func() {
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+				MountPath: "/foo",
+			})
+			executeReturnString := []string{mounts, destinationStats, fooStats}
+			executeReturnError := []error{nil, errors.New("command error"), nil}
+			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
+			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+
+			Expect(err).To(MatchError("command error"))
+			Expect(result).To(Equal([]utils.FileStats{*fooFileStats}))
+		})
+	})
+})

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -124,7 +124,7 @@ var _ = Describe("utils", func() {
 			executeReturnString := []string{mounts, destinationStats}
 			executeReturnError := []error{nil, nil}
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
-			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats}}))
@@ -137,7 +137,7 @@ var _ = Describe("utils", func() {
 			executeReturnString := []string{mounts, destinationStats, fooStats}
 			executeReturnError := []error{nil, nil, nil}
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
-			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats, fooFileStats}}))
@@ -170,7 +170,7 @@ var _ = Describe("utils", func() {
 			executeReturnString := []string{}
 			executeReturnError := []error{}
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
-			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
 			Expect(err).To(MatchError("container with Name foo not (yet) in status\ncontainer with Name bar not (yet) running\ncannot handle container with Name baz"))
 			Expect(result).To(Equal(map[string][]utils.FileStats{}))
@@ -180,7 +180,7 @@ var _ = Describe("utils", func() {
 			executeReturnString := []string{mounts}
 			executeReturnError := []error{errors.New("command error")}
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
-			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
 			Expect(err).To(MatchError("command error"))
 			Expect(result).To(Equal(map[string][]utils.FileStats{}))
@@ -193,7 +193,7 @@ var _ = Describe("utils", func() {
 			executeReturnString := []string{mounts, destinationStats, fooStats}
 			executeReturnError := []error{nil, errors.New("command error"), nil}
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
-			result, err := utils.GetPodMountedFileStatResults(ctx, fakePodExecutor, pod, "", []string{"/lib/modules"})
+			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
 			Expect(err).To(MatchError("command error"))
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {fooFileStats}}))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `GetPodMountedFileStatResults()` to be used in the split `pod-files` DISA K8s STIGs rules.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
