### PR TITLE
[DISA K8s STIG] 242459 check files even if GetMountedFilesStats errored

### DIFF
--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
@@ -138,7 +138,6 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 			mappedFileStats, err := dikiutils.GetMountedFilesStats(ctx, execContainerPath, podExecutor, pod, excludedSources)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), execPodTarget))
-				continue
 			}
 
 			expectedFilePermissionsMax := "600"

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459_test.go
@@ -41,6 +41,16 @@ var _ = Describe("#242459", func() {
     "source": "/source"
   }
 ]`
+		mountsMulty = `[
+  {
+    "destination": "/destination",
+    "source": "/destination"
+  },
+  {
+    "destination": "/destination",
+    "source": "/destination"
+  }
+]`
 		emptyMounts       = `[]`
 		compliantStats    = "600\t0\t0\tregular file\t/destination/file1.txt\n400\t0\t65532\tregular file\t/destination/bar/file2.txt"
 		compliantStats2   = "600\t0\t0\tregular file\t/destination/file3.txt\n600\t1000\t0\tregular file\t/destination/bar/file4.txt\n"
@@ -211,6 +221,14 @@ var _ = Describe("#242459", func() {
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242459-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242459-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
+			}),
+		Entry("should check files when GetMountedFilesStats errors",
+			[][]string{{mountsMulty, compliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
+			[][]error{{nil, nil, errors.New("bar"), nil, nil, nil, nil}},
+			[]rule.CheckResult{
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242459-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.txt, permissions: 600")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.txt, permissions: 400")),
 			}),
 		Entry("should correctly return all checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2}},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves rule 242459 by not continuing the for loop when `GetMountedFilesStats` errors. When `GetMountedFilesStats` errors it also returns all successfully found file stats.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
