### PR TITLE
Add renovate config improvements

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,13 +18,21 @@
       "datasourceTemplate": "docker"
     },
     {
-      // Generic detection for install manifests from GitHub releases.
+      // Generic detection for go version in github-actions.
+      "customType": "regex",
+      "fileMatch": ["^\.github\/workflows\/upload-diki-binaries.yaml$"],
+      "matchStrings": ["go-version: '(?<currentValue>.*?)'\\s"],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "docker"
+    },
+    {
+      // Generic detection for nerdctl binary in Dockerfile.
       "customType": "regex",
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": [
-        "https:\/\/github\\.com\/(?<depName>[^/]*\/[^/]*?)\/releases\/download\/(?<currentValue>.*?)\/",
-        "https:\/\/raw\\.githubusercontent\\.com\/(?<depName>[^/]*\/[^/]*?)\/(?<currentValue>.*?)\/",
+        "https:\/\/github\\.com\/containerd\/nerdctl\/releases\/download\/.*?\/nerdctl-(?<currentValue>.*?)-linux",
       ],
+      "depNameTemplate": "containerd/nerdctl",
       "datasourceTemplate": "github-releases"
     }
   ],
@@ -32,8 +40,8 @@
     {
       // Group golang updates in one PR.
       "groupName": "golang",
-      "matchDatasources": ["docker", "go-version"],
-      "matchPackagePatterns": ["golang"],
+      "matchDatasources": ["docker", "go", "golang-version"],
+      "matchPackageNames": ["go", "golang"],
     },
     {
       // Update only patchlevels of major dependencies like kubernetes and controller-runtime.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the renovate config by:
- Adding detection for go-lang version in github-actions
- Specifying nerdctl manifest in Dockerfile
- Fixing golang version update group

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
