### PR TITLE
Add diki release version to generated json report

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -12,6 +12,8 @@ import (
 	"slices"
 	"time"
 
+	"k8s.io/component-base/version"
+
 	"github.com/gardener/diki/pkg/provider"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
@@ -20,9 +22,10 @@ import (
 // Report contains information about a Diki run
 // in a suitable for reporting format.
 type Report struct {
-	Time      time.Time   `json:"time"`
-	MinStatus rule.Status `json:"minStatus,omitempty"`
-	Providers []Provider  `json:"providers"`
+	Time        time.Time   `json:"time"`
+	MinStatus   rule.Status `json:"minStatus,omitempty"`
+	DikiVersion string      `json:"dikiVersion"`
+	Providers   []Provider  `json:"providers"`
 }
 
 // Provider contains information about a known provider
@@ -83,9 +86,10 @@ func FromProviderResults(results []provider.ProviderResult, options ...ReportOpt
 		o.ApplyToReport(opts)
 	}
 	report := &Report{
-		Time:      time.Now().UTC(),
-		MinStatus: opts.MinStatus,
-		Providers: make([]Provider, 0, len(results)),
+		Time:        time.Now().UTC(),
+		MinStatus:   opts.MinStatus,
+		DikiVersion: version.Get().GitVersion,
+		Providers:   make([]Provider, 0, len(results)),
 	}
 	for _, providerResult := range results {
 		p := Provider{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds additional metadata to generated json Diki report. The new metadata is `dikiVersion`, which contains the release version of Diki.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The generated `json` report summary now contains a `dikiVersion` containing the release version of `Diki`.
```
