### PR TITLE
Add output flag to diki run

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Most of Diki's `run` configurations are provided through its [config file](./con
 diki run --config=config.yaml --all
 ```
 
+- Run all known rulesets for all known providers and save json report data into a file
+```bash
+diki run --config=config.yaml --all --output=/tmp/report.json
+```
+
 - Run a specific ruleset for a known provider
 ```bash
 diki run --config=config.yaml --provider=gardener --ruleset-id=disa-kubernetes-stig --ruleset-version=v1r11

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Most of Diki's `run` configurations are provided through its [config file](./con
 diki run --config=config.yaml --all
 ```
 
-- Run all known rulesets for all known providers and save json report data into a file
+- Run all known rulesets for all known providers and create a summary json report file
 ```bash
 diki run --config=config.yaml --all --output=/tmp/report.json
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ diki run --config=config.yaml --all
 
 - Run all known rulesets for all known providers and create a summary json report file
 ```bash
-diki run --config=config.yaml --all --output=/tmp/report.json
+diki run --config=config.yaml --all --output=./report.json
 ```
 
 - Run a specific ruleset for a known provider

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -120,7 +120,6 @@ func addReportFlags(cmd *cobra.Command, opts *reportOptions) {
 
 func addRunFlags(cmd *cobra.Command, opts *runOptions) {
 	cmd.PersistentFlags().StringVar(&opts.outputPath, "output", "", "If set diki creates an summary json report at the given path.")
-	cmd.PersistentFlags().StringVar(&opts.minStatus, "min-status", "Passed", "Minimal status for json report. Defaults to Passed.")
 	cmd.PersistentFlags().StringVar(&opts.configFile, "config", "", "Configuration file for diki containing info about providers and rulesets.")
 	cmd.PersistentFlags().BoolVar(&opts.all, "all", false, "If set to true diki will run all rulesets for all known providers.")
 	cmd.PersistentFlags().StringVar(&opts.provider, "provider", "", "The provider that should be used to run checks.")
@@ -249,6 +248,11 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 		return err
 	}
 
+	outputPath := opts.outputPath
+	if len(outputPath) == 0 && dikiConfig.Output != nil && len(dikiConfig.Output.Path) > 0 {
+		outputPath = dikiConfig.Output.Path
+	}
+
 	providers, err := getProvidersFromConfig(dikiConfig, providerCreateFuncs)
 	if err != nil {
 		return err
@@ -264,10 +268,13 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 			providerResults = append(providerResults, res)
 		}
 
-		if len(opts.outputPath) > 0 {
-			reportOpts := []report.ReportOption{report.MinStatus(opts.minStatus)}
+		if len(outputPath) > 0 {
+			reportOpts := []report.ReportOption{}
+			if dikiConfig.Output != nil && len(dikiConfig.Output.MinStatus) > 0 {
+				reportOpts = append(reportOpts, report.MinStatus(dikiConfig.Output.MinStatus))
+			}
 			rep := report.FromProviderResults(providerResults, reportOpts...)
-			return rep.WriteToFile(opts.outputPath)
+			return rep.WriteToFile(outputPath)
 		}
 		return nil
 	}
@@ -286,10 +293,13 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 		}
 		providerResults := []provider.ProviderResult{res}
 
-		if len(opts.outputPath) > 0 {
-			reportOpts := []report.ReportOption{report.MinStatus(opts.minStatus)}
+		if len(outputPath) > 0 {
+			reportOpts := []report.ReportOption{}
+			if dikiConfig.Output != nil && len(dikiConfig.Output.MinStatus) > 0 {
+				reportOpts = append(reportOpts, report.MinStatus(dikiConfig.Output.MinStatus))
+			}
 			rep := report.FromProviderResults(providerResults, reportOpts...)
-			return rep.WriteToFile(opts.outputPath)
+			return rep.WriteToFile(outputPath)
 		}
 		return nil
 	case opts.rulesetID != "" && opts.rulesetVersion == "":
@@ -306,10 +316,13 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 		}
 		providerResults := []provider.ProviderResult{{ProviderID: p.ID(), ProviderName: p.Name(), RulesetResults: []ruleset.RulesetResult{res}}}
 
-		if len(opts.outputPath) > 0 {
-			reportOpts := []report.ReportOption{report.MinStatus(opts.minStatus)}
+		if len(outputPath) > 0 {
+			reportOpts := []report.ReportOption{}
+			if dikiConfig.Output != nil && len(dikiConfig.Output.MinStatus) > 0 {
+				reportOpts = append(reportOpts, report.MinStatus(dikiConfig.Output.MinStatus))
+			}
 			rep := report.FromProviderResults(providerResults, reportOpts...)
-			return rep.WriteToFile(opts.outputPath)
+			return rep.WriteToFile(outputPath)
 		}
 		return nil
 	}
@@ -338,7 +351,6 @@ type reportOptions struct {
 
 type runOptions struct {
 	outputPath     string
-	minStatus      string
 	configFile     string
 	all            bool
 	provider       string

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -119,7 +119,7 @@ func addReportFlags(cmd *cobra.Command, opts *reportOptions) {
 }
 
 func addRunFlags(cmd *cobra.Command, opts *runOptions) {
-	cmd.PersistentFlags().StringVar(&opts.outputPath, "output", "", "Output path.")
+	cmd.PersistentFlags().StringVar(&opts.outputPath, "output", "", "If set diki creates an summary json report at the given path.")
 	cmd.PersistentFlags().StringVar(&opts.minStatus, "min-status", "Passed", "Minimal status for json report. Defaults to Passed.")
 	cmd.PersistentFlags().StringVar(&opts.configFile, "config", "", "Configuration file for diki containing info about providers and rulesets.")
 	cmd.PersistentFlags().BoolVar(&opts.all, "all", false, "If set to true diki will run all rulesets for all known providers.")

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -119,6 +119,8 @@ func addReportFlags(cmd *cobra.Command, opts *reportOptions) {
 }
 
 func addRunFlags(cmd *cobra.Command, opts *runOptions) {
+	cmd.PersistentFlags().StringVar(&opts.outputPath, "output", "", "Output path.")
+	cmd.PersistentFlags().StringVar(&opts.minStatus, "min-status", "Passed", "Minimal status for json report. Defaults to Passed.")
 	cmd.PersistentFlags().StringVar(&opts.configFile, "config", "", "Configuration file for diki containing info about providers and rulesets.")
 	cmd.PersistentFlags().BoolVar(&opts.all, "all", false, "If set to true diki will run all rulesets for all known providers.")
 	cmd.PersistentFlags().StringVar(&opts.provider, "provider", "", "The provider that should be used to run checks.")
@@ -262,13 +264,10 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 			providerResults = append(providerResults, res)
 		}
 
-		if dikiConfig.Output != nil && dikiConfig.Output.Path != "" {
-			opts := []report.ReportOption{}
-			if dikiConfig.Output.MinStatus != "" {
-				opts = append(opts, report.MinStatus(dikiConfig.Output.MinStatus))
-			}
-			rep := report.FromProviderResults(providerResults, opts...)
-			return rep.WriteToFile(dikiConfig.Output.Path)
+		if len(opts.outputPath) > 0 {
+			reportOpts := []report.ReportOption{report.MinStatus(opts.minStatus)}
+			rep := report.FromProviderResults(providerResults, reportOpts...)
+			return rep.WriteToFile(opts.outputPath)
 		}
 		return nil
 	}
@@ -287,13 +286,10 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 		}
 		providerResults := []provider.ProviderResult{res}
 
-		if dikiConfig.Output != nil && dikiConfig.Output.Path != "" {
-			opts := []report.ReportOption{}
-			if dikiConfig.Output.MinStatus != "" {
-				opts = append(opts, report.MinStatus(dikiConfig.Output.MinStatus))
-			}
-			rep := report.FromProviderResults(providerResults, opts...)
-			return rep.WriteToFile(dikiConfig.Output.Path)
+		if len(opts.outputPath) > 0 {
+			reportOpts := []report.ReportOption{report.MinStatus(opts.minStatus)}
+			rep := report.FromProviderResults(providerResults, reportOpts...)
+			return rep.WriteToFile(opts.outputPath)
 		}
 		return nil
 	case opts.rulesetID != "" && opts.rulesetVersion == "":
@@ -310,13 +306,10 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 		}
 		providerResults := []provider.ProviderResult{{ProviderID: p.ID(), ProviderName: p.Name(), RulesetResults: []ruleset.RulesetResult{res}}}
 
-		if dikiConfig.Output != nil && dikiConfig.Output.Path != "" {
-			opts := []report.ReportOption{}
-			if dikiConfig.Output.MinStatus != "" {
-				opts = append(opts, report.MinStatus(dikiConfig.Output.MinStatus))
-			}
-			rep := report.FromProviderResults(providerResults, opts...)
-			return rep.WriteToFile(dikiConfig.Output.Path)
+		if len(opts.outputPath) > 0 {
+			reportOpts := []report.ReportOption{report.MinStatus(opts.minStatus)}
+			rep := report.FromProviderResults(providerResults, reportOpts...)
+			return rep.WriteToFile(opts.outputPath)
 		}
 		return nil
 	}
@@ -344,6 +337,8 @@ type reportOptions struct {
 }
 
 type runOptions struct {
+	outputPath     string
+	minStatus      string
 	configFile     string
 	all            bool
 	provider       string

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -119,7 +119,7 @@ func addReportFlags(cmd *cobra.Command, opts *reportOptions) {
 }
 
 func addRunFlags(cmd *cobra.Command, opts *runOptions) {
-	cmd.PersistentFlags().StringVar(&opts.outputPath, "output", "", "If set diki creates an summary json report at the given path.")
+	cmd.PersistentFlags().StringVar(&opts.outputPath, "output", "", "If set diki writes a summary json report to the given file path.")
 	cmd.PersistentFlags().StringVar(&opts.configFile, "config", "", "Configuration file for diki containing info about providers and rulesets.")
 	cmd.PersistentFlags().BoolVar(&opts.all, "all", false, "If set to true diki will run all rulesets for all known providers.")
 	cmd.PersistentFlags().StringVar(&opts.provider, "provider", "", "The provider that should be used to run checks.")

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -81,6 +81,3 @@ providers:             # contains information about known providers
     - ruleID: "254800"
       args:
         minPodSecurityLevel: "baseline"
-output:
-  path: /tmp/test-output.json          #  optional, path to summary json report
-  minStatus: Passed

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -81,3 +81,6 @@ providers:             # contains information about known providers
     - ruleID: "254800"
       args:
         minPodSecurityLevel: "baseline"
+output:
+  path: /tmp/test-output.json # optional, path to summary json report. If --output flag is set this configuration is ignored
+  minStatus: Passed

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -152,6 +152,3 @@ providers:                   # contains information about known providers
     #       foo: bar
     #     nodeGroupByLabels:
     #     - foo
-output:
-  path: /tmp/test-output.json  # optional, path to summary json report
-  minStatus: Passed

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -152,3 +152,6 @@ providers:                   # contains information about known providers
     #       foo: bar
     #     nodeGroupByLabels:
     #     - foo
+output:
+  path: /tmp/test-output.json # optional, path to summary json report. If --output flag is set this configuration is ignored
+  minStatus: Passed

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -43,6 +43,3 @@ providers:               # contains information about known providers
         - user: "health-check"
           uid: "health-check"
           # groups: "group1,group2,group3"
-output:
-  path: /tmp/test-output.json          #  optional, path to summary json report
-  minStatus: Passed

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -43,3 +43,6 @@ providers:               # contains information about known providers
         - user: "health-check"
           uid: "health-check"
           # groups: "group1,group2,group3"
+output:
+  path: /tmp/test-output.json # optional, path to summary json report. If --output flag is set this configuration is ignored
+  minStatus: Passed

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,8 @@ package config
 type DikiConfig struct {
 	// Providers is a list of all known providers.
 	Providers []ProviderConfig `yaml:"providers"`
+	// Output describes options related to diki's output configuration.
+	Output *OutputConfig `yaml:"output,omitempty"`
 }
 
 // ProviderConfig is used to describe and configure a provider.
@@ -52,4 +54,13 @@ type RuleOptionSkipConfig struct {
 	Enabled bool `yaml:"enabled"`
 	// Justification represents the reason why a rule is skipped.
 	Justification string `yaml:"justification"`
+}
+
+// OutputConfig represents output configurations.
+type OutputConfig struct {
+	// Path is the location which will be used to write a diki report.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	Path string `yaml:"path"`
+	// MinStatus is the minimal status that diki will report.
+	MinStatus string `yaml:"minStatus"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,8 +8,6 @@ package config
 type DikiConfig struct {
 	// Providers is a list of all known providers.
 	Providers []ProviderConfig `yaml:"providers"`
-	// Output describes options related to diki's output configuration.
-	Output *OutputConfig `yaml:"output,omitempty"`
 }
 
 // ProviderConfig is used to describe and configure a provider.
@@ -54,12 +52,4 @@ type RuleOptionSkipConfig struct {
 	Enabled bool `yaml:"enabled"`
 	// Justification represents the reason why a rule is skipped.
 	Justification string `yaml:"justification"`
-}
-
-// OutputConfig represents output configurations.
-type OutputConfig struct {
-	// Path is the location which will be used to write a diki report.
-	Path string `yaml:"path"`
-	// MinStatus is the minimal status that diki will report.
-	MinStatus string `yaml:"minStatus"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Setting `output.path` in the diki configuration file is now deprecated. Users are advised to use the `--output` flag instead.
```
```feature user
The `diki run` command now accepts an `--output` flag. If set diki will write a report summary to the file path location.
```
