### PR TITLE
[Docu] How to run Managed K8S ruleset on a Gardener shoot cluster

### DIFF
--- a/docs/usage/partial-disa-k8s-stig-shoot.md
+++ b/docs/usage/partial-disa-k8s-stig-shoot.md
@@ -1,0 +1,36 @@
+## Run Partial DISA k8s STIGs ruleset against a Gardener shoot cluster
+
+### Introduction
+
+This part shows how to run the DISA k8s STIGs ruleset against a Gardener shoot cluster when you do not access to a seed kubeconfig. The `managedk8s` provider is used which does not check `ControlPlane` components.
+
+### Prerequisites
+
+Make sure you have installed diki (how to install diki can be found [here](../../README.md#Installation)) and have a running Gardener shoot cluster.
+
+### Configuration
+
+We will be using the [guides partial-disa-k8s-stig-shoot configuration](../../example/guides/partial-disa-k8s-stig-shoot.yaml) for this run. You will need to modify the `provider.args` field with correct shoot admin kubeconfig. You can can find a guide on how to get the kubeconfig [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md).
+
+The provided configuration contains the recommended rule options for running the `managedk8s` provider ruleset against a shoot cluster. For specific cluster the rule options can be changed in order for the report to show more accurate compliance. A full picture of all rule options can be found [here](../../example/config/managedk8s.yaml).
+
+### Run diki
+
+To run diki against a Gardener shoot cluster we can simply use the `run` command:
+```bash
+diki run --config=./example/guides/managedshoot.yaml --provider=managedk8s --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
+```
+
+We can also select a single rule to be ran with the `--rule-id` flag:
+```bash
+diki run --config=./example/guides/managedshoot.yaml --provider=managedk8s --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
+```
+
+### Generate diki report
+
+After running diki an output file is generated if the `output.path` configuration is set. In the example config it is set to `/tmp/output.json`. We can use this file to create a html diki report using the following command:
+```bash
+diki run --config=./example/guides/managedshoot.yaml --provider=managedk8s --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
+```
+diki report /tmp/output.json > /tmp/output.html
+```

--- a/docs/usage/partial-disa-k8s-stig-shoot.md
+++ b/docs/usage/partial-disa-k8s-stig-shoot.md
@@ -10,7 +10,7 @@ Make sure you have diki installed ([diki installation instructions](../../README
 
 ### Configuration
 
-We will be using the sample [partial-disa-k8s-stig-shoot configuration file](../../example/guides/partial-disa-k8s-stig-shoot.yaml) for this run. You will need to set the `provider.args.kubeconfigPath` field pointing to a shoot admin kubeconfig. In case you need instructions on how to generate such kubeconfig, please read the [shoot access guide](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md).
+We will be using the sample [partial-disa-k8s-stig-shoot configuration file](../../example/guides/partial-disa-k8s-stig-shoot.yaml) for this run. You will need to set the `provider.args.kubeconfigPath` field pointing to a shoot admin kubeconfig. In case you need instructions on how to generate such kubeconfig, please read the [shoot access guide](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md). Additional metadata such as the shoot's name can also be included in the `provider.metadata` section. The metadata section can be used to add addtional context to different diki runs.
 
 The provided configuration contains the recommended rule options for running the `managedk8s` provider ruleset against a shoot cluster, but one can modify rule options parameters according to requirements. All available options can be found in the [managedk8s example configuration](../../example/config/managedk8s.yaml).
 

--- a/docs/usage/partial-disa-k8s-stig-shoot.md
+++ b/docs/usage/partial-disa-k8s-stig-shoot.md
@@ -30,7 +30,5 @@ diki run --config=./example/guides/managedshoot.yaml --provider=managedk8s --rul
 
 After running diki an output file is generated if the `output.path` configuration is set. In the example config it is set to `/tmp/output.json`. We can use this file to create a html diki report using the following command:
 ```bash
-diki run --config=./example/guides/managedshoot.yaml --provider=managedk8s --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
-```
-diki report /tmp/output.json > /tmp/output.html
+diki report generate --output=/tmp/output.html /tmp/output.json
 ```

--- a/docs/usage/partial-disa-k8s-stig-shoot.md
+++ b/docs/usage/partial-disa-k8s-stig-shoot.md
@@ -1,34 +1,36 @@
-## Run Partial DISA k8s STIGs ruleset against a Gardener shoot cluster
+## Run Partial DISA K8s STIGs ruleset against a Gardener shoot cluster
 
 ### Introduction
 
-This part shows how to run the DISA k8s STIGs ruleset against a Gardener shoot cluster when you do not access to a seed kubeconfig. The `managedk8s` provider is used which does not check `ControlPlane` components.
+This part shows how to run the DISA K8s STIGs ruleset against a Gardener shoot cluster. The `managedk8s` provider is used which does not check control plane components.
 
 ### Prerequisites
 
-Make sure you have installed diki (how to install diki can be found [here](../../README.md#Installation)) and have a running Gardener shoot cluster.
+Make sure you have diki installed ([diki installation instructions](../../README.md#Installation)) and have a running Gardener shoot cluster.
 
 ### Configuration
 
-We will be using the [guides partial-disa-k8s-stig-shoot configuration](../../example/guides/partial-disa-k8s-stig-shoot.yaml) for this run. You will need to modify the `provider.args` field with correct shoot admin kubeconfig. You can can find a guide on how to get the kubeconfig [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md).
+We will be using the sample [partial-disa-k8s-stig-shoot configuration file](../../example/guides/partial-disa-k8s-stig-shoot.yaml) for this run. You will need to set the `provider.args.kubeconfigPath` field pointing to a shoot admin kubeconfig. In case you need instructions on how to generate such kubeconfig, please read the [shoot access guide](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md).
 
-The provided configuration contains the recommended rule options for running the `managedk8s` provider ruleset against a shoot cluster. For specific cluster the rule options can be changed in order for the report to show more accurate compliance. A full picture of all rule options can be found [here](../../example/config/managedk8s.yaml).
+The provided configuration contains the recommended rule options for running the `managedk8s` provider ruleset against a shoot cluster, but one can modify rule options parameters according to requirements. All available options can be found in the [managedk8s example configuration](../../example/config/managedk8s.yaml).
 
-### Run diki
+### Run DISA K8s STIGs ruleset
 
-To run diki against a Gardener shoot cluster we can simply use the `run` command:
+To run diki against a Gardener shoot cluster run the following command:
 ```bash
-diki run --config=./example/guides/managedshoot.yaml --provider=managedk8s --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11
+diki run \
+    --config=./example/guides/managedshoot.yaml \
+    --provider=managedk8s \
+    --ruleset-id=disa-kubernetes-stig \
+    --ruleset-version=v1r11 \
+    --output=disa-k8s-stigs-report.json
 ```
 
-We can also select a single rule to be ran with the `--rule-id` flag:
-```bash
-diki run --config=./example/guides/managedshoot.yaml --provider=managedk8s --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11 --rule-id=242414
-```
+### Generate a report
 
-### Generate diki report
-
-After running diki an output file is generated if the `output.path` configuration is set. In the example config it is set to `/tmp/output.json`. We can use this file to create a html diki report using the following command:
+We can use the file generated in the previous step to create an html report using the following command:
 ```bash
-diki report generate --output=/tmp/output.html /tmp/output.json
+diki report generate \
+    --output=disa-k8s-stigs-report.json \
+    disa-k8s-stigs-report.html
 ```

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -29,6 +29,13 @@ providers:                   # contains information about known providers
     #       status: Passed
     # - ruleID: "242393"
     #   args:
+    #     # Diki will group nodes by the value of this label
+    #     # and perform the rule checks on a single node from each group.
+    #     # Skip these labels if you want diki 
+    #     # to perform checks on all nodes in the cluster.
+    #     # Mind that not providing a set of labels to group by
+    #     # can slow down the execution of the ruleset and spawn
+    #     # additional pods in the cluster.
     #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242394"

--- a/example/guides/partial-disa-k8s-stig-shoot.yaml
+++ b/example/guides/partial-disa-k8s-stig-shoot.yaml
@@ -2,7 +2,8 @@ providers:
 - id: managedk8s
   name: "Managed Kubernetes"
   metadata:
-    foo: bar
+    # foo: bar
+    shootName: shoot-abcd
   args:
     kubeconfigPath: /shoot-abcd-access/kubeconfig  # path to shoot admin kubeconfig
   rulesets:

--- a/example/guides/partial-disa-k8s-stig-shoot.yaml
+++ b/example/guides/partial-disa-k8s-stig-shoot.yaml
@@ -4,7 +4,7 @@ providers:
   metadata:
     foo: bar
   args:
-    kubeconfigPath: /tmp/kubeconfig.config  # path to shoot admin kubeconfig
+    kubeconfigPath: /shoot-abcd-access/kubeconfig  # path to shoot admin kubeconfig
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
@@ -12,6 +12,13 @@ providers:
     ruleOptions:
     - ruleID: "242393"
       args:
+        # Diki will group nodes by the value of this label
+        # and perform the rule checks on a single node from each group.
+        # Skip these labels if you want diki 
+        # to perform checks on all nodes in the cluster.
+        # Mind that not providing a set of labels to group by
+        # can slow down the execution of the ruleset and spawn
+        # additional pods in the cluster.
         nodeGroupByLabels:
         - worker.gardener.cloud/pool
     - ruleID: "242394"
@@ -84,5 +91,4 @@ providers:
         nodeGroupByLabels:
         - worker.gardener.cloud/pool
 output:
-  path: /tmp/output.json  # optional, path to summary json report
   minStatus: Passed

--- a/example/guides/partial-disa-k8s-stig-shoot.yaml
+++ b/example/guides/partial-disa-k8s-stig-shoot.yaml
@@ -1,0 +1,88 @@
+providers:
+- id: managedk8s
+  name: "Managed Kubernetes"
+  metadata:
+    foo: bar
+  args:
+    kubeconfigPath: /tmp/kubeconfig.config  # path to shoot admin kubeconfig
+  rulesets:
+  - id: disa-kubernetes-stig
+    name: DISA Kubernetes Security Technical Implementation Guide
+    version: v1r11
+    ruleOptions:
+    - ruleID: "242393"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242394"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242396"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242404"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242406"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242407"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242414"
+      args:
+        acceptedPods:
+        - podMatchLabels:
+            k8s-app: node-local-dns
+          namespaceMatchLabels:
+            kubernetes.io/metadata.name: kube-system
+          justification: "node local dns requires port 53 in order to operate properly"
+          ports:
+          - 53
+    - ruleID: "242417"
+      args:
+        acceptedPods:
+        - podMatchLabels:
+            resources.gardener.cloud/managed-by: gardener
+          namespaceNames:
+          - kube-system
+          - kube-public
+          - kube-node-lease
+          justification: "justification"
+          status: Passed
+    - ruleID: "242449"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242450"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242451"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242452"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242453"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242466"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+    - ruleID: "242467"
+      args:
+        nodeGroupByLabels:
+        - worker.gardener.cloud/pool
+output:
+  path: /tmp/output.json  # optional, path to summary json report
+  minStatus: Passed


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds documentation on how to run Managed K8S ruleset on a Gardener shoot cluster.

**Which issue(s) this PR fixes**:
Fixes #174 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
