### PR TITLE
[Docu] Improve partial-disa-k8s-stig-shoot documentation

### DIFF
--- a/docs/usage/partial-disa-k8s-stig-shoot.md
+++ b/docs/usage/partial-disa-k8s-stig-shoot.md
@@ -2,7 +2,7 @@
 
 ### Introduction
 
-This part shows how to run the DISA K8s STIGs ruleset against a Gardener shoot cluster. The `managedk8s` provider is used, which does not check control plane components.
+This part shows how to run the DISA K8s STIGs ruleset against a Gardener shoot cluster when you do not have access to the seed's kubeconfig. The `managedk8s` provider is used which does not check control plane components.
 
 ### Prerequisites
 

--- a/docs/usage/partial-disa-k8s-stig-shoot.md
+++ b/docs/usage/partial-disa-k8s-stig-shoot.md
@@ -2,7 +2,7 @@
 
 ### Introduction
 
-This part shows how to run the DISA K8s STIGs ruleset against a Gardener shoot cluster when you do not have access to the seed's kubeconfig. The `managedk8s` provider is used which does not check control plane components.
+This part shows how to run the DISA K8s STIGs ruleset against a Gardener shoot cluster. The guide features the `managedk8s` provider which does not implement all of the DISA K8s STIG rules since it assumes that the user running the ruleset does not have access to the environment (the seed in this particular case) in which the control plane components reside.
 
 ### Prerequisites
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds better explanation to when to use the `managedk8s` provider against a shoot cluster in the `partial-disa-k8s-stig-shoot` documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
