### PR TITLE
Move ExceedFilePermissions() to diki internal utils

### DIFF
--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -199,4 +199,23 @@ var _ = Describe("utils", func() {
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {fooFileStats}}))
 		})
 	})
+
+	DescribeTable("#ExceedFilePermissions",
+		func(filePermissions, filePermissionsMax string, expectedResult bool, errorMatcher gomegatypes.GomegaMatcher) {
+			result, err := utils.ExceedFilePermissions(filePermissions, filePermissionsMax)
+
+			Expect(result).To(Equal(expectedResult))
+			Expect(err).To(errorMatcher)
+		},
+		Entry("should return false when filePermissions do not exceed filePermissionsMax",
+			"0600", "0644", false, BeNil()),
+		Entry("should return false when filePermissions equal filePermissionsMax",
+			"0644", "0644", false, BeNil()),
+		Entry("should return true when filePermissions exceed filePermissionsMax by user permissions",
+			"0700", "0644", true, BeNil()),
+		Entry("should return true when filePermissions exceed filePermissionsMax by group permissions",
+			"0460", "0644", true, BeNil()),
+		Entry("should return true when filePermissions exceed filePermissionsMax by other permissions",
+			"0406", "0644", true, BeNil()),
+	)
 })

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -12,7 +12,6 @@ import (
 	kubernetesgardener "github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -397,25 +396,6 @@ var _ = Describe("utils", func() {
 			}))
 		})
 	})
-
-	DescribeTable("#ExceedFilePermissions",
-		func(filePermissions, filePermissionsMax string, expectedResult bool, errorMatcher gomegatypes.GomegaMatcher) {
-			result, err := utils.ExceedFilePermissions(filePermissions, filePermissionsMax)
-
-			Expect(result).To(Equal(expectedResult))
-			Expect(err).To(errorMatcher)
-		},
-		Entry("should return false when filePermissions do not exceed filePermissionsMax",
-			"0600", "0644", false, BeNil()),
-		Entry("should return false when filePermissions equal filePermissionsMax",
-			"0644", "0644", false, BeNil()),
-		Entry("should return true when filePermissions exceed filePermissionsMax by user permissions",
-			"0700", "0644", true, BeNil()),
-		Entry("should return true when filePermissions exceed filePermissionsMax by group permissions",
-			"0460", "0644", true, BeNil()),
-		Entry("should return true when filePermissions exceed filePermissionsMax by other permissions",
-			"0406", "0644", true, BeNil()),
-	)
 
 	Describe("#MatchFileOwnersCases", func() {
 		var (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves `ExceedFilePermissions()` from  `pkg/provider/gardener/internal/utils` to `pkg/internal/utils`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
