### PR TITLE
Add `args` field `opsPodLabels` to all providers

### DIFF
--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -6,7 +6,7 @@ providers:             # contains information about known providers
     shootName: local
     # foo: bar
   args:
-    # opsPodLabels: # pod labels that will be added to diki ops pods
+    # additionalOpsPodLabels: # pod labels that will be added to diki ops pods
     #   foo: bar
     shootKubeconfigPath: /tmp/shoot.config  # path to shoot admin kubeconfig
     seedKubeconfigPath: /tmp/seed.config    # path to seed admin kubeconfig

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -6,6 +6,8 @@ providers:             # contains information about known providers
     shootName: local
     # foo: bar
   args:
+    # opsPodLabels: # pod labels that will be added to diki ops pods
+    #   foo: bar
     shootKubeconfigPath: /tmp/shoot.config  # path to shoot admin kubeconfig
     seedKubeconfigPath: /tmp/seed.config    # path to seed admin kubeconfig
     shootName: local                           # name of shoot cluster to be tested

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -4,6 +4,8 @@ providers:                   # contains information about known providers
   metadata:
     foo: bar
   args:
+    # opsPodLabels: # pod labels that will be added to diki ops pods
+    #   foo: bar
     kubeconfigPath: /tmp/kubeconfig.config  # path to cluster admin kubeconfig
   rulesets:
   - id: disa-kubernetes-stig

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -4,7 +4,7 @@ providers:                   # contains information about known providers
   metadata:
     foo: bar
   args:
-    # opsPodLabels: # pod labels that will be added to diki ops pods
+    # additionalOpsPodLabels: # pod labels that will be added to diki ops pods
     #   foo: bar
     kubeconfigPath: /tmp/kubeconfig.config  # path to cluster admin kubeconfig
   rulesets:

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -4,6 +4,8 @@ providers:               # contains information about known providers
   metadata:
     foo: bar
   args:
+    # opsPodLabels: # pod labels that will be added to diki ops pods
+    #   foo: bar
     runtimeKubeconfigPath: /tmp/runtime.config  # path to runtime cluster admin kubeconfig
   rulesets:
   - id: disa-kubernetes-stig

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -4,7 +4,7 @@ providers:               # contains information about known providers
   metadata:
     foo: bar
   args:
-    # opsPodLabels: # pod labels that will be added to diki ops pods
+    # additionalOpsPodLabels: # pod labels that will be added to diki ops pods
     #   foo: bar
     runtimeKubeconfigPath: /tmp/runtime.config  # path to runtime cluster admin kubeconfig
   rulesets:

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -48,6 +48,8 @@ type SimplePodExecutor struct {
 type SimplePodContext struct {
 	client client.Client
 	config *rest.Config
+	// PodLabels are labels to be added to the created pods
+	PodLabels map[string]string
 	// IntervalWait is the time between wait API calls.
 	IntervalWait time.Duration
 	// TimeoutWait is the time waited for a pod to reach Running state or be deleted.
@@ -55,10 +57,11 @@ type SimplePodContext struct {
 }
 
 // NewSimplePodContext creates a new SimplePodContext.
-func NewSimplePodContext(client client.Client, config *rest.Config) (*SimplePodContext, error) {
+func NewSimplePodContext(client client.Client, config *rest.Config, podLabels map[string]string) (*SimplePodContext, error) {
 	return &SimplePodContext{
 		client:       client,
 		config:       config,
+		PodLabels:    podLabels,
 		IntervalWait: 2 * time.Second,
 		TimeoutWait:  time.Minute,
 	}, nil
@@ -67,6 +70,11 @@ func NewSimplePodContext(client client.Client, config *rest.Config) (*SimplePodC
 // Create creates a Pod and waits for it to get in Running state.
 func (spc *SimplePodContext) Create(ctx context.Context, podConstructorFn func() *corev1.Pod) (PodExecutor, error) {
 	pod := podConstructorFn()
+	for label, value := range spc.PodLabels {
+		if _, ok := pod.Labels[label]; !ok {
+			pod.Labels[label] = value
+		}
+	}
 
 	if err := spc.client.Create(ctx, pod); err != nil {
 		return nil, err

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -57,11 +57,11 @@ type SimplePodContext struct {
 }
 
 // NewSimplePodContext creates a new SimplePodContext.
-func NewSimplePodContext(client client.Client, config *rest.Config, podLabels map[string]string) (*SimplePodContext, error) {
+func NewSimplePodContext(client client.Client, config *rest.Config, additionalPodLabels map[string]string) (*SimplePodContext, error) {
 	return &SimplePodContext{
 		client:              client,
 		config:              config,
-		AdditionalPodLabels: podLabels,
+		AdditionalPodLabels: additionalPodLabels,
 		IntervalWait:        2 * time.Second,
 		TimeoutWait:         time.Minute,
 	}, nil

--- a/pkg/kubernetes/pod/pod_test.go
+++ b/pkg/kubernetes/pod/pod_test.go
@@ -36,7 +36,7 @@ var _ = Describe("pod", func() {
 		})
 
 		It("should create diki pod", func() {
-			spc, err := pod.NewSimplePodContext(fakeClient, fakeConfig)
+			spc, err := pod.NewSimplePodContext(fakeClient, fakeConfig, map[string]string{})
 			Expect(err).To(BeNil())
 
 			_, err = spc.Create(ctx, fakePodContructor(name, namespace, ""))
@@ -56,8 +56,39 @@ var _ = Describe("pod", func() {
 			Expect(err).To(BeNil())
 		})
 
+		It("should create diki pod with correct labels", func() {
+			spc, err := pod.NewSimplePodContext(fakeClient, fakeConfig, map[string]string{
+				"foo":     "not-bar",
+				"bar":     "foo",
+				"foo-bar": "bar",
+			})
+			Expect(err).To(BeNil())
+
+			_, err = spc.Create(ctx, fakePodContructor(name, namespace, ""))
+			Expect(err).To(BeNil())
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			}
+			expectedLabels := map[string]string{
+				"foo":     "bar",
+				"bar":     "foo",
+				"foo-bar": "bar",
+			}
+
+			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+			Expect(err).To(BeNil())
+			Expect(pod.Labels).To(Equal(expectedLabels))
+		})
+
 		It("should delete diki pod", func() {
-			spc, err := pod.NewSimplePodContext(fakeClient, fakeConfig)
+			spc, err := pod.NewSimplePodContext(fakeClient, fakeConfig, map[string]string{})
 			Expect(err).To(BeNil())
 
 			_, err = spc.Create(ctx, fakePodContructor(name, namespace, ""))
@@ -94,6 +125,9 @@ func fakePodContructor(name, namespace, nodeName string) func() *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				"foo": "bar",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/pkg/provider/builder/gardener.go
+++ b/pkg/provider/builder/gardener.go
@@ -33,7 +33,7 @@ func GardenerProviderFromConfig(conf config.ProviderConfig) (provider.Provider, 
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.OpsPodLabels, p.ShootConfig, p.SeedConfig, p.Args.ShootNamespace)
+			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.AdditionalOpsPodLabels, p.ShootConfig, p.SeedConfig, p.Args.ShootNamespace)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/builder/gardener.go
+++ b/pkg/provider/builder/gardener.go
@@ -33,7 +33,7 @@ func GardenerProviderFromConfig(conf config.ProviderConfig) (provider.Provider, 
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.ShootConfig, p.SeedConfig, p.Args.ShootNamespace)
+			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.OpsPodLabels, p.ShootConfig, p.SeedConfig, p.Args.ShootNamespace)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -30,7 +30,7 @@ func ManagedK8SProviderFromConfig(conf config.ProviderConfig) (provider.Provider
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.OpsPodLabels, p.Config)
+			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.AdditionalOpsPodLabels, p.Config)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -30,7 +30,7 @@ func ManagedK8SProviderFromConfig(conf config.ProviderConfig) (provider.Provider
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.Config)
+			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.OpsPodLabels, p.Config)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -30,7 +30,7 @@ func VirtualGardenProviderFromConfig(conf config.ProviderConfig) (provider.Provi
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.RuntimeConfig)
+			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.OpsPodLabels, p.RuntimeConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -30,7 +30,7 @@ func VirtualGardenProviderFromConfig(conf config.ProviderConfig) (provider.Provi
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.OpsPodLabels, p.RuntimeConfig)
+			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.AdditionalOpsPodLabels, p.RuntimeConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/gardener/options.go
+++ b/pkg/provider/gardener/options.go
@@ -28,10 +28,10 @@ func WithName(name string) CreateOption {
 	}
 }
 
-// WithOpsPodLabels sets the OpsPodLabels of a [Provider].
-func WithOpsPodLabels(labels map[string]string) CreateOption {
+// WithAdditionalOpsPodLabels sets the AdditionalOpsPodLabels of a [Provider].
+func WithAdditionalOpsPodLabels(labels map[string]string) CreateOption {
 	return func(p *Provider) {
-		p.OpsPodLabels = labels
+		p.AdditionalOpsPodLabels = labels
 	}
 }
 

--- a/pkg/provider/gardener/options.go
+++ b/pkg/provider/gardener/options.go
@@ -28,6 +28,13 @@ func WithName(name string) CreateOption {
 	}
 }
 
+// WithOpsPodLabels sets the OpsPodLabels of a [Provider].
+func WithOpsPodLabels(labels map[string]string) CreateOption {
+	return func(p *Provider) {
+		p.OpsPodLabels = labels
+	}
+}
+
 // WithShootConfig sets the ShootConfig of a Provider.
 func WithShootConfig(config *rest.Config) CreateOption {
 	return func(p *Provider) {

--- a/pkg/provider/gardener/provider.go
+++ b/pkg/provider/gardener/provider.go
@@ -25,6 +25,7 @@ import (
 // against a shoot cluster and its controlplane (residing in a seed cluster).
 type Provider struct {
 	id, name                string
+	OpsPodLabels            map[string]string
 	ShootConfig, SeedConfig *rest.Config
 	Args                    Args
 	rulesets                map[string]ruleset.Ruleset
@@ -33,10 +34,11 @@ type Provider struct {
 }
 
 type providerArgs struct {
-	ShootKubeconfigPath string
-	SeedKubeconfigPath  string
-	ShootName           string
-	ShootNamespace      string
+	OpsPodLabels        map[string]string `json:"opsPodLabels" yaml:"opsPodLabels"`
+	ShootKubeconfigPath string            `json:"shootKubeconfigPath" yaml:"shootKubeconfigPath"`
+	SeedKubeconfigPath  string            `json:"seedKubeconfigPath" yaml:"seedKubeconfigPath"`
+	ShootName           string            `json:"shootName" yaml:"shootName"`
+	ShootNamespace      string            `json:"shootNamespace" yaml:"shootNamespace"`
 }
 
 // Args are Gardener Provider specific arguments.
@@ -179,6 +181,7 @@ func FromGenericConfig(providerConf config.ProviderConfig) (*Provider, error) {
 	gardenerProvider, err := New(
 		WithID(providerConf.ID),
 		WithName(providerConf.Name),
+		WithOpsPodLabels(providerGardenerArgs.OpsPodLabels),
 		WithSeedConfig(seedKubeConfig),
 		WithShootConfig(shootKubeConfig),
 		WithMetadata(providerConf.Metadata),

--- a/pkg/provider/gardener/provider.go
+++ b/pkg/provider/gardener/provider.go
@@ -25,7 +25,7 @@ import (
 // against a shoot cluster and its controlplane (residing in a seed cluster).
 type Provider struct {
 	id, name                string
-	OpsPodLabels            map[string]string
+	AdditionalOpsPodLabels  map[string]string
 	ShootConfig, SeedConfig *rest.Config
 	Args                    Args
 	rulesets                map[string]ruleset.Ruleset
@@ -34,11 +34,11 @@ type Provider struct {
 }
 
 type providerArgs struct {
-	OpsPodLabels        map[string]string `json:"opsPodLabels" yaml:"opsPodLabels"`
-	ShootKubeconfigPath string            `json:"shootKubeconfigPath" yaml:"shootKubeconfigPath"`
-	SeedKubeconfigPath  string            `json:"seedKubeconfigPath" yaml:"seedKubeconfigPath"`
-	ShootName           string            `json:"shootName" yaml:"shootName"`
-	ShootNamespace      string            `json:"shootNamespace" yaml:"shootNamespace"`
+	AdditionalOpsPodLabels map[string]string `json:"additionalOpsPodLabels" yaml:"additionalOpsPodLabels"`
+	ShootKubeconfigPath    string            `json:"shootKubeconfigPath" yaml:"shootKubeconfigPath"`
+	SeedKubeconfigPath     string            `json:"seedKubeconfigPath" yaml:"seedKubeconfigPath"`
+	ShootName              string            `json:"shootName" yaml:"shootName"`
+	ShootNamespace         string            `json:"shootNamespace" yaml:"shootNamespace"`
 }
 
 // Args are Gardener Provider specific arguments.
@@ -181,7 +181,7 @@ func FromGenericConfig(providerConf config.ProviderConfig) (*Provider, error) {
 	gardenerProvider, err := New(
 		WithID(providerConf.ID),
 		WithName(providerConf.Name),
-		WithOpsPodLabels(providerGardenerArgs.OpsPodLabels),
+		WithAdditionalOpsPodLabels(providerGardenerArgs.AdditionalOpsPodLabels),
 		WithSeedConfig(seedKubeConfig),
 		WithShootConfig(shootKubeConfig),
 		WithMetadata(providerConf.Metadata),

--- a/pkg/provider/gardener/ruleset/disak8sstig/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/options.go
@@ -21,10 +21,10 @@ func WithVersion(version string) CreateOption {
 	}
 }
 
-// WithOpsPodLabels sets the OpsPodLabels of a [Ruleset].
-func WithOpsPodLabels(labels map[string]string) CreateOption {
+// WithAdditionalOpsPodLabels sets the AdditionalOpsPodLabels of a [Ruleset].
+func WithAdditionalOpsPodLabels(labels map[string]string) CreateOption {
 	return func(r *Ruleset) {
-		r.OpsPodLabels = labels
+		r.AdditionalOpsPodLabels = labels
 	}
 }
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/options.go
@@ -21,6 +21,13 @@ func WithVersion(version string) CreateOption {
 	}
 }
 
+// WithOpsPodLabels sets the OpsPodLabels of a [Ruleset].
+func WithOpsPodLabels(labels map[string]string) CreateOption {
+	return func(r *Ruleset) {
+		r.OpsPodLabels = labels
+	}
+}
+
 // WithShootConfig sets the ShootConfig of a Ruleset.
 func WithShootConfig(config *rest.Config) CreateOption {
 	return func(r *Ruleset) {

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -29,7 +29,7 @@ var _ ruleset.Ruleset = &Ruleset{}
 type Ruleset struct {
 	version                 string
 	rules                   map[string]rule.Rule
-	OpsPodLabels            map[string]string
+	AdditionalOpsPodLabels  map[string]string
 	ShootConfig, SeedConfig *rest.Config
 	shootNamespace          string
 	numWorkers              int
@@ -69,11 +69,11 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, opsPodLabels map[string]string, shootConfig, seedConfig *rest.Config, shootNamespace string) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, shootConfig, seedConfig *rest.Config, shootNamespace string) (*Ruleset, error) {
 	// TODO: add all known rules and validate
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
-		WithOpsPodLabels(opsPodLabels),
+		WithAdditionalOpsPodLabels(additionalOpsPodLabels),
 		WithShootConfig(shootConfig),
 		WithSeedConfig(seedConfig),
 		WithShootNamespace(shootNamespace),

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -29,6 +29,7 @@ var _ ruleset.Ruleset = &Ruleset{}
 type Ruleset struct {
 	version                 string
 	rules                   map[string]rule.Rule
+	OpsPodLabels            map[string]string
 	ShootConfig, SeedConfig *rest.Config
 	shootNamespace          string
 	numWorkers              int
@@ -68,10 +69,11 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, shootConfig, seedConfig *rest.Config, shootNamespace string) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, opsPodLabels map[string]string, shootConfig, seedConfig *rest.Config, shootNamespace string) (*Ruleset, error) {
 	// TODO: add all known rules and validate
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
+		WithOpsPodLabels(opsPodLabels),
 		WithShootConfig(shootConfig),
 		WithSeedConfig(seedConfig),
 		WithShootNamespace(shootNamespace),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -60,12 +60,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
-	shootPodContext, err := pod.NewSimplePodContext(shootClient, r.ShootConfig, r.OpsPodLabels)
+	shootPodContext, err := pod.NewSimplePodContext(shootClient, r.ShootConfig, r.AdditionalOpsPodLabels)
 	if err != nil {
 		return err
 	}
 
-	seedPodContext, err := pod.NewSimplePodContext(seedClient, r.SeedConfig, r.OpsPodLabels)
+	seedPodContext, err := pod.NewSimplePodContext(seedClient, r.SeedConfig, r.AdditionalOpsPodLabels)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -60,12 +60,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
-	shootPodContext, err := pod.NewSimplePodContext(shootClient, r.ShootConfig)
+	shootPodContext, err := pod.NewSimplePodContext(shootClient, r.ShootConfig, r.OpsPodLabels)
 	if err != nil {
 		return err
 	}
 
-	seedPodContext, err := pod.NewSimplePodContext(seedClient, r.SeedConfig)
+	seedPodContext, err := pod.NewSimplePodContext(seedClient, r.SeedConfig, r.OpsPodLabels)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/managedk8s/options.go
+++ b/pkg/provider/managedk8s/options.go
@@ -28,6 +28,13 @@ func WithName(name string) CreateOption {
 	}
 }
 
+// WithOpsPodLabels sets the OpsPodLabels of a [Provider].
+func WithOpsPodLabels(labels map[string]string) CreateOption {
+	return func(p *Provider) {
+		p.OpsPodLabels = labels
+	}
+}
+
 // WithConfig sets the Config of a [Provider].
 func WithConfig(config *rest.Config) CreateOption {
 	return func(p *Provider) {

--- a/pkg/provider/managedk8s/options.go
+++ b/pkg/provider/managedk8s/options.go
@@ -28,10 +28,10 @@ func WithName(name string) CreateOption {
 	}
 }
 
-// WithOpsPodLabels sets the OpsPodLabels of a [Provider].
-func WithOpsPodLabels(labels map[string]string) CreateOption {
+// WithAdditionalOpsPodLabels sets the AdditionalOpsPodLabels of a [Provider].
+func WithAdditionalOpsPodLabels(labels map[string]string) CreateOption {
 	return func(p *Provider) {
-		p.OpsPodLabels = labels
+		p.AdditionalOpsPodLabels = labels
 	}
 }
 

--- a/pkg/provider/managedk8s/provider.go
+++ b/pkg/provider/managedk8s/provider.go
@@ -24,15 +24,17 @@ import (
 // Provider is a Managed Kubernetes Cluster Provider that can
 // be used to implement rules against a kubernetes cluster.
 type Provider struct {
-	id, name string
-	Config   *rest.Config
-	rulesets map[string]ruleset.Ruleset
-	metadata map[string]string
-	logger   sharedprovider.Logger
+	id, name     string
+	OpsPodLabels map[string]string
+	Config       *rest.Config
+	rulesets     map[string]ruleset.Ruleset
+	metadata     map[string]string
+	logger       sharedprovider.Logger
 }
 
 type providerArgs struct {
-	KubeconfigPath string
+	OpsPodLabels   map[string]string `json:"opsPodLabels" yaml:"opsPodLabels"`
+	KubeconfigPath string            `json:"kubeconfigPath" yaml:"kubeconfigPath"`
 }
 
 var _ provider.Provider = &Provider{}
@@ -136,6 +138,7 @@ func FromGenericConfig(providerConf config.ProviderConfig) (*Provider, error) {
 	provider, err := New(
 		WithID(providerConf.ID),
 		WithName(providerConf.Name),
+		WithOpsPodLabels(providerArgs.OpsPodLabels),
 		WithConfig(kubeconfig),
 		WithMetadata(providerConf.Metadata),
 	)

--- a/pkg/provider/managedk8s/provider.go
+++ b/pkg/provider/managedk8s/provider.go
@@ -24,17 +24,17 @@ import (
 // Provider is a Managed Kubernetes Cluster Provider that can
 // be used to implement rules against a kubernetes cluster.
 type Provider struct {
-	id, name     string
-	OpsPodLabels map[string]string
-	Config       *rest.Config
-	rulesets     map[string]ruleset.Ruleset
-	metadata     map[string]string
-	logger       sharedprovider.Logger
+	id, name               string
+	AdditionalOpsPodLabels map[string]string
+	Config                 *rest.Config
+	rulesets               map[string]ruleset.Ruleset
+	metadata               map[string]string
+	logger                 sharedprovider.Logger
 }
 
 type providerArgs struct {
-	OpsPodLabels   map[string]string `json:"opsPodLabels" yaml:"opsPodLabels"`
-	KubeconfigPath string            `json:"kubeconfigPath" yaml:"kubeconfigPath"`
+	AdditionalOpsPodLabels map[string]string `json:"additionalOpsPodLabels" yaml:"additionalOpsPodLabels"`
+	KubeconfigPath         string            `json:"kubeconfigPath" yaml:"kubeconfigPath"`
 }
 
 var _ provider.Provider = &Provider{}
@@ -138,7 +138,7 @@ func FromGenericConfig(providerConf config.ProviderConfig) (*Provider, error) {
 	provider, err := New(
 		WithID(providerConf.ID),
 		WithName(providerConf.Name),
-		WithOpsPodLabels(providerArgs.OpsPodLabels),
+		WithAdditionalOpsPodLabels(providerArgs.AdditionalOpsPodLabels),
 		WithConfig(kubeconfig),
 		WithMetadata(providerConf.Metadata),
 	)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
@@ -21,6 +21,13 @@ func WithVersion(version string) CreateOption {
 	}
 }
 
+// WithOpsPodLabels sets the OpsPodLabels of a [Ruleset].
+func WithOpsPodLabels(labels map[string]string) CreateOption {
+	return func(r *Ruleset) {
+		r.OpsPodLabels = labels
+	}
+}
+
 // WithConfig sets the Config of a [Ruleset].
 func WithConfig(config *rest.Config) CreateOption {
 	return func(r *Ruleset) {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
@@ -21,10 +21,10 @@ func WithVersion(version string) CreateOption {
 	}
 }
 
-// WithOpsPodLabels sets the OpsPodLabels of a [Ruleset].
-func WithOpsPodLabels(labels map[string]string) CreateOption {
+// WithAdditionalOpsPodLabels sets the AdditionalOpsPodLabels of a [Ruleset].
+func WithAdditionalOpsPodLabels(labels map[string]string) CreateOption {
 	return func(r *Ruleset) {
-		r.OpsPodLabels = labels
+		r.AdditionalOpsPodLabels = labels
 	}
 }
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -27,13 +27,13 @@ var _ ruleset.Ruleset = &Ruleset{}
 
 // Ruleset implements DISA Kubernetes STIG.
 type Ruleset struct {
-	version      string
-	rules        map[string]rule.Rule
-	OpsPodLabels map[string]string
-	Config       *rest.Config
-	numWorkers   int
-	instanceID   string
-	logger       *slog.Logger
+	version                string
+	rules                  map[string]rule.Rule
+	AdditionalOpsPodLabels map[string]string
+	Config                 *rest.Config
+	numWorkers             int
+	instanceID             string
+	logger                 *slog.Logger
 }
 
 // New creates a new Ruleset.
@@ -67,10 +67,10 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, opsPodLabels map[string]string, managedConfig *rest.Config) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, managedConfig *rest.Config) (*Ruleset, error) {
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
-		WithOpsPodLabels(opsPodLabels),
+		WithAdditionalOpsPodLabels(additionalOpsPodLabels),
 		WithConfig(managedConfig),
 	)
 	if err != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -27,12 +27,13 @@ var _ ruleset.Ruleset = &Ruleset{}
 
 // Ruleset implements DISA Kubernetes STIG.
 type Ruleset struct {
-	version    string
-	rules      map[string]rule.Rule
-	Config     *rest.Config
-	numWorkers int
-	instanceID string
-	logger     *slog.Logger
+	version      string
+	rules        map[string]rule.Rule
+	OpsPodLabels map[string]string
+	Config       *rest.Config
+	numWorkers   int
+	instanceID   string
+	logger       *slog.Logger
 }
 
 // New creates a new Ruleset.
@@ -66,9 +67,10 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, opsPodLabels map[string]string, managedConfig *rest.Config) (*Ruleset, error) {
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
+		WithOpsPodLabels(opsPodLabels),
 		WithConfig(managedConfig),
 	)
 	if err != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
@@ -145,11 +145,11 @@ func (r *Rule242466) checkPods(
 		additionalLabels = map[string]string{pod.LabelInstanceID: r.InstanceID}
 	)
 
-	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
-			r.Logger.Error(err.Error())
-		}
-	}()
+	// defer func() {
+	// 	if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+	// 		r.Logger.Error(err.Error())
+	// 	}
+	// }()
 
 	podExecutor, err := r.PodContext.Create(ctx, pod.NewPrivilegedPod(podName, "kube-system", imageName, nodeName, additionalLabels))
 	if err != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
@@ -145,11 +145,11 @@ func (r *Rule242466) checkPods(
 		additionalLabels = map[string]string{pod.LabelInstanceID: r.InstanceID}
 	)
 
-	// defer func() {
-	// 	if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
-	// 		r.Logger.Error(err.Error())
-	// 	}
-	// }()
+	defer func() {
+		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			r.Logger.Error(err.Error())
+		}
+	}()
 
 	podExecutor, err := r.PodContext.Create(ctx, pod.NewPrivilegedPod(podName, "kube-system", imageName, nodeName, additionalLabels))
 	if err != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11_ruleset.go
@@ -26,7 +26,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
-	podContext, err := pod.NewSimplePodContext(client, r.Config)
+	podContext, err := pod.NewSimplePodContext(client, r.Config, r.OpsPodLabels)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11_ruleset.go
@@ -26,7 +26,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
-	podContext, err := pod.NewSimplePodContext(client, r.Config, r.OpsPodLabels)
+	podContext, err := pod.NewSimplePodContext(client, r.Config, r.AdditionalOpsPodLabels)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/virtualgarden/options.go
+++ b/pkg/provider/virtualgarden/options.go
@@ -28,6 +28,13 @@ func WithName(name string) CreateOption {
 	}
 }
 
+// WithOpsPodLabels sets the OpsPodLabels of a [Provider].
+func WithOpsPodLabels(labels map[string]string) CreateOption {
+	return func(p *Provider) {
+		p.OpsPodLabels = labels
+	}
+}
+
 // WithRuntimeConfig sets the ShootConfig of a [Provider].
 func WithRuntimeConfig(config *rest.Config) CreateOption {
 	return func(p *Provider) {

--- a/pkg/provider/virtualgarden/options.go
+++ b/pkg/provider/virtualgarden/options.go
@@ -28,10 +28,10 @@ func WithName(name string) CreateOption {
 	}
 }
 
-// WithOpsPodLabels sets the OpsPodLabels of a [Provider].
-func WithOpsPodLabels(labels map[string]string) CreateOption {
+// WithAdditionalOpsPodLabels sets the AdditionalOpsPodLabels of a [Provider].
+func WithAdditionalOpsPodLabels(labels map[string]string) CreateOption {
 	return func(p *Provider) {
-		p.OpsPodLabels = labels
+		p.AdditionalOpsPodLabels = labels
 	}
 }
 

--- a/pkg/provider/virtualgarden/provider.go
+++ b/pkg/provider/virtualgarden/provider.go
@@ -24,17 +24,17 @@ import (
 // Provider is a Garden Cluster Provider that can be used to implement rules
 // against a virtual garden cluster and its controlplane (residing in a runtime cluster).
 type Provider struct {
-	id, name      string
-	OpsPodLabels  map[string]string
-	RuntimeConfig *rest.Config
-	rulesets      map[string]ruleset.Ruleset
-	metadata      map[string]string
-	logger        *slog.Logger
+	id, name               string
+	AdditionalOpsPodLabels map[string]string
+	RuntimeConfig          *rest.Config
+	rulesets               map[string]ruleset.Ruleset
+	metadata               map[string]string
+	logger                 *slog.Logger
 }
 
 type providerArgs struct {
-	OpsPodLabels          map[string]string `json:"opsPodLabels" yaml:"opsPodLabels"`
-	RuntimeKubeconfigPath string            `json:"runtimeKubeconfigPath" yaml:"runtimeKubeconfigPath"`
+	AdditionalOpsPodLabels map[string]string `json:"additionalOpsPodLabels" yaml:"additionalOpsPodLabels"`
+	RuntimeKubeconfigPath  string            `json:"runtimeKubeconfigPath" yaml:"runtimeKubeconfigPath"`
 }
 
 var _ provider.Provider = &Provider{}
@@ -138,7 +138,7 @@ func FromGenericConfig(providerConf config.ProviderConfig) (*Provider, error) {
 	gardenProvider, err := New(
 		WithID(providerConf.ID),
 		WithName(providerConf.Name),
-		WithOpsPodLabels(providerGardenArgs.OpsPodLabels),
+		WithAdditionalOpsPodLabels(providerGardenArgs.AdditionalOpsPodLabels),
 		WithRuntimeConfig(runtimeKubeconfig),
 		WithMetadata(providerConf.Metadata),
 	)

--- a/pkg/provider/virtualgarden/provider.go
+++ b/pkg/provider/virtualgarden/provider.go
@@ -25,6 +25,7 @@ import (
 // against a virtual garden cluster and its controlplane (residing in a runtime cluster).
 type Provider struct {
 	id, name      string
+	OpsPodLabels  map[string]string
 	RuntimeConfig *rest.Config
 	rulesets      map[string]ruleset.Ruleset
 	metadata      map[string]string
@@ -32,7 +33,8 @@ type Provider struct {
 }
 
 type providerArgs struct {
-	RuntimeKubeconfigPath string
+	OpsPodLabels          map[string]string `json:"opsPodLabels" yaml:"opsPodLabels"`
+	RuntimeKubeconfigPath string            `json:"runtimeKubeconfigPath" yaml:"runtimeKubeconfigPath"`
 }
 
 var _ provider.Provider = &Provider{}
@@ -136,6 +138,7 @@ func FromGenericConfig(providerConf config.ProviderConfig) (*Provider, error) {
 	gardenProvider, err := New(
 		WithID(providerConf.ID),
 		WithName(providerConf.Name),
+		WithOpsPodLabels(providerGardenArgs.OpsPodLabels),
 		WithRuntimeConfig(runtimeKubeconfig),
 		WithMetadata(providerConf.Metadata),
 	)

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
@@ -21,6 +21,13 @@ func WithVersion(version string) CreateOption {
 	}
 }
 
+// WithOpsPodLabels sets the OpsPodLabels of a [Ruleset].
+func WithOpsPodLabels(labels map[string]string) CreateOption {
+	return func(r *Ruleset) {
+		r.OpsPodLabels = labels
+	}
+}
+
 // WithRuntimeConfig sets the RuntimeConfig of a [Ruleset].
 func WithRuntimeConfig(config *rest.Config) CreateOption {
 	return func(r *Ruleset) {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
@@ -21,10 +21,10 @@ func WithVersion(version string) CreateOption {
 	}
 }
 
-// WithOpsPodLabels sets the OpsPodLabels of a [Ruleset].
-func WithOpsPodLabels(labels map[string]string) CreateOption {
+// WithAdditionalOpsPodLabels sets the AdditionalOpsPodLabels of a [Ruleset].
+func WithAdditionalOpsPodLabels(labels map[string]string) CreateOption {
 	return func(r *Ruleset) {
-		r.OpsPodLabels = labels
+		r.AdditionalOpsPodLabels = labels
 	}
 }
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -27,13 +27,13 @@ var _ ruleset.Ruleset = &Ruleset{}
 
 // Ruleset implements DISA Kubernetes STIG.
 type Ruleset struct {
-	version       string
-	rules         map[string]rule.Rule
-	OpsPodLabels  map[string]string
-	RuntimeConfig *rest.Config
-	numWorkers    int
-	instanceID    string
-	logger        *slog.Logger
+	version                string
+	rules                  map[string]rule.Rule
+	AdditionalOpsPodLabels map[string]string
+	RuntimeConfig          *rest.Config
+	numWorkers             int
+	instanceID             string
+	logger                 *slog.Logger
 }
 
 // New creates a new Ruleset.
@@ -67,10 +67,10 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, opsPodLabels map[string]string, runtimeConfig *rest.Config) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, runtimeConfig *rest.Config) (*Ruleset, error) {
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
-		WithOpsPodLabels(opsPodLabels),
+		WithAdditionalOpsPodLabels(additionalOpsPodLabels),
 		WithRuntimeConfig(runtimeConfig),
 	)
 	if err != nil {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -29,6 +29,7 @@ var _ ruleset.Ruleset = &Ruleset{}
 type Ruleset struct {
 	version       string
 	rules         map[string]rule.Rule
+	OpsPodLabels  map[string]string
 	RuntimeConfig *rest.Config
 	numWorkers    int
 	instanceID    string
@@ -66,9 +67,10 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, runtimeConfig *rest.Config) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, opsPodLabels map[string]string, runtimeConfig *rest.Config) (*Ruleset, error) {
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
+		WithOpsPodLabels(opsPodLabels),
 		WithRuntimeConfig(runtimeConfig),
 	)
 	if err != nil {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -25,7 +25,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
-	runtimePodContext, err := pod.NewSimplePodContext(runtimeClient, r.RuntimeConfig, r.OpsPodLabels)
+	runtimePodContext, err := pod.NewSimplePodContext(runtimeClient, r.RuntimeConfig, r.AdditionalOpsPodLabels)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -25,7 +25,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
-	runtimePodContext, err := pod.NewSimplePodContext(runtimeClient, r.RuntimeConfig)
+	runtimePodContext, err := pod.NewSimplePodContext(runtimeClient, r.RuntimeConfig, r.OpsPodLabels)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add the option to users to add their own labels to diki pods for the `gardener`, `managedk8s` and `virtual` provider. Diki pod specific labels cannot be overwritten. Users can add their labels by setting the `args` field `opsPodLabels` with their wanted labels.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A new field `.args.additionalOpsPodLabels` has been added to the `gardener`, `managedk8s` and `virtual` providers. The field contains key value pairs that will be added to the `diki` ops pods as additional labels.
```
