### PR TITLE
[DISA K8s STIG] Use diki-ops image for pod executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,41 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-REPO_ROOT := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+NAME              := diki
+NAME_OPS          := diki-ops
+REGISTRY          := europe-docker.pkg.dev/gardener-project/releases/gardener
+REPO_ROOT         := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+HACK_DIR          := $(REPO_ROOT)/hack
+VERSION           := $(shell cat "$(REPO_ROOT)/VERSION")
+EFFECTIVE_VERSION := $(VERSION)-$(shell git rev-parse HEAD)
+GOARCH            ?= $(shell go env GOARCH)
 
 # TODO: remove this once g/g updates to this or newer version
 GOIMPORTSREVISER_VERSION = v3.4.0
+
+
+LD_FLAGS := "-w $(shell EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) bash $(HACK_DIR)/get-build-ld-flags.sh)"
 
 TOOLS_DIR := $(REPO_ROOT)/hack/tools
 include $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/tools.mk
 
 # additional tools
 include hack/tools.mk
+
+.PHONY: run
+run:
+	go run -ldflags $(LD_FLAGS) \
+	./cmd/diki run \
+	--config=$(CONFIG) \
+	--rule-id=$(RULE_ID) \
+	--provider=gardener \
+	--ruleset-id=disa-kubernetes-stig \
+	--ruleset-version=v1r11
+
+.PHONY: docker-images
+docker-images:
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --build-arg TARGETARCH=$(GOARCH) -t $(REGISTRY)/$(NAME):$(EFFECTIVE_VERSION) -t $(REGISTRY)/$(NAME):latest -f Dockerfile -m 6g --target $(NAME) .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --build-arg TARGETARCH=$(GOARCH) -t $(REGISTRY)/$(NAME_OPS):$(EFFECTIVE_VERSION) -t $(REGISTRY)/$(NAME_OPS):latest -f Dockerfile -m 6g --target $(NAME_OPS) .
 
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,24 @@ include $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/tools.mk
 # additional tools
 include hack/tools.mk
 
+# make run runs diki with flags specified by environment variables:
+# CONFIG - required - specifies the path to diki config file
+# RULE_ID - optional - if set diki executes only the specified rule
+# PROVIDER - optional - selects provider, defaults to "gardener"
+# RULESET_ID - optional - selects ruleset, defaults to "disa-kubernetes-stig"
+# RULESET_VERSION - optional - selects ruleset version, defaults to "v1r11"
+PROVIDER        ?= gardener
+RULESET_ID      ?= disa-kubernetes-stig
+RULESET_VERSION ?= v1r11
 .PHONY: run
 run:
 	go run -ldflags $(LD_FLAGS) \
 	./cmd/diki run \
 	--config=$(CONFIG) \
 	--rule-id=$(RULE_ID) \
-	--provider=gardener \
-	--ruleset-id=disa-kubernetes-stig \
-	--ruleset-version=v1r11
+	--provider=${PROVIDER} \
+	--ruleset-id=${RULESET_ID} \
+	--ruleset-version=${RULESET_VERSION}
 
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-NAME              := diki
-NAME_OPS          := diki-ops
-REGISTRY          := europe-docker.pkg.dev/gardener-project/releases/gardener
 REPO_ROOT         := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR          := $(REPO_ROOT)/hack
 VERSION           := $(shell cat "$(REPO_ROOT)/VERSION")
 EFFECTIVE_VERSION := $(VERSION)-$(shell git rev-parse HEAD)
-GOARCH            ?= $(shell go env GOARCH)
 
 # TODO: remove this once g/g updates to this or newer version
 GOIMPORTSREVISER_VERSION = v3.4.0
@@ -32,11 +28,6 @@ run:
 	--provider=gardener \
 	--ruleset-id=disa-kubernetes-stig \
 	--ruleset-version=v1r11
-
-.PHONY: docker-images
-docker-images:
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --build-arg TARGETARCH=$(GOARCH) -t $(REGISTRY)/$(NAME):$(EFFECTIVE_VERSION) -t $(REGISTRY)/$(NAME):latest -f Dockerfile -m 6g --target $(NAME) .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --build-arg TARGETARCH=$(GOARCH) -t $(REGISTRY)/$(NAME_OPS):$(EFFECTIVE_VERSION) -t $(REGISTRY)/$(NAME_OPS):latest -f Dockerfile -m 6g --target $(NAME_OPS) .
 
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -10,5 +10,4 @@ images:
   tag: "0.25.0"
 - name: diki-ops
   sourceRepository: github.com/gardener/diki
-  repository: eu.gcr.io/gardener-project/gardener/diki-ops
-  tag: "v0.3.0"
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/diki-ops

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -8,3 +8,7 @@ images:
   sourceRepository: github.com/gardener/ops-toolbelt
   repository: eu.gcr.io/gardener-project/gardener/ops-toolbelt
   tag: "0.25.0"
+- name: diki-ops
+  sourceRepository: github.com/gardener/diki
+  repository: eu.gcr.io/gardener-project/gardener/diki-ops
+  tag: "v0.3.0"

--- a/pkg/provider/gardener/ruleset/constants.go
+++ b/pkg/provider/gardener/ruleset/constants.go
@@ -7,4 +7,6 @@ package ruleset
 const (
 	// OpsToolbeltImageName is a constant for the name of the github.com/gardener/ops-toolbelt image.
 	OpsToolbeltImageName = "ops-toolbelt"
+	// DikiOpsImageName is a constant for the name of the github.com/gardener/diki diki-ops image.
+	DikiOpsImageName = "diki-ops"
 )

--- a/pkg/provider/gardener/ruleset/constants.go
+++ b/pkg/provider/gardener/ruleset/constants.go
@@ -7,6 +7,4 @@ package ruleset
 const (
 	// OpsToolbeltImageName is a constant for the name of the github.com/gardener/ops-toolbelt image.
 	OpsToolbeltImageName = "ops-toolbelt"
-	// DikiOpsImageName is a constant for the name of the github.com/gardener/diki diki-ops image.
-	DikiOpsImageName = "diki-ops"
 )

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
@@ -61,9 +61,9 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
@@ -67,7 +67,7 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
@@ -14,6 +14,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -64,6 +65,12 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242387.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242387{}
@@ -62,9 +62,9 @@ func (r *Rule242387) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -63,6 +64,12 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
@@ -66,7 +66,7 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
@@ -20,8 +20,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242391{}
@@ -61,9 +61,9 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242391.go
@@ -60,9 +60,9 @@ func (r *Rule242391) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
@@ -60,9 +60,9 @@ func (r *Rule242392) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	checkResults := []rule.CheckResult{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -63,6 +64,12 @@ func (r *Rule242392) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	checkResults := []rule.CheckResult{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
@@ -20,8 +20,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242392{}
@@ -61,9 +61,9 @@ func (r *Rule242392) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242392.go
@@ -66,7 +66,7 @@ func (r *Rule242392) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"k8s.io/component-base/version"
 )
 
 var _ rule.Rule = &Rule242393{}
@@ -38,6 +39,12 @@ func (r *Rule242393) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	defer func() {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
@@ -10,11 +10,12 @@ import (
 	"log/slog"
 	"strings"
 
+	"k8s.io/component-base/version"
+
 	"github.com/gardener/diki/imagevector"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
-	"k8s.io/component-base/version"
 )
 
 var _ rule.Rule = &Rule242393{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
@@ -42,7 +42,7 @@ func (r *Rule242393) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/gardener/diki/imagevector"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242393{}
@@ -37,9 +37,9 @@ func (r *Rule242393) Name() string {
 func (r *Rule242393) Run(ctx context.Context) (rule.RuleResult, error) {
 	target := rule.NewTarget("cluster", "shoot")
 	podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242393.go
@@ -35,9 +35,9 @@ func (r *Rule242393) Name() string {
 func (r *Rule242393) Run(ctx context.Context) (rule.RuleResult, error) {
 	target := rule.NewTarget("cluster", "shoot")
 	podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	defer func() {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"k8s.io/component-base/version"
 )
 
 var _ rule.Rule = &Rule242394{}
@@ -38,6 +39,12 @@ func (r *Rule242394) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	defer func() {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
@@ -42,7 +42,7 @@ func (r *Rule242394) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
@@ -35,9 +35,9 @@ func (r *Rule242394) Name() string {
 func (r *Rule242394) Run(ctx context.Context) (rule.RuleResult, error) {
 	target := rule.NewTarget("cluster", "shoot")
 	podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	defer func() {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/gardener/diki/imagevector"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242394{}
@@ -37,9 +37,9 @@ func (r *Rule242394) Name() string {
 func (r *Rule242394) Run(ctx context.Context) (rule.RuleResult, error) {
 	target := rule.NewTarget("cluster", "shoot")
 	podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242394.go
@@ -10,11 +10,12 @@ import (
 	"log/slog"
 	"strings"
 
+	"k8s.io/component-base/version"
+
 	"github.com/gardener/diki/imagevector"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
-	"k8s.io/component-base/version"
 )
 
 var _ rule.Rule = &Rule242394{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
@@ -59,9 +59,9 @@ func (r *Rule242397) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	checkResults := []rule.CheckResult{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
@@ -19,8 +19,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242397{}
@@ -60,9 +60,9 @@ func (r *Rule242397) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
@@ -65,7 +65,7 @@ func (r *Rule242397) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242397.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -62,6 +63,12 @@ func (r *Rule242397) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	checkResults := []rule.CheckResult{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242399{}
@@ -70,9 +70,9 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
@@ -69,9 +69,9 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
@@ -14,6 +14,7 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -72,6 +73,12 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242399.go
@@ -75,7 +75,7 @@ func (r *Rule242399) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
@@ -57,9 +57,9 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		err = fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		err = fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 		r.Logger.Error(err.Error())
 		return rule.RuleResult{}, err
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
@@ -63,7 +63,7 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
@@ -18,8 +18,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242404{}
@@ -58,9 +58,9 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242404.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -59,9 +60,13 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		err = fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
-		r.Logger.Error(err.Error())
-		return rule.RuleResult{}, err
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	checkResults := []rule.CheckResult{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
@@ -20,8 +20,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242420{}
@@ -61,9 +61,9 @@ func (r *Rule242420) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
@@ -66,7 +66,7 @@ func (r *Rule242420) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
@@ -60,9 +60,9 @@ func (r *Rule242420) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242420.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -63,6 +64,12 @@ func (r *Rule242420) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
@@ -67,7 +67,7 @@ func (r *Rule242424) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242424{}
@@ -62,9 +62,9 @@ func (r *Rule242424) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -64,6 +65,12 @@ func (r *Rule242424) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242424.go
@@ -61,9 +61,9 @@ func (r *Rule242424) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -64,6 +65,12 @@ func (r *Rule242425) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
@@ -61,9 +61,9 @@ func (r *Rule242425) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
@@ -67,7 +67,7 @@ func (r *Rule242425) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242425.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242425{}
@@ -62,9 +62,9 @@ func (r *Rule242425) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -62,6 +63,12 @@ func (r *Rule242434) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
@@ -59,9 +59,9 @@ func (r *Rule242434) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
@@ -19,8 +19,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242434{}
@@ -60,9 +60,9 @@ func (r *Rule242434) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242434.go
@@ -65,7 +65,7 @@ func (r *Rule242434) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
@@ -20,8 +20,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule245541{}
@@ -61,9 +61,9 @@ func (r *Rule245541) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
@@ -60,9 +60,9 @@ func (r *Rule245541) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
@@ -66,7 +66,7 @@ func (r *Rule245541) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/245541.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -63,6 +64,12 @@ func (r *Rule245541) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
@@ -70,7 +70,7 @@ func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule254801{}
@@ -65,9 +65,9 @@ func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
@@ -14,6 +14,7 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -67,6 +68,12 @@ func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/254801.go
@@ -64,9 +64,9 @@ func (r *Rule254801) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("cluster", "seed", "kind", "workerList"))), nil
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	nodesAllocatablePodsNum := kubeutils.GetNodesAllocatablePodsNum(clusterPods, clusterNodes)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
@@ -53,7 +53,7 @@ func (r *RuleNodeFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
@@ -47,9 +47,9 @@ func (r *RuleNodeFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 	expectedFileOwnerUsers := []string{"0"}
 	expectedFileOwnerGroups := []string{"0", "65534"}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	clusterNodes, err := kubeutils.GetNodes(ctx, r.ClusterClient, 512)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -50,6 +51,12 @@ func (r *RuleNodeFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	clusterNodes, err := kubeutils.GetNodes(ctx, r.ClusterClient, 512)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
@@ -20,8 +20,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &RuleNodeFiles{}
@@ -48,9 +48,9 @@ func (r *RuleNodeFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 	expectedFileOwnerUsers := []string{"0"}
 	expectedFileOwnerGroups := []string{"0", "65534"}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -83,6 +84,12 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	seedTarget := rule.NewTarget("cluster", "seed")

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
@@ -27,8 +27,8 @@ import (
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
@@ -81,9 +81,9 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 		r.Options.ExpectedFileOwner.Groups = []string{"0"}
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
@@ -86,7 +86,7 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/pod_files_permissions_and_owner.go
@@ -80,9 +80,9 @@ func (r *RulePodFiles) Run(ctx context.Context) (rule.RuleResult, error) {
 		r.Options.ExpectedFileOwner.Groups = []string{"0"}
 	}
 
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
 	seedTarget := rule.NewTarget("cluster", "seed")

--- a/pkg/shared/images/images.go
+++ b/pkg/shared/images/images.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package images
+
+const (
+	// DikiOpsImageName is a constant for the name of the github.com/gardener/diki diki-ops image.
+	DikiOpsImageName = "diki-ops"
+)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
@@ -20,8 +20,8 @@ import (
 	dikiutils "github.com/gardener/diki/pkg/internal/utils"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
-	"github.com/gardener/diki/pkg/provider/gardener/ruleset"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/images"
 )
 
 var _ rule.Rule = &Rule242459{}
@@ -96,9 +96,9 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 	nodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allPods, nodes)
 	groupedPods, checks := kubeutils.SelectPodOfReferenceGroup(checkPods, nodesAllocatablePods, target)
 	checkResults = append(checkResults, checks...)
-	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
+	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 
 	// check if tag is not present and use diki's version as a default

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
@@ -101,7 +101,7 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
 	}
 
-	// check if tag is not present and use the controller's version if that is the case
+	// check if tag is not present and use diki's version as a default
 	if image.Tag == nil {
 		tag := version.Get().GitVersion
 		image.Tag = &tag

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -95,9 +96,15 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 	nodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allPods, nodes)
 	groupedPods, checks := kubeutils.SelectPodOfReferenceGroup(checkPods, nodesAllocatablePods, target)
 	checkResults = append(checkResults, checks...)
-	image, err := imagevector.ImageVector().FindImage(ruleset.OpsToolbeltImageName)
+	image, err := imagevector.ImageVector().FindImage(ruleset.DikiOpsImageName)
 	if err != nil {
-		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.OpsToolbeltImageName, err)
+		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", ruleset.DikiOpsImageName, err)
+	}
+
+	// check if tag is not present and use the controller's version if that is the case
+	if image.Tag == nil {
+		tag := version.Get().GitVersion
+		image.Tag = &tag
 	}
 
 	for nodeName, pods := range groupedPods {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the use of the `ops-toolbelt` image with `diki-ops` for DISA K8s STIG V1R11 ruleset. The `diki-ops` is considerably lighter and contains only the needed tools for `diki`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Diki now uses a lighter image for pod executors in DISA K8s STIG V1R11 ruleset
```
