### PR TITLE
Rm redundant component-descriptor trait

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -53,7 +53,6 @@ diki:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~
         publish:
           dockerimages:
             diki:


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove [redundant component-descriptor trait](https://github.com/gardener/diki/blob/687f28218b3f3844b4f0edbbb398526d38e2ab44/.ci/pipeline_definitions#L44) to properly release new diki versions to Google Artifact Registry.
This duplicate configuration was introduced with [this commit](https://github.com/gardener/diki/commit/609ef65dadf05015eec5fc58ffa9fbe225a38e5a#diff-f6d7f429b1dea52fac85480a4d09b40a781726c59a82705f6e7b2af33972b2cbR56).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Release new diki versions to europe-docker.pkg.dev/gardener-project/releases
```
