### PR TITLE
Move MatchFileOwnersCases to pkg/internal/utils

### DIFF
--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -7,7 +7,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -122,35 +121,6 @@ func anyNodesForWorkerGroup(workerGroupName string, nodes []corev1.Node) bool {
 		}
 	}
 	return false
-}
-
-// MatchFileOwnersCases returns []rule.CheckResult for a given file and its owners for a select expected values.
-func MatchFileOwnersCases(
-	fileOwnerUser,
-	fileOwnerGroup,
-	fileName string,
-	expectedFileOwnerUsers,
-	expectedFileOwnerGroups []string,
-	target rule.Target,
-) []rule.CheckResult {
-	checkResults := []rule.CheckResult{}
-
-	if !slices.Contains(expectedFileOwnerUsers, fileOwnerUser) {
-		detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerUser: %s, expectedOwnerUsers: %v", fileName, fileOwnerUser, expectedFileOwnerUsers))
-		checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner user", detailedTarget))
-	}
-
-	if !slices.Contains(expectedFileOwnerGroups, fileOwnerGroup) {
-		detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerGroup: %s, expectedOwnerGroups: %v", fileName, fileOwnerGroup, expectedFileOwnerGroups))
-		checkResults = append(checkResults, rule.FailedCheckResult("File has unexpected owner group", detailedTarget))
-	}
-
-	if len(checkResults) == 0 {
-		detailedTarget := target.With("details", fmt.Sprintf("fileName: %s, ownerUser: %s, ownerGroup: %s", fileName, fileOwnerUser, fileOwnerGroup))
-		checkResults = append(checkResults, rule.PassedCheckResult("File has expected owners", detailedTarget))
-	}
-
-	return checkResults
 }
 
 // MatchFilePermissionsAndOwnersCases returns []rule.CheckResult for a given file and its permissions and owners for a select expected values.

--- a/pkg/provider/gardener/internal/utils/utils_test.go
+++ b/pkg/provider/gardener/internal/utils/utils_test.go
@@ -397,37 +397,6 @@ var _ = Describe("utils", func() {
 		})
 	})
 
-	Describe("#MatchFileOwnersCases", func() {
-		var (
-			target = rule.NewTarget()
-		)
-		DescribeTable("#MatchCases",
-			func(fileOwnerUser, fileOwnerGroup, fileName string, expectedFileOwnerUsers, expectedFileOwnerGroups []string, target rule.Target, expectedResults []rule.CheckResult) {
-				result := utils.MatchFileOwnersCases(fileOwnerUser, fileOwnerGroup, fileName, expectedFileOwnerUsers, expectedFileOwnerGroups, target)
-
-				Expect(result).To(Equal(expectedResults))
-			},
-			Entry("should return passed when all checks pass",
-				"0", "2000", "/foo/bar/file.txt", []string{"0"}, []string{"0", "2000"}, target,
-				[]rule.CheckResult{
-					rule.PassedCheckResult("File has expected owners", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 0, ownerGroup: 2000")),
-				}),
-			Entry("should return failed results when all checks fail",
-				"1000", "2000", "/foo/bar/file.txt", []string{"0"}, []string{"0", "1000"}, target,
-				[]rule.CheckResult{
-
-					rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 1000, expectedOwnerUsers: [0]")),
-					rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerGroup: 2000, expectedOwnerGroups: [0 1000]")),
-				}),
-			Entry("should return failed when expected owners are empty",
-				"1000", "2000", "/foo/bar/file.txt", []string{}, []string{}, target,
-				[]rule.CheckResult{
-					rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerUser: 1000, expectedOwnerUsers: []")),
-					rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("details", "fileName: /foo/bar/file.txt, ownerGroup: 2000, expectedOwnerGroups: []")),
-				}),
-		)
-	})
-
 	Describe("#MatchFilePermissionsAndOwnersCases", func() {
 		var (
 			target = rule.NewTarget()

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
+	dikiutils "github.com/gardener/diki/pkg/internal/utils"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
@@ -222,8 +223,8 @@ func (r *RuleNodeFiles) checkWorkerGroup(ctx context.Context, image, workerGroup
 					checkResults = append(checkResults, utils.MatchFilePermissionsAndOwnersCases(pkiAllStatSlice[0], pkiAllStatSlice[1], pkiAllStatSlice[2], fileName,
 						"644", expectedFileOwnerUsers, expectedFileOwnerGroups, target)...)
 				case fileType == "directory": // rule 242451
-					checkResults = append(checkResults, utils.MatchFileOwnersCases(pkiAllStatSlice[1], pkiAllStatSlice[2], fileName,
-						expectedFileOwnerUsers, expectedFileOwnerGroups, target)...)
+					checkResults = append(checkResults, dikiutils.MatchFileOwnersCases(dikiutils.FileStats{UserOwner: pkiAllStatSlice[1], GroupOwner: pkiAllStatSlice[2],
+						Path: fileName}, expectedFileOwnerUsers, expectedFileOwnerGroups, target)...)
 				default:
 					checkResults = append(checkResults, utils.MatchFilePermissionsAndOwnersCases(pkiAllStatSlice[0], pkiAllStatSlice[1], pkiAllStatSlice[2], fileName,
 						"644", expectedFileOwnerUsers, expectedFileOwnerGroups, target)...)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves `MatchFileOwnersCases` to `pkg/internal/utils` and also improves it by using `FileStats` as parameter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
