### PR TITLE
[DISA K8s STIG] Fix rule 242451 validation for managed k8s provider

### DIFF
--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
@@ -51,7 +51,10 @@ var _ option.Option = (*Options242451)(nil)
 func (o Options242451) Validate() field.ErrorList {
 	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 	allErrs = append(allErrs, option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))...)
-	return append(allErrs, o.FileOwnerOptions.Validate()...)
+	if o.FileOwnerOptions != nil {
+		return append(allErrs, o.FileOwnerOptions.Validate()...)
+	}
+	return allErrs
 }
 
 func (r *Rule242451) ID() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug causing rule 242451 validation for managedk8s provider to crash when no file owner options for the rule were set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing rule 242451 validation for managedk8s provider to crash when no file owner options for the rule were set was fixed.
```
