### PR TITLE
Remove unnecessary kubeconfig from virtual garden provider

### DIFF
--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -4,7 +4,6 @@ providers:               # contains information about known providers
   metadata:
     foo: bar
   args:
-    gardenKubeconfigPath: /tmp/garden.config    # path to garden cluster admin kubeconfig
     runtimeKubeconfigPath: /tmp/runtime.config  # path to runtime cluster admin kubeconfig
   rulesets:
   - id: disa-kubernetes-stig

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -22,7 +22,6 @@ func VirtualGardenProviderFromConfig(conf config.ProviderConfig) (provider.Provi
 		return nil, err
 	}
 
-	setConfigDefaults(p.GardenConfig)
 	setConfigDefaults(p.RuntimeConfig)
 	providerLogger := slog.Default().With("provider", p.ID())
 	setLoggerFunc := virtualgarden.WithLogger(providerLogger)
@@ -31,7 +30,7 @@ func VirtualGardenProviderFromConfig(conf config.ProviderConfig) (provider.Provi
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.GardenConfig, p.RuntimeConfig)
+			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.RuntimeConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/virtualgarden/options.go
+++ b/pkg/provider/virtualgarden/options.go
@@ -35,13 +35,6 @@ func WithRuntimeConfig(config *rest.Config) CreateOption {
 	}
 }
 
-// WithGardenConfig sets the SeedConfig of a [Provider].
-func WithGardenConfig(config *rest.Config) CreateOption {
-	return func(p *Provider) {
-		p.GardenConfig = config
-	}
-}
-
 // WithMetadata sets the metadata of a [Provider].
 func WithMetadata(metadata map[string]string) CreateOption {
 	return func(p *Provider) {

--- a/pkg/provider/virtualgarden/provider.go
+++ b/pkg/provider/virtualgarden/provider.go
@@ -24,16 +24,15 @@ import (
 // Provider is a Garden Cluster Provider that can be used to implement rules
 // against a virtual garden cluster and its controlplane (residing in a runtime cluster).
 type Provider struct {
-	id, name                    string
-	RuntimeConfig, GardenConfig *rest.Config
-	rulesets                    map[string]ruleset.Ruleset
-	metadata                    map[string]string
-	logger                      *slog.Logger
+	id, name      string
+	RuntimeConfig *rest.Config
+	rulesets      map[string]ruleset.Ruleset
+	metadata      map[string]string
+	logger        *slog.Logger
 }
 
 type providerArgs struct {
 	RuntimeKubeconfigPath string
-	GardenKubeconfigPath  string
 }
 
 var _ provider.Provider = &Provider{}
@@ -50,10 +49,6 @@ func New(options ...CreateOption) (*Provider, error) {
 	var err error
 	if p.RuntimeConfig == nil {
 		err = errors.Join(err, errors.New("runtime cluster config is nil"))
-	}
-
-	if p.GardenConfig == nil {
-		err = errors.Join(err, errors.New("garden cluster config is nil"))
 	}
 
 	if err != nil {
@@ -138,15 +133,9 @@ func FromGenericConfig(providerConf config.ProviderConfig) (*Provider, error) {
 		return nil, err
 	}
 
-	gardenKubeconfig, err := kubeutils.RESTConfigFromFile(providerGardenArgs.GardenKubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-
 	gardenProvider, err := New(
 		WithID(providerConf.ID),
 		WithName(providerConf.Name),
-		WithGardenConfig(gardenKubeconfig),
 		WithRuntimeConfig(runtimeKubeconfig),
 		WithMetadata(providerConf.Metadata),
 	)

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
@@ -21,13 +21,6 @@ func WithVersion(version string) CreateOption {
 	}
 }
 
-// WithGardenConfig sets the GardenConfig of a [Ruleset].
-func WithGardenConfig(config *rest.Config) CreateOption {
-	return func(r *Ruleset) {
-		r.GardenConfig = config
-	}
-}
-
 // WithRuntimeConfig sets the RuntimeConfig of a [Ruleset].
 func WithRuntimeConfig(config *rest.Config) CreateOption {
 	return func(r *Ruleset) {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -27,12 +27,12 @@ var _ ruleset.Ruleset = &Ruleset{}
 
 // Ruleset implements DISA Kubernetes STIG.
 type Ruleset struct {
-	version                     string
-	rules                       map[string]rule.Rule
-	GardenConfig, RuntimeConfig *rest.Config
-	numWorkers                  int
-	instanceID                  string
-	logger                      *slog.Logger
+	version       string
+	rules         map[string]rule.Rule
+	RuntimeConfig *rest.Config
+	numWorkers    int
+	instanceID    string
+	logger        *slog.Logger
 }
 
 // New creates a new Ruleset.
@@ -66,10 +66,9 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, gardenConfig, runtimeConfig *rest.Config) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, runtimeConfig *rest.Config) (*Ruleset, error) {
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
-		WithGardenConfig(gardenConfig),
 		WithRuntimeConfig(runtimeConfig),
 	)
 	if err != nil {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -7,7 +7,6 @@ package disak8sstig
 import (
 	"encoding/json"
 
-	kubernetesgardener "github.com/gardener/gardener/pkg/client/kubernetes"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -21,11 +20,6 @@ import (
 
 func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
 	runtimeClient, err := client.New(r.RuntimeConfig, client.Options{})
-	if err != nil {
-		return err
-	}
-
-	_, err = client.New(r.GardenConfig, client.Options{Scheme: kubernetesgardener.GardenScheme})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes unnecessary kubeconfig requirement from virtual garden provider.

**Which issue(s) this PR fixes**:
Fixes #169

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Virtual Garden provider no longer requires garden kubeconfig to execute rulesets.
```
