### PR TITLE
Add GetDeploymentPods kubernetes utils function

### DIFF
--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -53,7 +53,7 @@ func GetObjectsMetadata(ctx context.Context, c client.Client, gvk schema.GroupVe
 	}
 }
 
-// GetPods return all pods for a given namespace, or all namespaces if it's set to empty string "".
+// GetPods returns all pods for a given namespace, or all namespaces if it's set to empty string "".
 // It retrieves pods by portions set by limit.
 func GetPods(ctx context.Context, c client.Client, namespace string, selector labels.Selector, limit int64) ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
@@ -72,7 +72,7 @@ func GetPods(ctx context.Context, c client.Client, namespace string, selector la
 	}
 }
 
-// GetReplicaSets return all replicaSets for a given namespace, or all namespaces if it's set to empty string "".
+// GetReplicaSets returns all replicaSets for a given namespace, or all namespaces if it's set to empty string "".
 // It retrieves replicaSets by portions set by limit.
 func GetReplicaSets(ctx context.Context, c client.Client, namespace string, selector labels.Selector, limit int64) ([]appsv1.ReplicaSet, error) {
 	replicaSetList := &appsv1.ReplicaSetList{}
@@ -91,7 +91,7 @@ func GetReplicaSets(ctx context.Context, c client.Client, namespace string, sele
 	}
 }
 
-// GetDeploymentPods return all pods of a given deployment.
+// GetDeploymentPods returns all pods of a given deployment.
 func GetDeploymentPods(ctx context.Context, c client.Client, name, namespace string) ([]corev1.Pod, error) {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/pkg/kubernetes/config"
@@ -70,6 +71,63 @@ func GetPods(ctx context.Context, c client.Client, namespace string, selector la
 			return pods, nil
 		}
 	}
+}
+
+// GetReplicaSets return all replicaSets for a given namespace, or all namespaces if it's set to empty string "".
+// It retrieves replicaSets by portions set by limit.
+func GetReplicaSets(ctx context.Context, c client.Client, namespace string, selector labels.Selector, limit int64) ([]appsv1.ReplicaSet, error) {
+	replicaSetList := &appsv1.ReplicaSetList{}
+	replicaSets := []appsv1.ReplicaSet{}
+
+	for {
+		if err := c.List(ctx, replicaSetList, client.InNamespace(namespace), client.Limit(limit), client.MatchingLabelsSelector{Selector: selector}, client.Continue(replicaSetList.Continue)); err != nil {
+			return nil, err
+		}
+
+		replicaSets = append(replicaSets, replicaSetList.Items...)
+
+		if len(replicaSetList.Continue) == 0 {
+			return replicaSets, nil
+		}
+	}
+}
+
+// GetDeploymentPods return all pods of a given deployment.
+func GetDeploymentPods(ctx context.Context, c client.Client, deploymentName, namespace string) ([]corev1.Pod, error) {
+	pods := []corev1.Pod{}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+		},
+	}
+
+	if err := c.Get(ctx, client.ObjectKeyFromObject(deployment), deployment); err != nil {
+		return pods, err
+	}
+
+	allPods, err := GetPods(ctx, c, namespace, labels.NewSelector(), 300)
+	if err != nil {
+		return pods, err
+	}
+
+	allReplicaSets, err := GetReplicaSets(ctx, c, namespace, labels.NewSelector(), 300)
+	if err != nil {
+		return pods, err
+	}
+
+	for _, replicaSet := range allReplicaSets {
+		// When not specified replicaSet.Spec.Replicas defaults to 1: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#replicas
+		if replicaSet.OwnerReferences[0].UID == deployment.UID && (replicaSet.Spec.Replicas == nil || *replicaSet.Spec.Replicas > *pointer.Int32(int32(0))) {
+			for _, pod := range allPods {
+				if pod.OwnerReferences[0].UID == replicaSet.UID {
+					pods = append(pods, pod)
+				}
+			}
+		}
+	}
+
+	return pods, nil
 }
 
 // GetNodes return all nodes. It retrieves pods by portions set by limit.

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -402,6 +402,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "1",
+					Kind: "Deployment",
 				},
 			}
 			replicaSet.Spec.Replicas = pointer.Int32(int32(1))
@@ -411,6 +412,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "2",
+					Kind: "ReplicaSet",
 				},
 			}
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
@@ -422,10 +424,11 @@ var _ = Describe("utils", func() {
 			Expect(pods).To(Equal([]corev1.Pod{*pod}))
 			Expect(err).To(BeNil())
 		})
+
 		It("should return error when deployment not found", func() {
 			pods, err := utils.GetDeploymentPods(ctx, fakeClient, "foo", namespace)
 
-			Expect(pods).To(Equal([]corev1.Pod{}))
+			Expect(pods).To(BeNil())
 			Expect(err).To(MatchError("deployments.apps \"foo\" not found"))
 		})
 
@@ -437,6 +440,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "1",
+					Kind: "Deployment",
 				},
 			}
 			replicaSet.Spec.Replicas = pointer.Int32(int32(0))
@@ -446,6 +450,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "2",
+					Kind: "ReplicaSet",
 				},
 			}
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
@@ -457,6 +462,7 @@ var _ = Describe("utils", func() {
 			Expect(pods).To(Equal([]corev1.Pod{}))
 			Expect(err).To(BeNil())
 		})
+
 		It("should return pods when relicaSet replicase are not specified", func() {
 			deployment := basicDeployment.DeepCopy()
 			deployment.UID = "1"
@@ -465,6 +471,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "1",
+					Kind: "Deployment",
 				},
 			}
 			replicaSet.UID = "2"
@@ -473,6 +480,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "2",
+					Kind: "ReplicaSet",
 				},
 			}
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
@@ -484,6 +492,7 @@ var _ = Describe("utils", func() {
 			Expect(pods).To(Equal([]corev1.Pod{*pod}))
 			Expect(err).To(BeNil())
 		})
+
 		It("should return multiple pods", func() {
 			deployment := basicDeployment.DeepCopy()
 			deployment.UID = "1"
@@ -493,6 +502,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "1",
+					Kind: "Deployment",
 				},
 			}
 			replicaSet1.UID = "2"
@@ -502,6 +512,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "1",
+					Kind: "Deployment",
 				},
 			}
 			replicaSet2.UID = "3"
@@ -511,6 +522,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "2",
+					Kind: "ReplicaSet",
 				},
 			}
 			pod2 := basicPod.DeepCopy()
@@ -519,6 +531,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "2",
+					Kind: "ReplicaSet",
 				},
 			}
 			pod3 := basicPod.DeepCopy()
@@ -527,6 +540,7 @@ var _ = Describe("utils", func() {
 				{
 					Name: "foo",
 					UID:  "3",
+					Kind: "ReplicaSet",
 				},
 			}
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -122,12 +122,14 @@ var _ = Describe("utils", func() {
 			Expect(len(pods)).To(Equal(18))
 			Expect(err).To(BeNil())
 		})
+
 		It("should return correct number of labeled pods in default namespace", func() {
 			pods, err := utils.GetObjectsMetadata(ctx, fakeClient, corev1.SchemeGroupVersion.WithKind("PodList"), namespaceDefault, labels.SelectorFromSet(labels.Set{"foo": "bar"}), 2)
 
 			Expect(len(pods)).To(Equal(2))
 			Expect(err).To(BeNil())
 		})
+
 		It("should return correct number of nodes", func() {
 			nodes, err := utils.GetObjectsMetadata(ctx, fakeClient, corev1.SchemeGroupVersion.WithKind("NodeList"), "", labels.NewSelector(), 2)
 
@@ -219,6 +221,7 @@ var _ = Describe("utils", func() {
 			Expect(len(pods)).To(Equal(18))
 			Expect(err).To(BeNil())
 		})
+
 		It("should return correct number of labeled pods in default namespace", func() {
 			pods, err := utils.GetPods(ctx, fakeClient, namespaceDefault, labels.SelectorFromSet(labels.Set{"foo": "bar"}), 2)
 
@@ -323,13 +326,13 @@ var _ = Describe("utils", func() {
 			Expect(len(replicaSets)).To(Equal(18))
 			Expect(err).To(BeNil())
 		})
+
 		It("should return correct number of labeled replicaSets in default namespace", func() {
 			replicaSets, err := utils.GetReplicaSets(ctx, fakeClient, namespaceDefault, labels.SelectorFromSet(labels.Set{"foo": "bar"}), 2)
 
 			Expect(len(replicaSets)).To(Equal(2))
 			Expect(err).To(BeNil())
 		})
-
 	})
 
 	Describe("#GetDeploymentPods", func() {
@@ -1127,7 +1130,6 @@ var _ = Describe("utils", func() {
 
 			Expect(result).To(BeNil())
 		})
-
 	})
 
 	Describe("#IsFlagSet", func() {
@@ -1585,6 +1587,5 @@ readOnlyPort: 222
 			Expect(res).To(Equal(expectedRes))
 			Expect(checkResult).To(Equal(expectedCheckResults))
 		})
-
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `GetReplicaSets()` and `GetDeploymentPods()` functions to `pkg/kubernetes/utils`.
`GetReplicaSets()` return all replicaSets for a given namespace.
`GetDeploymentPods()` returns all pods of a specified deployment by finding the deployments replicaSets and then the pods that reference the found replicaSets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
