### PR TITLE
Clean up package usage

### DIFF
--- a/pkg/provider/gardener/internal/utils/utils.go
+++ b/pkg/provider/gardener/internal/utils/utils.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dikiutils "github.com/gardener/diki/pkg/internal/utils"
+	intutils "github.com/gardener/diki/pkg/internal/utils"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
 )
@@ -136,7 +136,7 @@ func MatchFilePermissionsAndOwnersCases(
 ) []rule.CheckResult {
 	checkResults := []rule.CheckResult{}
 	if len(expectedFilePermissionsMax) > 0 {
-		exceedFilePermissions, err := dikiutils.ExceedFilePermissions(filePermissions, expectedFilePermissionsMax)
+		exceedFilePermissions, err := intutils.ExceedFilePermissions(filePermissions, expectedFilePermissionsMax)
 		if err != nil {
 			return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), target)}
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/node_files_permissions_and_owner.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
-	dikiutils "github.com/gardener/diki/pkg/internal/utils"
+	intutils "github.com/gardener/diki/pkg/internal/utils"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/gardener/internal/utils"
@@ -230,7 +230,7 @@ func (r *RuleNodeFiles) checkWorkerGroup(ctx context.Context, image, workerGroup
 					checkResults = append(checkResults, utils.MatchFilePermissionsAndOwnersCases(pkiAllStatSlice[0], pkiAllStatSlice[1], pkiAllStatSlice[2], fileName,
 						"644", expectedFileOwnerUsers, expectedFileOwnerGroups, target)...)
 				case fileType == "directory": // rule 242451
-					checkResults = append(checkResults, dikiutils.MatchFileOwnersCases(dikiutils.FileStats{UserOwner: pkiAllStatSlice[1], GroupOwner: pkiAllStatSlice[2],
+					checkResults = append(checkResults, intutils.MatchFileOwnersCases(intutils.FileStats{UserOwner: pkiAllStatSlice[1], GroupOwner: pkiAllStatSlice[2],
 						Path: fileName}, expectedFileOwnerUsers, expectedFileOwnerGroups, target)...)
 				default:
 					checkResults = append(checkResults, utils.MatchFilePermissionsAndOwnersCases(pkiAllStatSlice[0], pkiAllStatSlice[1], pkiAllStatSlice[2], fileName,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -116,7 +116,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 
 	rules := []rule.Rule{
 		&sharedv1r11.Rule242376{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242377{Logger: r.Logger().With("rule", v1r11.ID242377), Client: seedClient, Namespace: r.shootNamespace},
+		&v1r11.Rule242377{Logger: r.Logger().With("rule", sharedv1r11.ID242377), Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242378{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242379{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242380{Client: seedClient, Namespace: r.shootNamespace},
@@ -142,7 +142,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		),
 		&sharedv1r11.Rule242386{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242387{
-			Logger:                  r.Logger().With("rule", v1r11.ID242387),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242387),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -154,7 +154,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242389{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242390{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242391{
-			Logger:                  r.Logger().With("rule", v1r11.ID242391),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242391),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -163,7 +163,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
 		&v1r11.Rule242392{
-			Logger:                  r.Logger().With("rule", v1r11.ID242392),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242392),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -171,9 +171,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ClusterPodContext:       shootPodContext,
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
-		&v1r11.Rule242393{Logger: r.Logger().With("rule", v1r11.ID242393), InstanceID: r.instanceID, ClusterPodContext: shootPodContext},
-		&v1r11.Rule242394{Logger: r.Logger().With("rule", v1r11.ID242394), InstanceID: r.instanceID, ClusterPodContext: shootPodContext},
-		&v1r11.Rule242395{Logger: r.Logger().With("rule", v1r11.ID242395), Client: shootClient},
+		&v1r11.Rule242393{Logger: r.Logger().With("rule", sharedv1r11.ID242393), InstanceID: r.instanceID, ClusterPodContext: shootPodContext},
+		&v1r11.Rule242394{Logger: r.Logger().With("rule", sharedv1r11.ID242394), InstanceID: r.instanceID, ClusterPodContext: shootPodContext},
+		&v1r11.Rule242395{Logger: r.Logger().With("rule", sharedv1r11.ID242395), Client: shootClient},
 		rule.NewSkipRule(
 			sharedv1r11.ID242396,
 			"Kubernetes Kubectl cp command must give expected access and results (MEDIUM 242396)",
@@ -181,7 +181,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		&v1r11.Rule242397{
-			Logger:                  r.Logger().With("rule", v1r11.ID242397),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242397),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -197,7 +197,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		&v1r11.Rule242399{
-			Logger:                  r.Logger().With("rule", v1r11.ID242399),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242399),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterVersion:          semverShootKubernetesVersion,
@@ -210,7 +210,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242402{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242403{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242404{
-			Logger:                r.Logger().With("rule", v1r11.ID242404),
+			Logger:                r.Logger().With("rule", sharedv1r11.ID242404),
 			InstanceID:            r.instanceID,
 			ClusterClient:         shootClient,
 			ControlPlaneClient:    seedClient,
@@ -267,24 +267,24 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		&v1r11.Rule242414{
-			Logger:                r.Logger().With("rule", v1r11.ID242414),
+			Logger:                r.Logger().With("rule", sharedv1r11.ID242414),
 			ClusterClient:         shootClient,
 			ControlPlaneClient:    seedClient,
 			ControlPlaneNamespace: r.shootNamespace,
 			Options:               opts242414,
 		},
 		&v1r11.Rule242415{
-			Logger:                r.Logger().With("rule", v1r11.ID242415),
+			Logger:                r.Logger().With("rule", sharedv1r11.ID242415),
 			ClusterClient:         shootClient,
 			ControlPlaneClient:    seedClient,
 			ControlPlaneNamespace: r.shootNamespace,
 			Options:               opts242415,
 		},
-		&v1r11.Rule242417{Logger: r.Logger().With("rule", v1r11.ID242417), Client: shootClient},
+		&v1r11.Rule242417{Logger: r.Logger().With("rule", sharedv1r11.ID242417), Client: shootClient},
 		&sharedv1r11.Rule242418{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242419{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242420{
-			Logger:                  r.Logger().With("rule", v1r11.ID242420),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242420),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -296,7 +296,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242422{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242423{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242424{
-			Logger:                  r.Logger().With("rule", v1r11.ID242424),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242424),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -305,7 +305,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneNamespace:   r.shootNamespace,
 		},
 		&v1r11.Rule242425{
-			Logger:                  r.Logger().With("rule", v1r11.ID242425),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242425),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -322,7 +322,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule242432{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule242433{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242434{
-			Logger:                  r.Logger().With("rule", v1r11.ID242434),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID242434),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -332,7 +332,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		},
 		&sharedv1r11.Rule242436{Client: seedClient, Namespace: r.shootNamespace},
 		&v1r11.Rule242437{
-			Logger:                r.Logger().With("rule", v1r11.ID242437),
+			Logger:                r.Logger().With("rule", sharedv1r11.ID242437),
 			ClusterClient:         shootClient,
 			ClusterVersion:        semverShootKubernetesVersion,
 			ControlPlaneClient:    seedClient,
@@ -340,7 +340,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ControlPlaneNamespace: r.shootNamespace,
 		},
 		&sharedv1r11.Rule242438{Client: seedClient, Namespace: r.shootNamespace},
-		&v1r11.Rule242442{Logger: r.Logger().With("rule", v1r11.ID242442), ClusterClient: shootClient, ControlPlaneClient: seedClient, ControlPlaneNamespace: r.shootNamespace},
+		&v1r11.Rule242442{Logger: r.Logger().With("rule", sharedv1r11.ID242442), ClusterClient: shootClient, ControlPlaneClient: seedClient, ControlPlaneNamespace: r.shootNamespace},
 		rule.NewSkipRule(
 			sharedv1r11.ID242443,
 			"Kubernetes must contain the latest updates as authorized by IAVMs, CTOs, DTMs, and STIGs (MEDIUM 242443)",
@@ -432,7 +432,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		&sharedv1r11.Rule242459{
-			Logger:     r.Logger().With("rule", v1r11.ID242459),
+			Logger:     r.Logger().With("rule", sharedv1r11.ID242459),
 			InstanceID: r.instanceID,
 			Client:     seedClient,
 			PodContext: seedPodContext,
@@ -467,7 +467,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		&v1r11.Rule245541{
-			Logger:                  r.Logger().With("rule", v1r11.ID245541),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID245541),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterCoreV1RESTClient: shootClientSet.CoreV1().RESTClient(),
@@ -480,7 +480,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedv1r11.Rule245544{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedv1r11.Rule254800{Client: seedClient, Namespace: r.shootNamespace, Options: opts254800},
 		&v1r11.Rule254801{
-			Logger:                  r.Logger().With("rule", v1r11.ID254801),
+			Logger:                  r.Logger().With("rule", sharedv1r11.ID254801),
 			InstanceID:              r.instanceID,
 			ClusterClient:           shootClient,
 			ClusterVersion:          semverShootKubernetesVersion,

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
-	dikiutils "github.com/gardener/diki/pkg/internal/utils"
+	intutils "github.com/gardener/diki/pkg/internal/utils"
 	"github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
@@ -142,7 +142,7 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 
 		for _, pod := range pods {
 			excludedSources := []string{"/lib/modules", "/usr/share/ca-certificates", "/var/log/journal"}
-			mappedFileStats, err := dikiutils.GetMountedFilesStats(ctx, execContainerPath, podExecutor, pod, excludedSources)
+			mappedFileStats, err := intutils.GetMountedFilesStats(ctx, execContainerPath, podExecutor, pod, excludedSources)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), execPodTarget))
 				continue
@@ -152,7 +152,7 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 			for containerName, fileStats := range mappedFileStats {
 				for _, fileStat := range fileStats {
 					containerTarget := rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod", "containerName", containerName)
-					exceedFilePermissions, err := dikiutils.ExceedFilePermissions(fileStat.Permissions, expectedFilePermissionsMax)
+					exceedFilePermissions, err := intutils.ExceedFilePermissions(fileStat.Permissions, expectedFilePermissionsMax)
 					if err != nil {
 						checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), containerTarget))
 						continue


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the use of package `pkg/internal/utils` from `dikiutils` to `intutils` and utilizes the use of shared rule ids in `pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
