### PR TITLE
Improve getContainerMountedFileStatResults() dir files not found error.

### DIFF
--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -147,7 +147,15 @@ func getContainerMountedFileStatResults(
 			}
 
 			if len(mountStats) == 0 {
-				err = errors.Join(err, fmt.Errorf("could not find file %s", mount.Source))
+				fileNum, err2 := podExecutor.Execute(ctx, "/bin/sh", fmt.Sprintf(`ls %s | wc -l`, mount.Source))
+				if err2 != nil {
+					err = errors.Join(err, err2)
+					continue
+				}
+
+				if fileNum != "0\n" {
+					err = errors.Join(err, fmt.Errorf("could not find files in %s", mount.Source))
+				}
 				continue
 			}
 

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -144,16 +144,29 @@ var _ = Describe("utils", func() {
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats, fooFileStats}}))
 		})
 
-		It("Should return error when file could not be found", func() {
+		It("Should return error when files could not be found", func() {
 			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 				MountPath: "/foo",
 			})
-			executeReturnString := []string{mounts, destinationStats, ""}
-			executeReturnError := []error{nil, nil, nil}
+			executeReturnString := []string{mounts, destinationStats, "", "2\n"}
+			executeReturnError := []error{nil, nil, nil, nil}
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
 			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
-			Expect(err).To(MatchError("could not find file /foo"))
+			Expect(err).To(MatchError("could not find files in /foo"))
+			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats}}))
+		})
+
+		It("Should not return error when directory is empty", func() {
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+				MountPath: "/foo",
+			})
+			executeReturnString := []string{mounts, destinationStats, "", "0\n"}
+			executeReturnError := []error{nil, nil, nil, nil}
+			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
+			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
+
+			Expect(err).To(BeNil())
 			Expect(result).To(Equal(map[string][]utils.FileStats{"test": {destinationFileStats}}))
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the getContainerMountedFileStatResults() utils func to error when a dir has files, but they could not be found by the `find` command

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
