### PR TITLE
Return error when getContainerMountedFileStatResults fails to find file source

### DIFF
--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -145,6 +145,11 @@ func getContainerMountedFileStatResults(
 				continue
 			}
 
+			if len(mountStats) == 0 {
+				err = errors.Join(err, fmt.Errorf("could not find file with path %s", mount.Source))
+				continue
+			}
+
 			mountStatsSlice := strings.Split(strings.TrimSpace(mountStats), "\n")
 			for _, mountStats := range mountStatsSlice {
 				mountStatsFile, err2 := NewFileStats(mountStats, delimiter)

--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -146,7 +146,7 @@ func getContainerMountedFileStatResults(
 			}
 
 			if len(mountStats) == 0 {
-				err = errors.Join(err, fmt.Errorf("could not find file with path %s", mount.Source))
+				err = errors.Join(err, fmt.Errorf("could not find file %s", mount.Source))
 				continue
 			}
 

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -143,6 +143,19 @@ var _ = Describe("utils", func() {
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats, fooFileStats}}))
 		})
 
+		It("Should return error when file could not be found", func() {
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+				MountPath: "/foo",
+			})
+			executeReturnString := []string{mounts, destinationStats, ""}
+			executeReturnError := []error{nil, nil, nil}
+			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
+			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
+
+			Expect(err).To(MatchError("could not find file with path /foo"))
+			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats}}))
+		})
+
 		It("Should error when there are problems with container", func() {
 			pod.Spec.Containers = []corev1.Container{
 				{

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -152,7 +152,7 @@ var _ = Describe("utils", func() {
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
 			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
-			Expect(err).To(MatchError("could not find file with path /foo"))
+			Expect(err).To(MatchError("could not find file /foo"))
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats}}))
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improved getContainerMountedFileStatResults by adding error message when it fails to find file source.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
