### PR TITLE
Hide metadata of assessed instances in collapse element

### DIFF
--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -61,7 +61,7 @@
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label><br>
                 <button onclick="collapse(event)" class="text-lg pr-2"><i
                         class="arrow right"></i></button>
-                <span class="text-lg">Assessed targets</span>
+                <span class="text-lg">Evaluated targets</span>
                 <ul class="list-disc  list-inside pl-5 hidden">
                     {{- $meta := MergedMetadataTexts . }}
                     {{- $keys := SortedMapKeys $meta }}

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -61,7 +61,7 @@
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label><br>
                 <button onclick="collapse(event)" class="text-lg pr-2"><i
                         class="arrow right"></i></button>
-                <span class="text-lg">Assessed instances metadata</span>
+                <span class="text-lg">Assessed instances' metadata</span>
                 <ul class="list-disc  list-inside pl-5 hidden">
                     {{- $meta := MergedMetadataTexts . }}
                     {{- $keys := SortedMapKeys $meta }}

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -58,8 +58,11 @@
         <div class="content px-6">
             {{- range .Providers }}
             <div>
-                <label class="font-bold text-2xl">Provider {{ .Name }}</label>
-                <ul class="list-disc  list-inside">
+                <label class="font-bold text-2xl">Provider {{ .Name }}</label><br>
+                <button onclick="collapse(event)" class="text-lg pr-2"><i
+                        class="arrow right"></i></button>
+                <span class="text-lg">Assessed instances metadata</span>
+                <ul class="list-disc  list-inside pl-5 hidden">
                     {{- $meta := MergedMetadataTexts . }}
                     {{- $keys := SortedMapKeys $meta }}
                     {{- range $id := $keys }}

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -61,7 +61,7 @@
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label><br>
                 <button onclick="collapse(event)" class="text-lg pr-2"><i
                         class="arrow right"></i></button>
-                <span class="text-lg">Assessed instances' metadata</span>
+                <span class="text-lg">Assessed targets</span>
                 <ul class="list-disc  list-inside pl-5 hidden">
                     {{- $meta := MergedMetadataTexts . }}
                     {{- $keys := SortedMapKeys $meta }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR hides metadata of assessed instances of merged reports in collapse elements. The change will help in cases where a great number of reports are used to create a merge report and their metadata fills the html page.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
