### PR TITLE
Add generate diff command to create html difference reports

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -18,6 +18,7 @@ Files:
     go.sum
     tailwind.config.js
     pkg/report/templates/html/input.css
+    pkg/report/templates/html/difference_report.html
     pkg/report/templates/html/merged_report.html
     pkg/report/templates/html/report.html
 Copyright: 2017-2024 SAP SE or an SAP affiliate company and Gardener contributors

--- a/README.md
+++ b/README.md
@@ -79,11 +79,18 @@ diki report generate --distinct-by=gardener=id --output=report.hmtl output1.json
 
 #### Difference
 
-Diki can generate a json containing the difference between 2 output files of `diki run` executions. This can help to identify improvements (or regressions).
+Diki can generate a json containing the difference between 2 output files of `diki run` executions. This can help to identify improvements (or regressions). A human readable html difference report can also be generated from the json difference reports.
 
 - Generate json difference between 2 reports
 ```bash
-diki report diff --old=output1.json --new=output2.json --output=difference.json
+diki report diff --title=Title --old=output1.json --new=output2.json --output=difference.json
+```
+
+Diki can generate a human readable difference report from the json difference reports.
+
+- Generate html difference report from 1 or more json difference reports.
+```bash
+diki report generate diff --unique-attributes=gardener=id --output=difference.html difference1.json difference1.json
 ```
 
 #### Unit Tests

--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ diki report generate --distinct-by=gardener=id --output=report.hmtl output1.json
 
 #### Difference
 
-Diki can generate a json containing the difference between 2 output files of `diki run` executions. This can help to identify improvements (or regressions). A human readable html difference report can also be generated from the json difference reports.
+Diki can generate a json containing the difference between two output files of `diki run` executions. This can help to identify improvements (or regressions). A human readable html difference report can be generated from the difference reports.
 
-- Generate json difference between 2 reports
+- Generate json difference between two reports
 ```bash
 diki report diff --title=Title --old=output1.json --new=output2.json --output=difference.json
 ```
 
-- Generate html difference report from 1 or more json difference reports.
+- Combine one or more json difference reports to an html report.
 ```bash
-diki report generate diff --unique-attributes=gardener=id --output=difference.html difference1.json difference2.json
+diki report generate diff --identity-attributes=gardener=id --output=difference.html difference1.json difference2.json
 ```
 
 #### Unit Tests

--- a/README.md
+++ b/README.md
@@ -86,11 +86,9 @@ Diki can generate a json containing the difference between 2 output files of `di
 diki report diff --title=Title --old=output1.json --new=output2.json --output=difference.json
 ```
 
-Diki can generate a human readable difference report from the json difference reports.
-
 - Generate html difference report from 1 or more json difference reports.
 ```bash
-diki report generate diff --unique-attributes=gardener=id --output=difference.html difference1.json difference1.json
+diki report generate diff --unique-attributes=gardener=id --output=difference.html difference1.json difference2.json
 ```
 
 #### Unit Tests

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -152,7 +152,7 @@ func addReportDiffFlags(cmd *cobra.Command, opts *diffOptions) {
 }
 
 func addReportGenerateDiffFlags(cmd *cobra.Command, opts *generateDiffOptions) {
-	cmd.PersistentFlags().Var(cliflag.NewMapStringString(&opts.uniqueAttributes), "unique-attributes", "The keys are the IDs for the providers that will be present in the generated diff report and the values are metadata attributes to be used as IDs")
+	cmd.PersistentFlags().Var(cliflag.NewMapStringString(&opts.uniqueAttributes), "unique-attributes", "The keys are the IDs for the providers that will be present in the generated difference report and the values are metadata attributes to be used as IDs")
 }
 
 func generateDiffCmd(args []string, generateDiffOpts generateDiffOptions, rootOpts reportOptions, logger *slog.Logger) error {

--- a/pkg/report/difference.go
+++ b/pkg/report/difference.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/diki/pkg/rule"
 )
 
-// DifferenceReportWrapper wraps DifferenceReports and adds additional attributes needed for html rendering.
+// DifferenceReportWrapper wraps DifferenceReports and additional attributes needed for html rendering.
 type DifferenceReportWrapper struct {
 	DifferenceReports []*DifferenceReport `json:"differenceReports"`
 	UniqueAttributes  map[string]string   `json:"uniqueAttributes"`
@@ -291,7 +291,7 @@ func getUniqueRulesets(rulesets1, rulesets2 []Ruleset) map[string][]string {
 	return rulesets
 }
 
-// rulesetDiffSummaryHTML returns a summary template html with the number of added and returned rules with results per status.
+// rulesetDiffSummaryHTML returns a summary html template with the number of added and removed status types.
 func rulesetDiffSummaryHTML(ruleset *RulesetDifference) template.HTML {
 	var (
 		summaryBuilder strings.Builder
@@ -332,13 +332,13 @@ func rulesetDiffSummaryHTML(ruleset *RulesetDifference) template.HTML {
 	return template.HTML(summaryBuilder.String()) //nolint:gosec
 }
 
-func getDiffUniqAttrsText(key string, pd ProviderDifference) string {
+func getDiffUniqAttrsText(providerDiff ProviderDifference, key string) string {
 	switch {
-	case len(pd.OldMetadata[key]) == 0 && len(pd.NewMetadata[key]) == 0:
+	case len(providerDiff.OldMetadata[key]) == 0 && len(providerDiff.NewMetadata[key]) == 0:
 		return ""
-	case pd.OldMetadata[key] == pd.NewMetadata[key]:
-		return fmt.Sprintf("- %s", pd.NewMetadata[key])
+	case providerDiff.OldMetadata[key] == providerDiff.NewMetadata[key]:
+		return fmt.Sprintf("- %s", providerDiff.NewMetadata[key])
 	default:
-		return fmt.Sprintf("- %s/%s", pd.OldMetadata[key], pd.NewMetadata[key])
+		return fmt.Sprintf("- %s/%s", providerDiff.OldMetadata[key], providerDiff.NewMetadata[key])
 	}
 }

--- a/pkg/report/difference.go
+++ b/pkg/report/difference.go
@@ -8,6 +8,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"html/template"
 	"slices"
 	"strings"
 	"time"
@@ -290,8 +291,8 @@ func getUniqueRulesets(rulesets1, rulesets2 []Ruleset) map[string][]string {
 	return rulesets
 }
 
-// rulesetDiffSummaryText returns a summary string with the number of added and returned rules with results per status.
-func rulesetDiffSummaryText(ruleset *RulesetDifference) string {
+// rulesetDiffSummaryHTML returns a summary template html with the number of added and returned rules with results per status.
+func rulesetDiffSummaryHTML(ruleset *RulesetDifference) template.HTML {
 	var (
 		summaryBuilder strings.Builder
 		addedBuilder   strings.Builder
@@ -323,15 +324,12 @@ func rulesetDiffSummaryText(ruleset *RulesetDifference) string {
 		}
 	}
 	if addedBuilder.Len() > 0 {
-		summaryBuilder.WriteString(fmt.Sprintf("Added: (%s)", addedBuilder.String()))
+		summaryBuilder.WriteString(fmt.Sprintf("<br>Added statuses: %s", addedBuilder.String()))
 	}
 	if removedBuilder.Len() > 0 {
-		if summaryBuilder.Len() > 0 {
-			summaryBuilder.WriteString(", ")
-		}
-		summaryBuilder.WriteString(fmt.Sprintf("Removed: (%s)", removedBuilder.String()))
+		summaryBuilder.WriteString(fmt.Sprintf("<br>Removed statuses: %s", removedBuilder.String()))
 	}
-	return summaryBuilder.String()
+	return template.HTML(summaryBuilder.String())
 }
 
 func getDiffUniqAttrsText(key string, pd ProviderDifference) string {

--- a/pkg/report/difference.go
+++ b/pkg/report/difference.go
@@ -329,7 +329,7 @@ func rulesetDiffSummaryHTML(ruleset *RulesetDifference) template.HTML {
 	if removedBuilder.Len() > 0 {
 		summaryBuilder.WriteString(fmt.Sprintf("<br>Removed statuses: %s", removedBuilder.String()))
 	}
-	return template.HTML(summaryBuilder.String())
+	return template.HTML(summaryBuilder.String()) //nolint:gosec
 }
 
 func getDiffUniqAttrsText(key string, pd ProviderDifference) string {

--- a/pkg/report/difference_test.go
+++ b/pkg/report/difference_test.go
@@ -19,6 +19,7 @@ var _ = Describe("diff", func() {
 		var (
 			minStatus      rule.Status
 			reportTime     time.Time
+			title          = "Foo"
 			providerID     = "provider-foo"
 			providerName   = "Provider Foo"
 			rulesetID      = "ruleset-foo"
@@ -129,16 +130,17 @@ var _ = Describe("diff", func() {
 		It("should return error when reports do not have equal minStatus", func() {
 			simpleReport2.MinStatus = rule.Failed
 
-			diff, err := report.CreateDifference(simpleReport1, simpleReport2)
+			diff, err := report.CreateDifference(simpleReport1, simpleReport2, title)
 
 			Expect(diff).To(BeNil())
 			Expect(err).To(MatchError("reports must have equal minStatus"))
 		})
 		It("should create correct diff", func() {
 			simpleReport2.MinStatus = ""
-			diff, err := report.CreateDifference(simpleReport1, simpleReport2)
+			diff, err := report.CreateDifference(simpleReport1, simpleReport2, title)
 
-			expectedDiff := &report.Difference{
+			expectedDiff := &report.DifferenceReport{
+				Title:     "Foo",
 				Time:      diff.Time,
 				MinStatus: rule.Passed,
 				Providers: []report.ProviderDifference{
@@ -203,13 +205,15 @@ var _ = Describe("diff", func() {
 		})
 		It("should create correct diff of 2 reports with more than 1 ruleset", func() {
 			simpleReport1.MinStatus = ""
+			simpleReport2.Providers[0].Metadata["id"] = "foo"
 			simpleReport2.Providers[0].Rulesets = append(simpleReport2.Providers[0].Rulesets, simpleReport1.Providers[0].Rulesets[0])
 			simpleReport2.Providers[0].Rulesets[1].ID = "ruleset-bar"
 			simpleReport2.Providers[0].Rulesets[1].Name = "Ruleset Bar"
 
-			diff, err := report.CreateDifference(simpleReport1, simpleReport2)
+			diff, err := report.CreateDifference(simpleReport1, simpleReport2, title)
 
-			expectedDiff := &report.Difference{
+			expectedDiff := &report.DifferenceReport{
+				Title:     "Foo",
 				Time:      diff.Time,
 				MinStatus: rule.Passed,
 				Providers: []report.ProviderDifference{
@@ -222,7 +226,7 @@ var _ = Describe("diff", func() {
 							"time": reportTime.Format(time.RFC3339),
 						},
 						NewMetadata: map[string]string{
-							"id":   "bar",
+							"id":   "foo",
 							"foo":  "bar",
 							"time": reportTime.Format(time.RFC3339),
 						},
@@ -312,9 +316,10 @@ var _ = Describe("diff", func() {
 				Rulesets: simpleReport1.Providers[0].Rulesets,
 			})
 
-			diff, err := report.CreateDifference(simpleReport1, simpleReport2)
+			diff, err := report.CreateDifference(simpleReport1, simpleReport2, title)
 
-			expectedDiff := &report.Difference{
+			expectedDiff := &report.DifferenceReport{
+				Title:     "Foo",
 				Time:      diff.Time,
 				MinStatus: rule.Passed,
 				Providers: []report.ProviderDifference{
@@ -449,9 +454,10 @@ var _ = Describe("diff", func() {
 			})
 			simpleReport2.Providers[0].Rulesets[0].Version = "v1.1"
 
-			diff, err := report.CreateDifference(simpleReport1, simpleReport2)
+			diff, err := report.CreateDifference(simpleReport1, simpleReport2, title)
 
-			expectedDiff := &report.Difference{
+			expectedDiff := &report.DifferenceReport{
+				Title:     "Foo",
 				Time:      diff.Time,
 				MinStatus: rule.Passed,
 				Providers: []report.ProviderDifference{

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -49,12 +49,12 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 	templates := make(map[string]*template.Template)
 
 	parsedReport, err := template.New(tmplReportName+".html").Funcs(template.FuncMap{
-		"Statuses":           rule.Statuses,
-		"Icon":               rule.GetStatusIcon,
-		"Time":               convTimeFunc,
-		"RulesetSummaryText": rulesetSummaryText,
-		"RulesWithStatus":    rulesWithStatus,
-		"SortedMapKeys":      sortedKeys[string],
+		"getStatuses":        rule.Statuses,
+		"icon":               rule.GetStatusIcon,
+		"time":               convTimeFunc,
+		"rulesetSummaryText": rulesetSummaryText,
+		"rulesWithStatus":    rulesWithStatus,
+		"sortedMapKeys":      sortedKeys[string],
 	}).ParseFS(files, tmplReportPath, tmplStylesPath)
 	if err != nil {
 		return nil, err
@@ -62,13 +62,13 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 	templates[tmplReportName] = parsedReport
 
 	parsedMergedReport, err := template.New(tmplMergedReportName+".html").Funcs(template.FuncMap{
-		"Statuses":                 rule.Statuses,
-		"Icon":                     rule.GetStatusIcon,
-		"Time":                     convTimeFunc,
-		"MergedMetadataTexts":      metadataTextForMergedProvider,
-		"MergedRulesetSummaryText": mergedRulesetSummaryText,
-		"MergedRulesWithStatus":    mergedRulesWithStatus,
-		"SortedMapKeys":            sortedKeys[string],
+		"getStatuses":              rule.Statuses,
+		"icon":                     rule.GetStatusIcon,
+		"time":                     convTimeFunc,
+		"mergedMetadataTexts":      metadataTextForMergedProvider,
+		"mergedRulesetSummaryText": mergedRulesetSummaryText,
+		"mergedRulesWithStatus":    mergedRulesWithStatus,
+		"sortedMapKeys":            sortedKeys[string],
 	}).ParseFS(files, tmplMergedReportPath, tmplStylesPath)
 	if err != nil {
 		return nil, err
@@ -76,14 +76,12 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 	templates[tmplMergedReportName] = parsedMergedReport
 
 	parsedDifferenceReport, err := template.New(tmplDifferenceReportName+".html").Funcs(template.FuncMap{
-		"Add":                    add,
-		"Statuses":               rule.Statuses,
-		"Icon":                   rule.GetStatusIcon,
-		"Time":                   convTimeFunc,
-		"RulesetDiffSummaryText": rulesetDiffSummaryHTML,
+		"add":                    add,
+		"icon":                   rule.GetStatusIcon,
+		"rulesetDiffSummaryText": rulesetDiffSummaryHTML,
 		"keyExists":              keyExists,
 		"getAttrString":          getDiffUniqAttrsText,
-		"SortedMapKeys":          sortedKeys[string],
+		"sortedMapKeys":          sortedKeys[string],
 	}).ParseFS(files, tmplDifferenceReportPath, tmplStylesPath)
 	if err != nil {
 		return nil, err

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -76,12 +76,13 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 	templates[tmplMergedReportName] = parsedMergedReport
 
 	parsedDifferenceReport, err := template.New(tmplDifferenceReportName+".html").Funcs(template.FuncMap{
-		"add":                    add,
-		"icon":                   rule.GetStatusIcon,
-		"rulesetDiffSummaryText": rulesetDiffSummaryHTML,
-		"keyExists":              keyExists,
-		"getAttrString":          getDiffUniqAttrsText,
-		"sortedMapKeys":          sortedKeys[string],
+		"add":                           add,
+		"icon":                          rule.GetStatusIcon,
+		"rulesetDiffAddedSummaryText":   rulesetDiffAddedSummaryText,
+		"rulesetDiffRemovedSummaryText": rulesetDiffRemovedSummaryText,
+		"keyExists":                     keyExists,
+		"getAttrString":                 getProviderDiffIDText,
+		"sortedMapKeys":                 sortedKeys[string],
 	}).ParseFS(files, tmplDifferenceReportPath, tmplStylesPath)
 	if err != nil {
 		return nil, err
@@ -100,7 +101,7 @@ func (r *HTMLRenderer) Render(w io.Writer, report any) error {
 		return r.templates[tmplReportName].Execute(w, rep)
 	case *MergedReport:
 		return r.templates[tmplMergedReportName].Execute(w, rep)
-	case *DifferenceReportWrapper:
+	case *DifferenceReportsWrapper:
 		return r.templates[tmplDifferenceReportName].Execute(w, rep)
 	default:
 		return fmt.Errorf("unsupported report type: %T", report)

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -80,7 +80,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 		"Statuses":               rule.Statuses,
 		"Icon":                   rule.GetStatusIcon,
 		"Time":                   convTimeFunc,
-		"DiffRulesetSummaryText": rulesetDiffSummaryText,
+		"RulesetDiffSummaryText": rulesetDiffSummaryHTML,
 		"keyExists":              keyExists,
 		"getAttrString":          getDiffUniqAttrsText,
 		"SortedMapKeys":          sortedKeys[string],

--- a/pkg/report/templates/html/difference_report.html
+++ b/pkg/report/templates/html/difference_report.html
@@ -56,13 +56,13 @@
     <div class="flex-col">
         <h1 class="text-3xl font-bold pb-5 pt-2 flex justify-center">Difference report</h1>
         <div class="content px-6">
-            {{- $uniqAttr := .UniqueAttributes }}
+            {{- $IDAttr := .IdentityAttributes }}
             {{- range $index, $element := .DifferenceReports }}
             <label class="font-bold text-2xl">{{ add $index 1 }}. {{ .Title }}</label>
             {{- range .Providers }}
-            {{- if (keyExists $uniqAttr .ID) }}
+            {{- if (keyExists $IDAttr .ID) }}
             <div>
-                <label class="font-bold text-2xl">Provider {{ .Name }} {{ getAttrString . (index $uniqAttr .ID)}}</label>
+                <label class="font-bold text-2xl">Provider {{ .Name }} {{ getAttrString . (index $IDAttr .ID)}}</label>
                 <ul class="list-disc  list-inside">
                     {{- $keys := sortedMapKeys .OldMetadata }}
                     {{- $meta := .OldMetadata }}
@@ -85,7 +85,9 @@
                     {{- range .Rulesets }}
                     {{- $ruleset := . }}
                     <li>
-                        <span class="text-lg"><span class="font-semibold">{{ .Version }} {{ .Name }}</span>{{ rulesetDiffSummaryText $ruleset }}</span>
+                        <span class="text-lg"><span class="font-semibold">{{ .Version }} {{ .Name }}</span>
+                        <br>Added statuses: {{ rulesetDiffAddedSummaryText $ruleset }}
+                        <br>Removed statuses: {{ rulesetDiffRemovedSummaryText $ruleset }}</span>
                         <ul class="list-inside pl-2">
                             {{- range .Rules }}
                             <li>

--- a/pkg/report/templates/html/difference_report.html
+++ b/pkg/report/templates/html/difference_report.html
@@ -58,13 +58,13 @@
         <div class="content px-6">
             {{- $uniqAttr := .UniqueAttributes }}
             {{- range $index, $element := .DifferenceReports }}
-            <label class="font-bold text-2xl">{{ Add $index 1 }}. {{ .Title }}</label>
+            <label class="font-bold text-2xl">{{ add $index 1 }}. {{ .Title }}</label>
             {{- range .Providers }}
             {{- if (keyExists $uniqAttr .ID) }}
             <div>
-                <label class="font-bold text-2xl">Provider {{ .Name }} {{ getAttrString (index $uniqAttr .ID)  . }}</label>
+                <label class="font-bold text-2xl">Provider {{ .Name }} {{ getAttrString . (index $uniqAttr .ID)}}</label>
                 <ul class="list-disc  list-inside">
-                    {{- $keys := SortedMapKeys .OldMetadata }}
+                    {{- $keys := sortedMapKeys .OldMetadata }}
                     {{- $meta := .OldMetadata }}
                     <li><span class="font-bold">OldMetadata:</span>
                     {{- range $key := $keys -}}
@@ -73,7 +73,7 @@
                     </li>
                 </ul>
                 <ul class="list-disc  list-inside">
-                    {{- $keys := SortedMapKeys .NewMetadata }}
+                    {{- $keys := sortedMapKeys .NewMetadata }}
                     {{- $meta := .NewMetadata }}
                     <li><span class="font-bold">NewMetadata:</span>
                     {{- range $key := $keys -}}
@@ -85,7 +85,7 @@
                     {{- range .Rulesets }}
                     {{- $ruleset := . }}
                     <li>
-                        <span class="text-lg"><span class="font-semibold">{{ .Version }} {{ .Name }}</span>{{ RulesetDiffSummaryText $ruleset }}</span>
+                        <span class="text-lg"><span class="font-semibold">{{ .Version }} {{ .Name }}</span>{{ rulesetDiffSummaryText $ruleset }}</span>
                         <ul class="list-inside pl-2">
                             {{- range .Rules }}
                             <li>
@@ -101,7 +101,7 @@
                                         <ul class="list-inside pl-5 hidden">
                                             {{- range .Added }}
                                             <li>
-                                                <span class="font-medium">{{ .Status }} &#{{ Icon .Status }} {{ .Message }}</span>
+                                                <span class="font-medium">{{ .Status }} &#{{ icon .Status }} {{ .Message }}</span>
                                             </li>
                                             {{- end }}
                                         </ul>
@@ -115,7 +115,7 @@
                                         <ul class="list-inside pl-5 hidden">
                                             {{- range .Removed }}
                                             <li>
-                                                <span class="font-medium">{{ .Status }} &#{{ Icon .Status }} {{ .Message }}</span>
+                                                <span class="font-medium">{{ .Status }} &#{{ icon .Status }} {{ .Message }}</span>
                                             </li>
                                             {{- end }}
                                         </ul>

--- a/pkg/report/templates/html/difference_report.html
+++ b/pkg/report/templates/html/difference_report.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {{- template "_styles" }}
+    <style>
+        .arrow {
+            border: solid black;
+            border-width: 0px 3px 3px 0px;
+            display: inline-block;
+            padding: 4px;
+        }
+
+        .right {
+            transform: rotate(-45deg);
+            -webkit-transform: rotate(-45deg);
+        }
+
+        .left {
+            transform: rotate(135deg);
+            -webkit-transform: rotate(135deg);
+        }
+
+        .up {
+            transform: rotate(-135deg);
+            -webkit-transform: rotate(-135deg);
+        }
+
+        .down {
+            transform: rotate(45deg);
+            -webkit-transform: rotate(45deg);
+        }
+    </style>
+    <script>
+        function collapse(event) {
+            const parent = event.currentTarget.parentElement
+            const list = parent.getElementsByTagName('ul')[0]
+            const arrow = event.currentTarget.getElementsByTagName('i')[0]
+
+            if (list.classList.contains('hidden') === true) {
+                list.classList.remove('hidden')
+                arrow.classList.replace('right', 'down')
+                return
+            }
+
+            list.classList.add('hidden')
+            arrow.classList.replace('down', 'right')
+        }
+    </script>
+</head>
+
+<body>
+    <div class="flex-col">
+        <h1 class="text-3xl font-bold pb-5 pt-2 flex justify-center">Difference report</h1>
+        <div class="content px-6">
+            {{- $uniqAttr := .UniqueAttributes }}
+            {{- range $index, $element := .DifferenceReports }}
+            <label class="font-bold text-2xl">{{ Add $index 1 }}. {{ .Title }}</label>
+            {{- range .Providers }}
+            {{- if (keyExists $uniqAttr .ID) }}
+            <div>
+                <label class="font-bold text-2xl">Provider {{ .Name }} {{ getAttrString (index $uniqAttr .ID)  . }}</label>
+                <ul class="list-disc  list-inside">
+                    {{- $keys := SortedMapKeys .OldMetadata }}
+                    {{- $meta := .OldMetadata }}
+                    <li><span class="font-bold">OldMetadata:</span>
+                    {{- range $key := $keys -}}
+                    <span class="font-semibold"> {{ $key }}</span>: {{ index $meta $key }},
+                    {{- end -}}
+                    </li>
+                </ul>
+                <ul class="list-disc  list-inside">
+                    {{- $keys := SortedMapKeys .NewMetadata }}
+                    {{- $meta := .NewMetadata }}
+                    <li><span class="font-bold">NewMetadata:</span>
+                    {{- range $key := $keys -}}
+                    <span class="font-semibold"> {{ $key }}</span>: {{ index $meta $key }}, 
+                    {{- end -}}
+                    </li>
+                </ul>
+                <ul class="list-none list-inside">
+                    {{- range .Rulesets }}
+                    {{- $ruleset := . }}
+                    <li>
+                        <span class="text-lg"><span class="font-semibold">{{ .Version }} {{ .Name }}</span> ({{ DiffRulesetSummaryText $ruleset }})</span>
+                        <ul class="list-inside pl-2">
+                            {{- range .Rules }}
+                            <li>
+                                <button onclick="collapse(event)" class="pr-2"><i
+                                        class="arrow right"></i></button>
+                                <span class="font-semibold">{{ .Name }}</span>
+                                <ul class="list-inside pl-5 hidden">
+                                    {{- if .Added }}
+                                    <li>
+                                        <button onclick="collapse(event)" class="pr-2"><i
+                                                class="arrow right"></i></button>
+                                        <span class="font-semibold">Added</span>
+                                        <ul class="list-inside pl-5 hidden">
+                                            {{- range .Added }}
+                                            <li>
+                                                <span class="font-medium">{{ .Status }} &#{{ Icon .Status }} {{ .Message }}</span>
+                                            </li>
+                                            {{- end }}
+                                        </ul>
+                                    </li>
+                                    {{- end }}
+                                    {{- if .Removed }}
+                                    <li>
+                                        <button onclick="collapse(event)" class="pr-2"><i
+                                                class="arrow right"></i></button>
+                                        <span class="font-semibold">Removed</span>
+                                        <ul class="list-inside pl-5 hidden">
+                                            {{- range .Removed }}
+                                            <li>
+                                                <span class="font-medium">{{ .Status }} &#{{ Icon .Status }} {{ .Message }}</span>
+                                            </li>
+                                            {{- end }}
+                                        </ul>
+                                    </li>
+                                    {{- end }}
+                                </ul>
+                            </li> 
+                            {{- end }}
+                        </ul>
+                    </li>
+                    {{- end }}
+                </ul>
+            </div>
+            {{- end }}
+            <br>
+            {{- end }}
+            {{- end }}
+        </div>
+    </div>
+</body>
+
+</html>

--- a/pkg/report/templates/html/difference_report.html
+++ b/pkg/report/templates/html/difference_report.html
@@ -85,7 +85,7 @@
                     {{- range .Rulesets }}
                     {{- $ruleset := . }}
                     <li>
-                        <span class="text-lg"><span class="font-semibold">{{ .Version }} {{ .Name }}</span> ({{ DiffRulesetSummaryText $ruleset }})</span>
+                        <span class="text-lg"><span class="font-semibold">{{ .Version }} {{ .Name }}</span>{{ RulesetDiffSummaryText $ruleset }}</span>
                         <ul class="list-inside pl-2">
                             {{- range .Rules }}
                             <li>
@@ -97,7 +97,7 @@
                                     <li>
                                         <button onclick="collapse(event)" class="pr-2"><i
                                                 class="arrow right"></i></button>
-                                        <span class="font-semibold">Added</span>
+                                        <span class="font-semibold">Added statuses</span>
                                         <ul class="list-inside pl-5 hidden">
                                             {{- range .Added }}
                                             <li>
@@ -111,7 +111,7 @@
                                     <li>
                                         <button onclick="collapse(event)" class="pr-2"><i
                                                 class="arrow right"></i></button>
-                                        <span class="font-semibold">Removed</span>
+                                        <span class="font-semibold">Removed statuses</span>
                                         <ul class="list-inside pl-5 hidden">
                                             {{- range .Removed }}
                                             <li>

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -54,7 +54,7 @@
 
 <body>
     <div class="flex-col">
-        <h1 class="text-3xl font-bold pb-5 pt-2 flex justify-center">Compliance Run ({{ Time .Time }})</h1>
+        <h1 class="text-3xl font-bold pb-5 pt-2 flex justify-center">Compliance Run ({{ time .Time }})</h1>
         <div class="content px-6">
             {{- range .Providers }}
             <div>
@@ -63,25 +63,25 @@
                         class="arrow right"></i></button>
                 <span class="text-lg">Evaluated targets</span>
                 <ul class="list-disc  list-inside pl-5 hidden">
-                    {{- $meta := MergedMetadataTexts . }}
-                    {{- $keys := SortedMapKeys $meta }}
+                    {{- $meta := mergedMetadataTexts . }}
+                    {{- $keys := sortedMapKeys $meta }}
                     {{- range $id := $keys }}
                     <li><span class="font-bold">{{ $id }}</span> {{ index $meta $id }}</li>
                     {{- end }}
                 </ul>
                 <ul class="list-none list-inside">
                     {{- range .Rulesets }}
-                    {{- $statuses := Statuses }}
+                    {{- $statuses := getStatuses }}
                     {{- $ruleset := . }}
                     <li>
-                        <span class="text-lg"><span class="font-semibold">{{ $ruleset.Version }} {{ $ruleset.Name }}</span> ({{ MergedRulesetSummaryText $ruleset }})</span>
+                        <span class="text-lg"><span class="font-semibold">{{ $ruleset.Version }} {{ $ruleset.Name }}</span> ({{ mergedRulesetSummaryText $ruleset }})</span>
                         {{- range $key, $value := $statuses }}
-                        {{- with MergedRulesWithStatus $ruleset $value }}
+                        {{- with mergedRulesWithStatus $ruleset $value }}
                         <ul class="list-inside pl-2">
                             <li>
                                 <button onclick="collapse(event)" class="text-lg pr-2"><i
                                         class="arrow right"></i></button>
-                                <span class="text-lg">&#{{ Icon $value }} {{ $value }}</span>
+                                <span class="text-lg">&#{{ icon $value }} {{ $value }}</span>
                                 <ul class="list-inside pl-5 hidden">
                                     {{- range . }}
                                     <li>

--- a/pkg/report/templates/html/report.html
+++ b/pkg/report/templates/html/report.html
@@ -54,13 +54,13 @@
 
 <body>
     <div class="flex-col">
-        <h1 class="text-3xl font-bold pb-5 pt-2 flex justify-center">Compliance Run ({{ Time .Time }})</h1>
+        <h1 class="text-3xl font-bold pb-5 pt-2 flex justify-center">Compliance Run ({{ time .Time }})</h1>
         <div class="content px-6">
             {{- range .Providers }}
             <div>
                 <label class="font-bold text-2xl">Provider {{ .Name }}</label>
                 <ul class="list-disc  list-inside">
-                    {{- $keys := SortedMapKeys .Metadata }}
+                    {{- $keys := sortedMapKeys .Metadata }}
                     {{- $meta := .Metadata }}
                     {{- range $key := $keys }}
                     <li><span class="font-semibold">{{ $key }}</span>: {{ index $meta $key }}</li>
@@ -68,17 +68,17 @@
                 </ul>
                 <ul class="list-none list-inside">
                     {{- range .Rulesets }}
-                    {{- $statuses := Statuses }}
+                    {{- $statuses := getStatuses }}
                     {{- $ruleset := . }}
                     <li>
-                        <span class="text-lg"><span class="font-semibold">{{ $ruleset.Version }} {{ $ruleset.Name }}</span> ({{ RulesetSummaryText $ruleset }})</span>
+                        <span class="text-lg"><span class="font-semibold">{{ $ruleset.Version }} {{ $ruleset.Name }}</span> ({{ rulesetSummaryText $ruleset }})</span>
                         {{- range $key, $value := $statuses }}
-                        {{- with RulesWithStatus $ruleset $value }}
+                        {{- with rulesWithStatus $ruleset $value }}
                         <ul class="list-inside pl-2"> 
                             <li>
                                 <button onclick="collapse(event)" class="text-lg pr-2"><i
                                         class="arrow right"></i></button>
-                                <span class="text-lg">&#{{ Icon $value }} {{ $value }}</span>
+                                <span class="text-lg">&#{{ icon $value }} {{ $value }}</span>
                                 <ul class="list-inside pl-5 hidden">
                                     {{- range . }}
                                     <li>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new `diki report generate diff` command that creates a html difference report with 1 or more json difference reports. The `--identity-attributes` is required, it's value is a list of `key=value` pairs, where the keys are the IDs for the providers that will be present in the generated difference report and the values are metadata attributes to be used as IDs.

**Which issue(s) this PR fixes**:
Fixes #159 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A new command `diki report generate diff` that converts one or more `json` difference reports into a single `html` difference report was introduced.
```
