### PR TITLE
Minor refactor of option names for managedk8s provider

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -29,15 +29,15 @@ providers:                   # contains information about known providers
     #       status: Passed
     # - ruleID: "242393"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242394"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242396"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242400"
     #   args:
@@ -45,21 +45,21 @@ providers:                   # contains information about known providers
     #       foo: bar
     # - ruleID: "242404"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242406"
     #   args:
     #     # Node labels used to group nodes by specified
     #     # label value combinations. Only one node per
     #     # combination will be tested
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     #     expectedFileOwner:
     #       users: ["0"]
     #       groups: ["0"]
     # - ruleID: "242407"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242414"
     #   args:
@@ -107,11 +107,11 @@ providers:                   # contains information about known providers
     #       groups: ["0"]
     # - ruleID: "242449"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242450"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     #     expectedFileOwner:
     #       users: ["0"]
@@ -120,18 +120,18 @@ providers:                   # contains information about known providers
     #   args:
     #     podMatchLabels:
     #       foo: bar
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     #     expectedFileOwner:
     #       users: ["0"]
     #       groups: ["0"]
     # - ruleID: "242452"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242453"
     #   args:
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     #     expectedFileOwner:
     #       users: ["0"]
@@ -140,13 +140,13 @@ providers:                   # contains information about known providers
     #   args:
     #     podMatchLabels:
     #       foo: bar
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242467"
     #   args:
     #     podMatchLabels:
     #       foo: bar
-    #     groupByLabels:
+    #     nodeGroupByLabels:
     #     - foo
 output:
   path: /tmp/test-output.json  # optional, path to summary json report

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -41,7 +41,7 @@ providers:                   # contains information about known providers
     #     - foo
     # - ruleID: "242400"
     #   args:
-    #     podMatchLabels:
+    #     kubeProxyMatchLabels:
     #       foo: bar
     # - ruleID: "242404"
     #   args:
@@ -96,11 +96,11 @@ providers:                   # contains information about known providers
     #       status: Passed
     # - ruleID: "242447"
     #   args:
-    #     podMatchLabels:
+    #     kubeProxyMatchLabels:
     #       foo: bar
     # - ruleID: "242448"
     #   args:
-    #     podMatchLabels:
+    #     kubeProxyMatchLabels:
     #       foo: bar
     #     expectedFileOwner:
     #       users: ["0"]
@@ -118,7 +118,7 @@ providers:                   # contains information about known providers
     #       groups: ["0"]
     # - ruleID: "242451"
     #   args:
-    #     podMatchLabels:
+    #     kubeProxyMatchLabels:
     #       foo: bar
     #     nodeGroupByLabels:
     #     - foo
@@ -138,13 +138,13 @@ providers:                   # contains information about known providers
     #       groups: ["0"]
     # - ruleID: "242466"
     #   args:
-    #     podMatchLabels:
+    #     kubeProxyMatchLabels:
     #       foo: bar
     #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242467"
     #   args:
-    #     podMatchLabels:
+    #     kubeProxyMatchLabels:
     #       foo: bar
     #     nodeGroupByLabels:
     #     - foo

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -177,7 +177,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242393{
-				GroupByLabels: workerPoolGroupByLabels,
+				NodeGroupByLabels: workerPoolGroupByLabels,
 			},
 		},
 		&sharedv1r11.Rule242394{
@@ -186,7 +186,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242394{
-				GroupByLabels: workerPoolGroupByLabels,
+				NodeGroupByLabels: workerPoolGroupByLabels,
 			},
 		},
 		&sharedv1r11.Rule242395{Client: shootClient},
@@ -229,7 +229,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242404{
-				GroupByLabels: workerPoolGroupByLabels,
+				NodeGroupByLabels: workerPoolGroupByLabels,
 			},
 		},
 		rule.NewSkipRule(
@@ -244,8 +244,8 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242406{
-				GroupByLabels:    workerPoolGroupByLabels,
-				FileOwnerOptions: gardenerFileOwnerOptions,
+				NodeGroupByLabels: workerPoolGroupByLabels,
+				FileOwnerOptions:  gardenerFileOwnerOptions,
 			},
 		},
 		&sharedv1r11.Rule242407{
@@ -254,7 +254,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242407{
-				GroupByLabels: workerPoolGroupByLabels,
+				NodeGroupByLabels: workerPoolGroupByLabels,
 			},
 		},
 		rule.NewSkipRule(
@@ -406,7 +406,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242449{
-				GroupByLabels: workerPoolGroupByLabels,
+				NodeGroupByLabels: workerPoolGroupByLabels,
 			},
 		},
 		&sharedv1r11.Rule242450{
@@ -415,8 +415,8 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242450{
-				GroupByLabels:    workerPoolGroupByLabels,
-				FileOwnerOptions: gardenerFileOwnerOptions,
+				NodeGroupByLabels: workerPoolGroupByLabels,
+				FileOwnerOptions:  gardenerFileOwnerOptions,
 			},
 		},
 		&v1r11.Rule242451{
@@ -435,7 +435,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     seedClient,
 			PodContext: seedPodContext,
 			Options: &sharedv1r11.Options242452{
-				GroupByLabels: workerPoolGroupByLabels,
+				NodeGroupByLabels: workerPoolGroupByLabels,
 			},
 		},
 		&sharedv1r11.Rule242453{
@@ -444,8 +444,8 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Client:     shootClient,
 			PodContext: shootPodContext,
 			Options: &sharedv1r11.Options242453{
-				GroupByLabels:    workerPoolGroupByLabels,
-				FileOwnerOptions: gardenerFileOwnerOptions,
+				NodeGroupByLabels: workerPoolGroupByLabels,
+				FileOwnerOptions:  gardenerFileOwnerOptions,
 			},
 		},
 		rule.NewSkipRule(

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400.go
@@ -41,7 +41,7 @@ type Rule242400 struct {
 }
 
 type Options242400 struct {
-	PodMatchLabels map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
+	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
 }
 
 func (r *Rule242400) ID() string {
@@ -59,8 +59,8 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 		kubeProxySelector = labels.SelectorFromSet(labels.Set{"role": "proxy"})
 	)
 
-	if r.Options != nil && len(r.Options.PodMatchLabels) > 0 {
-		kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
+	if r.Options != nil && len(r.Options.KubeProxyMatchLabels) > 0 {
+		kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
 	}
 
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
@@ -258,7 +258,7 @@ var _ = Describe("#242400", func() {
 		Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
 
 		options := v1r11.Options242400{
-			PodMatchLabels: map[string]string{
+			KubeProxyMatchLabels: map[string]string{
 				"foo": "bar",
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
@@ -39,8 +39,8 @@ type Rule242451 struct {
 }
 
 type Options242451 struct {
-	PodMatchLabels map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
-	GroupByLabels  []string          `json:"groupByLabels" yaml:"groupByLabels"`
+	PodMatchLabels    map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
+	NodeGroupByLabels []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 	*option.FileOwnerOptions
 }
 
@@ -68,8 +68,8 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 		if len(r.Options.PodMatchLabels) > 0 {
 			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
 		}
-		if r.Options.GroupByLabels != nil {
-			nodeLabels = slices.Clone(r.Options.GroupByLabels)
+		if r.Options.NodeGroupByLabels != nil {
+			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 		}
 	}
 	if len(options.ExpectedFileOwner.Users) == 0 {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
@@ -39,8 +39,8 @@ type Rule242451 struct {
 }
 
 type Options242451 struct {
-	PodMatchLabels    map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
-	NodeGroupByLabels []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
+	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
+	NodeGroupByLabels    []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 	*option.FileOwnerOptions
 }
 
@@ -65,8 +65,8 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 		if r.Options.FileOwnerOptions != nil {
 			options = *r.Options.FileOwnerOptions
 		}
-		if len(r.Options.PodMatchLabels) > 0 {
-			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
+		if len(r.Options.KubeProxyMatchLabels) > 0 {
+			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
 		}
 		if r.Options.NodeGroupByLabels != nil {
 			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
@@ -253,7 +253,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should check only nodes wtih labels",
 			v1r11.Options242451{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{mounts, compliantStats, compliantDirStats, emptyMounts}},
 			[][]error{{nil, nil, nil, nil}},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
@@ -236,7 +236,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should check only pod with matched labels",
 			v1r11.Options242451{
-				PodMatchLabels: map[string]string{
+				KubeProxyMatchLabels: map[string]string{
 					"component": "kube-proxy",
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
@@ -38,8 +38,8 @@ type Rule242466 struct {
 }
 
 type Options242466 struct {
-	PodMatchLabels    map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
-	NodeGroupByLabels []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
+	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
+	NodeGroupByLabels    []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242466) ID() string {
@@ -60,8 +60,8 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 	)
 
 	if r.Options != nil {
-		if len(r.Options.PodMatchLabels) > 0 {
-			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
+		if len(r.Options.KubeProxyMatchLabels) > 0 {
+			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
 		}
 		if r.Options.NodeGroupByLabels != nil {
 			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
@@ -38,8 +38,8 @@ type Rule242466 struct {
 }
 
 type Options242466 struct {
-	PodMatchLabels map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
-	GroupByLabels  []string          `json:"groupByLabels" yaml:"groupByLabels"`
+	PodMatchLabels    map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
+	NodeGroupByLabels []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242466) ID() string {
@@ -63,8 +63,8 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 		if len(r.Options.PodMatchLabels) > 0 {
 			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
 		}
-		if r.Options.GroupByLabels != nil {
-			nodeLabels = slices.Clone(r.Options.GroupByLabels)
+		if r.Options.NodeGroupByLabels != nil {
+			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 		}
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
@@ -236,7 +236,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should check only nodes wtih labels",
 			v1r11.Options242466{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{mounts, compliantStats, emptyMounts}},
 			[][]error{{nil, nil, nil}},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
@@ -223,7 +223,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should check only pod with matched labels",
 			v1r11.Options242466{
-				PodMatchLabels: map[string]string{
+				KubeProxyMatchLabels: map[string]string{
 					"component": "kube-proxy",
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
@@ -38,8 +38,8 @@ type Rule242467 struct {
 }
 
 type Options242467 struct {
-	PodMatchLabels    map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
-	NodeGroupByLabels []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
+	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
+	NodeGroupByLabels    []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242467) ID() string {
@@ -60,8 +60,8 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	)
 
 	if r.Options != nil {
-		if len(r.Options.PodMatchLabels) > 0 {
-			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
+		if len(r.Options.KubeProxyMatchLabels) > 0 {
+			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
 		}
 		if r.Options.NodeGroupByLabels != nil {
 			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
@@ -38,8 +38,8 @@ type Rule242467 struct {
 }
 
 type Options242467 struct {
-	PodMatchLabels map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
-	GroupByLabels  []string          `json:"groupByLabels" yaml:"groupByLabels"`
+	PodMatchLabels    map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
+	NodeGroupByLabels []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242467) ID() string {
@@ -63,8 +63,8 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 		if len(r.Options.PodMatchLabels) > 0 {
 			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
 		}
-		if r.Options.GroupByLabels != nil {
-			nodeLabels = slices.Clone(r.Options.GroupByLabels)
+		if r.Options.NodeGroupByLabels != nil {
+			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 		}
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
@@ -236,7 +236,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should check only nodes wtih labels",
 			v1r11.Options242467{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{mounts, compliantStats, emptyMounts}},
 			[][]error{{nil, nil, nil}},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
@@ -223,7 +223,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should check only pod with matched labels",
 			v1r11.Options242467{
-				PodMatchLabels: map[string]string{
+				KubeProxyMatchLabels: map[string]string{
 					"component": "kube-proxy",
 				},
 			},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242393.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242393.go
@@ -35,7 +35,7 @@ type Rule242393 struct {
 }
 
 type Options242393 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242393) ID() string {
@@ -50,8 +50,8 @@ func (r *Rule242393) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
 	nodeLabels := []string{}
 
-	if r.Options != nil && r.Options.GroupByLabels != nil {
-		nodeLabels = slices.Clone(r.Options.GroupByLabels)
+	if r.Options != nil && r.Options.NodeGroupByLabels != nil {
+		nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 	}
 
 	pods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242393_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242393_test.go
@@ -102,7 +102,7 @@ var _ = Describe("#242393", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242393{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{"", "foo"}, {"", "foo"}},
 			[][]error{{nil, nil}, {nil, nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242394.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242394.go
@@ -35,7 +35,7 @@ type Rule242394 struct {
 }
 
 type Options242394 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242394) ID() string {
@@ -50,8 +50,8 @@ func (r *Rule242394) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
 	nodeLabels := []string{}
 
-	if r.Options != nil && r.Options.GroupByLabels != nil {
-		nodeLabels = slices.Clone(r.Options.GroupByLabels)
+	if r.Options != nil && r.Options.NodeGroupByLabels != nil {
+		nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 	}
 
 	pods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242394_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242394_test.go
@@ -102,7 +102,7 @@ var _ = Describe("#242394", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242394{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{"", "foo"}, {"", ""}},
 			[][]error{{nil, nil}, {nil, errors.New(" foo NO such file or directory  ")}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242396.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242396.go
@@ -38,7 +38,7 @@ type Rule242396 struct {
 }
 
 type Options242396 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242396) ID() string {
@@ -55,8 +55,8 @@ func (r *Rule242396) Run(ctx context.Context) (rule.RuleResult, error) {
 		checkResults []rule.CheckResult
 	)
 
-	if r.Options != nil && r.Options.GroupByLabels != nil {
-		nodeLabels = slices.Clone(r.Options.GroupByLabels)
+	if r.Options != nil && r.Options.NodeGroupByLabels != nil {
+		nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 	}
 
 	pods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242396_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242396_test.go
@@ -108,7 +108,7 @@ var _ = Describe("#242396", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242396{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{allowedKubectlVersion}, {allowedKubectlVersion}},
 			[][]error{{nil}, {nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242404.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242404.go
@@ -33,7 +33,7 @@ type Rule242404 struct {
 }
 
 type Options242404 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242404) ID() string {
@@ -48,8 +48,8 @@ func (r *Rule242404) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
 	nodeLabels := []string{}
 
-	if r.Options != nil && r.Options.GroupByLabels != nil {
-		nodeLabels = slices.Clone(r.Options.GroupByLabels)
+	if r.Options != nil && r.Options.NodeGroupByLabels != nil {
+		nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 	}
 
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242404_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242404_test.go
@@ -89,7 +89,7 @@ var _ = Describe("#242404", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242404{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{kubeletPID, "--hostname-override=/foo/bar --config=./config"}},
 			[][]error{{nil, nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242406.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242406.go
@@ -34,7 +34,7 @@ type Rule242406 struct {
 }
 
 type Options242406 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 	*option.FileOwnerOptions
 }
 
@@ -56,8 +56,8 @@ func (r *Rule242406) Run(ctx context.Context) (rule.RuleResult, error) {
 		if r.Options.FileOwnerOptions != nil {
 			options = *r.Options.FileOwnerOptions
 		}
-		if r.Options.GroupByLabels != nil {
-			nodeLabels = slices.Clone(r.Options.GroupByLabels)
+		if r.Options.NodeGroupByLabels != nil {
+			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 		}
 	}
 	if len(options.ExpectedFileOwner.Users) == 0 {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242406_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242406_test.go
@@ -111,7 +111,7 @@ var _ = Describe("#242406", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			sharedv1r11.Options242406{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{kubeletServicePath, compliantKubeletServiceFileStats}, {kubeletServicePath, compliantKubeletServiceFileStats}},
 			[][]error{{nil, nil}, {nil, nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242407.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242407.go
@@ -33,7 +33,7 @@ type Rule242407 struct {
 }
 
 type Options242407 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242407) ID() string {
@@ -50,8 +50,8 @@ func (r *Rule242407) Run(ctx context.Context) (rule.RuleResult, error) {
 	expectedFilePermissionsMax := "644"
 	nodeLabels := []string{}
 
-	if r.Options != nil && r.Options.GroupByLabels != nil {
-		nodeLabels = slices.Clone(r.Options.GroupByLabels)
+	if r.Options != nil && r.Options.NodeGroupByLabels != nil {
+		nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 	}
 
 	pods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242407_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242407_test.go
@@ -109,7 +109,7 @@ var _ = Describe("#242407", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242407{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{kubeletServicePath, compliantKubeletServiceFileStats}, {kubeletServicePath, compliantKubeletServiceFileStats}},
 			[][]error{{nil, nil}, {nil, nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242447.go
@@ -37,7 +37,7 @@ type Rule242447 struct {
 }
 
 type Options242447 struct {
-	PodMatchLabels map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
+	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
 }
 
 func (r *Rule242447) ID() string {
@@ -52,8 +52,8 @@ func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
 	kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
 
-	if r.Options != nil && len(r.Options.PodMatchLabels) > 0 {
-		kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
+	if r.Options != nil && len(r.Options.KubeProxyMatchLabels) > 0 {
+		kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
 	}
 
 	target := rule.NewTarget()

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242447_test.go
@@ -209,7 +209,7 @@ var _ = Describe("#242447", func() {
 			}),
 		Entry("should check only pod with matched labels",
 			v1r11.Options242447{
-				PodMatchLabels: map[string]string{
+				KubeProxyMatchLabels: map[string]string{
 					"component": "kube-proxy",
 				},
 			},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242448.go
@@ -38,7 +38,7 @@ type Rule242448 struct {
 }
 
 type Options242448 struct {
-	PodMatchLabels map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
+	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
 	*option.FileOwnerOptions
 }
 
@@ -59,8 +59,8 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 		if r.Options.FileOwnerOptions != nil {
 			options = *r.Options.FileOwnerOptions
 		}
-		if len(r.Options.PodMatchLabels) > 0 {
-			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.PodMatchLabels))
+		if len(r.Options.KubeProxyMatchLabels) > 0 {
+			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
 		}
 	}
 	if len(options.ExpectedFileOwner.Users) == 0 {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242448_test.go
@@ -210,7 +210,7 @@ var _ = Describe("#242448", func() {
 			}),
 		Entry("should check only pod with matched labels",
 			v1r11.Options242448{
-				PodMatchLabels: map[string]string{
+				KubeProxyMatchLabels: map[string]string{
 					"component": "kube-proxy",
 				},
 			},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242449.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242449.go
@@ -34,7 +34,7 @@ type Rule242449 struct {
 }
 
 type Options242449 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242449) ID() string {
@@ -50,8 +50,8 @@ func (r *Rule242449) Run(ctx context.Context) (rule.RuleResult, error) {
 	expectedFilePermissionsMax := "644"
 	nodeLabels := []string{}
 
-	if r.Options != nil && r.Options.GroupByLabels != nil {
-		nodeLabels = slices.Clone(r.Options.GroupByLabels)
+	if r.Options != nil && r.Options.NodeGroupByLabels != nil {
+		nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 	}
 
 	pods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242449_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242449_test.go
@@ -113,7 +113,7 @@ var _ = Describe("#242449", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242449{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{kubeletPID, rawKubeletCommand, kubeletConfig, compliantClientCAFileStats}, {kubeletPID, rawKubeletCommand, kubeletConfig, compliantClientCAFileStats}},
 			[][]error{{nil, nil, nil, nil}, {nil, nil, nil, nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242450.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242450.go
@@ -35,7 +35,7 @@ type Rule242450 struct {
 }
 
 type Options242450 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 	*option.FileOwnerOptions
 }
 
@@ -56,8 +56,8 @@ func (r *Rule242450) Run(ctx context.Context) (rule.RuleResult, error) {
 		if r.Options.FileOwnerOptions != nil {
 			options = *r.Options.FileOwnerOptions
 		}
-		if r.Options.GroupByLabels != nil {
-			nodeLabels = slices.Clone(r.Options.GroupByLabels)
+		if r.Options.NodeGroupByLabels != nil {
+			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 		}
 	}
 	if len(options.ExpectedFileOwner.Users) == 0 {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242450_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242450_test.go
@@ -115,7 +115,7 @@ var _ = Describe("#242450", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242450{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{kubeletPID, rawKubeletCommand, kubeletConfig, compliantClientCAFileStats}, {kubeletPID, rawKubeletCommand, kubeletConfig, compliantClientCAFileStats}},
 			[][]error{{nil, nil, nil, nil}, {nil, nil, nil, nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242452.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242452.go
@@ -34,7 +34,7 @@ type Rule242452 struct {
 }
 
 type Options242452 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 func (r *Rule242452) ID() string {
@@ -50,8 +50,8 @@ func (r *Rule242452) Run(ctx context.Context) (rule.RuleResult, error) {
 	expectedFilePermissionsMax := "644"
 	nodeLabels := []string{}
 
-	if r.Options != nil && r.Options.GroupByLabels != nil {
-		nodeLabels = slices.Clone(r.Options.GroupByLabels)
+	if r.Options != nil && r.Options.NodeGroupByLabels != nil {
+		nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 	}
 
 	pods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242452_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242452_test.go
@@ -114,7 +114,7 @@ var _ = Describe("#242452", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242452{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{kubeletPID, rawKubeletCommand, compliantKubeconfigStats, compliantConfigStats}, {kubeletPID, rawKubeletCommand, compliantKubeconfigStats, compliantConfigStats}},
 			[][]error{{nil, nil, nil, nil}, {nil, nil, nil, nil}},

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242453.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242453.go
@@ -35,7 +35,7 @@ type Rule242453 struct {
 }
 
 type Options242453 struct {
-	GroupByLabels []string `json:"groupByLabels" yaml:"groupByLabels"`
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 	*option.FileOwnerOptions
 }
 
@@ -56,8 +56,8 @@ func (r *Rule242453) Run(ctx context.Context) (rule.RuleResult, error) {
 		if r.Options.FileOwnerOptions != nil {
 			options = *r.Options.FileOwnerOptions
 		}
-		if r.Options.GroupByLabels != nil {
-			nodeLabels = slices.Clone(r.Options.GroupByLabels)
+		if r.Options.NodeGroupByLabels != nil {
+			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
 		}
 	}
 	if len(options.ExpectedFileOwner.Users) == 0 {

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242453_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242453_test.go
@@ -115,7 +115,7 @@ var _ = Describe("#242453", func() {
 			}),
 		Entry("should return correct checkResults only for selected nodes",
 			v1r11.Options242453{
-				GroupByLabels: []string{"foo"},
+				NodeGroupByLabels: []string{"foo"},
 			},
 			[][]string{{kubeletPID, rawKubeletCommand, compliantKubeconfigStats, compliantConfigStats}, {kubeletPID, rawKubeletCommand, compliantKubeconfigStats, compliantConfigStats}},
 			[][]error{{nil, nil, nil, nil}, {nil, nil, nil, nil}},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
