### PR TITLE
[release-v0.6] Automated cherry pick of #204: [DISA K8s STIG] Fix rule 242451 validation for managed k8s provider

### DIFF
--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
@@ -51,7 +51,10 @@ var _ option.Option = (*Options242451)(nil)
 func (o Options242451) Validate() field.ErrorList {
 	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 	allErrs = append(allErrs, option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))...)
-	return append(allErrs, o.FileOwnerOptions.Validate()...)
+	if o.FileOwnerOptions != nil {
+		return append(allErrs, o.FileOwnerOptions.Validate()...)
+	}
+	return allErrs
 }
 
 func (r *Rule242451) ID() string {


### PR DESCRIPTION
Cherry pick of #204 on release-v0.6.

#204: [DISA K8s STIG] Fix rule 242451 validation for managed k8s provider

**Release Notes:**
```bugfix user
A bug causing rule 242451 validation for managedk8s provider to crash when no file owner options for the rule were set was fixed.
```