### PR TITLE
Add diki run script in /hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,25 +21,6 @@ include $(GARDENER_HACK_DIR)/tools.mk
 # additional tools
 include hack/tools.mk
 
-# make run runs diki with flags specified by environment variables:
-# CONFIG - required - specifies the path to diki config file
-# RULE_ID - optional - if set diki executes only the specified rule
-# PROVIDER - optional - selects provider, defaults to "gardener"
-# RULESET_ID - optional - selects ruleset, defaults to "disa-kubernetes-stig"
-# RULESET_VERSION - optional - selects ruleset version, defaults to "v1r11"
-PROVIDER        ?= gardener
-RULESET_ID      ?= disa-kubernetes-stig
-RULESET_VERSION ?= v1r11
-.PHONY: run
-run:
-	go run -ldflags $(LD_FLAGS) \
-	./cmd/diki run \
-	--config=$(CONFIG) \
-	--rule-id=$(RULE_ID) \
-	--provider=${PROVIDER} \
-	--ruleset-id=${RULESET_ID} \
-	--ruleset-version=${RULESET_VERSION}
-
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./imagevector

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Diki is the Greek word for "trial". You can also memorise it as "Detective Inves
 
 If you install via GitHub releases, you need to put the diki binary on your path.
 
-You can also install diki using these commands:
+You can also install diki using this code snippet:
 ```bash
 # Example for macOS
 
@@ -44,17 +44,17 @@ Most of Diki's `run` configurations are provided through its [config file](./con
 
 - Run all known rulesets for all known providers
 ```bash
-diki --config=config.yaml --all
+diki run --config=config.yaml --all
 ```
 
 - Run a specific ruleset for a known provider
 ```bash
-diki --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
+diki run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
 ```
 
 - Run a specific rule defined in a ruleset for a known provider
 ```bash
-diki --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
+diki run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
 ```
 
 #### Report

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Most of Diki's `run` configurations are provided through its [config file](./con
 
 - Run all known rulesets for all known providers
 ```bash
-diki run --config=config.yaml --all
+./hack/run --config=config.yaml --all
 ```
 
 - Run a specific ruleset for a known provider
 ```bash
-diki run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
+./hack/run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
 ```
 
 - Run a specific rule defined in a ruleset for a known provider
 ```bash
-diki run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
+./hack/run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
 ```
 
 #### Report

--- a/README.md
+++ b/README.md
@@ -15,8 +15,27 @@ Diki is the Greek word for "trial". You can also memorise it as "Detective Inves
 
 #### Installation
 
+If you install via GitHub releases, you need to put the diki binary on your path.
+
+You can also install diki using these commands:
 ```bash
-go install github.com/gardener/diki/cmd/diki@latest
+# Example for macOS
+
+# set operating system and architecture
+os=darwin # choose between darwin, linux, windows
+arch=amd64 # choose between amd64, arm64
+
+# Get latest version. Alternatively set your desired version
+version=$(curl -Ls -H 'Accept: application/json' https://github.com/gardener/diki/releases/latest | jq -r '.tag_name')
+
+# Download diki
+curl -LO "https://github.com/gardener/diki/releases/download/${version}/diki-${os}-${arch}"
+
+# Make the diki binary executable
+chmod +x "./diki-${os}-${arch}"
+
+# Move the binary in to your PATH
+sudo mv "./diki-${os}-${arch}" /usr/local/bin/diki
 ```
 
 #### Run
@@ -25,17 +44,17 @@ Most of Diki's `run` configurations are provided through its [config file](./con
 
 - Run all known rulesets for all known providers
 ```bash
-./hack/run --config=config.yaml --all
+diki --config=config.yaml --all
 ```
 
 - Run a specific ruleset for a known provider
 ```bash
-./hack/run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
+diki --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
 ```
 
 - Run a specific rule defined in a ruleset for a known provider
 ```bash
-./hack/run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
+diki --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
 ```
 
 #### Report

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -26,7 +26,7 @@ You can use the [example gardener configuration](../../example/config/gardener.y
 
 To run Diki you can use the [run script](../../hack/run.sh). It will use default ldflags flags or you can configure them by setting the `LD_FLAGS` env var. You will need to set the `IMAGEVECTOR_OVERWRITE` env var to overwrite the [images.yaml](../../imagevector/images.yaml) file to a file that specifies the version of the `diki-ops` image or change it's repository.
 
-After creating the overwrite images file you can run diki as follow:
+After creating the overwrite images file you can run diki as follows:
 ```bash
 IMAGEVECTOR_OVERWRITE=/path/to/images/file ./hack/run.sh --config=/path/to/config/file
 ```

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -20,7 +20,7 @@ Make sure that you have a running local Gardener setup with a created shoot clus
 
 ### Diki configuration
 
-You can use the [example gardener configuration](../../example/config/gardener.yaml) for this run. You will need to modify the `provider.args` field with correct kubeconfigs and shoot name/ namespace. You can can find a guide on how to get the shoot's kubeconfig [here]([here](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md).
+You can use the [example gardener configuration](../../example/config/gardener.yaml) for this run. You will need to modify the `provider.args` field with correct kubeconfigs and shoot name/ namespace. You can can find a guide on how to get the shoot's kubeconfig [here](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md).
 
 ### Diki run
 

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -8,3 +8,30 @@
 - the [report package](../../pkg/report/) defines a `report`. A `report` is the output of a `diki` run.
 
 See the [provider specific documentation](../providers/).
+
+## Running diki Locally
+
+This document will walk you through running Diki against a local shoot cluster for development purposes. This guide uses the Gardener's local development setup.
+If you encounter difficulties, please open an issue so that we can make this process easier.
+
+### Prerequisites
+
+Make sure that you have a running local Gardener setup with a created shoot cluster. The steps to complete this can be found [here](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md).
+
+### Diki configuration
+
+You can use the [example gardener configuration](../../example/config/gardener.yaml) for this run. You will need to modify the `provider.args` field with correct kubeconfigs and shoot name/ namespace. You can can find a guide on how to get the shoot's kubeconfig [here]([here](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md).
+
+### Diki run
+
+To run Diki you can use the [run script](../../hack/run.sh). It will use default ldflags flags or you can configure them by setting the `LD_FLAGS` env var. You will need to set the `IMAGEVECTOR_OVERWRITE` env var to overwrite the [images.yaml](../../imagevector/images.yaml) file to a file that specifies the version of the `diki-ops` image or change it's repository.
+
+After creating the overwrite images file you can run diki as follow:
+```bash
+IMAGEVECTOR_OVERWRITE=/path/to/images/file ./hack/run.sh --config=/path/to/config/file
+```
+
+For more information about the script you can use it's help command:
+```bash
+./hack/run.sh --help
+```

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+rule_id=""
+provider="gardener"
+ruleset_id="disa-kubernetes-stig"
+ruleset_version="v1r11"
+run_all="false"
+
+
+function usage {
+    cat <<EOM
+Usage:
+run [options]
+
+This command runs diki with a specified config file.
+
+  options:
+    -h, --help        Display this help and exit.
+    --config          Path to diki configuration file.
+    --all             If set diki runs all rulesets specified in the config file.
+                      Also ignore all flags except --config.
+    --rule-id         ID of single rule that will be ran. If not set all rules of the
+                      specified ruleset are executed.
+    --provider        Ruleset provider. Defaults to "gardener".
+    --ruleset-id      ID of ruleset that will be ran. Defaults to "disa-kubernetes-stig".
+    --ruleset-version Version of ruleset that will be ran. Defaults to "v1r11".
+    
+  environment variables:
+    IMAGEVECTOR_OVERWRITE Overwrites diki/imagesvector/images.yaml file with specified file path.
+    LD_FLAGS              ldflags of go run diki command. Default ldflags will be generated if it is not set.
+EOM
+    exit 0
+}
+
+while :; do
+  case $1 in
+    -h|--help)
+      usage
+      ;;
+    --)
+      shift
+      break
+      ;;
+    --all)
+      run_all="true"
+      ;;
+    --config=*|--rule-id=*|--provider=*|--ruleset-id=*|--ruleset-version=*)
+      var="${1%%=*}"
+      var="${var#*--}"
+      var="${var//-/_}"
+      declare "${var}"="${1#*=}"
+      ;;
+    --config|--rule-id|--provider|--ruleset-id|--ruleset-version)
+      var="${1#*--}"
+      var="${var//-/_}"
+      declare "${var}"="${2}"
+      shift
+      ;;
+    --*)
+      var="${1%%=*}"
+      echo "Error: ${var} flag is not recognized!" >&2
+      usage
+      ;;
+    *)
+      break
+  esac
+  shift
+done
+
+if [ -z "${config}" ]; then
+  echo "Error: --config flag not set!" >&2
+  usage
+fi
+
+if [ -z "${LD_FLAGS}" ]; then
+  EFFECTIVE_VERSION="$(cat "$(dirname "$0")/../VERSION")"-"$(git rev-parse HEAD)"
+  LD_FLAGS=$(EFFECTIVE_VERSION=${EFFECTIVE_VERSION} "$(dirname "$0")"/get-build-ld-flags.sh)
+fi
+
+if [ "${run_all}" = "true" ]; then
+  go run -ldflags "${LD_FLAGS}" \
+  "$(dirname "$0")"/../cmd/diki run \
+  --config="${config}" \
+  --all
+
+  exit 0
+fi
+
+go run -ldflags "${LD_FLAGS}" \
+"$(dirname "$0")"/../cmd/diki run \
+--config="${config}" \
+--rule-id="${rule_id}" \
+--provider="${provider}" \
+--ruleset-id="${ruleset_id}" \
+--ruleset-version="${ruleset_version}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds diki run script in `/hack`. The purpose of the script is to ease the use of `diki`. The main improvements are a comprehensive `--help` message and default `ldflags` flags.

**Which issue(s) this PR fixes**:
Fixes #118 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
New `hack/run.sh` script that executes `diki run` added. The script sets default `ldflags` if not specified and provides a comprehensive `--help` message.
```
