### PR TITLE
Fix diki html report truncate

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -180,7 +180,7 @@ func generateDiffCmd(args []string, generateDiffOpts generateDiffOptions, rootOp
 
 	var writer io.Writer = os.Stdout
 	if len(rootOpts.outputPath) > 0 {
-		file, err := os.OpenFile(rootOpts.outputPath, os.O_WRONLY|os.O_CREATE, 0600)
+		file, err := os.OpenFile(rootOpts.outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return err
 		}
@@ -280,7 +280,7 @@ func generateCmd(args []string, rootOpts reportOptions, opts generateOptions, lo
 
 	var writer io.Writer = os.Stdout
 	if len(rootOpts.outputPath) > 0 {
-		file, err := os.OpenFile(rootOpts.outputPath, os.O_WRONLY|os.O_CREATE, 0600)
+		file, err := os.OpenFile(rootOpts.outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the writing of html reports by truncating the target dir.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing generated `html` reports to not truncate target path has been fixed.
```
