### PR TITLE
Add cve categorisation for diki images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,10 +19,28 @@ diki:
             image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/diki'
             dockerfile: 'Dockerfile'
             target: diki
+            resource_labels:
+            - name: "gardener.cloud/cve-categorisation"
+              value:
+                network_exposure: 'private'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'low'
+                availability_requirement: 'none'
           diki-ops:
             image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/diki-ops'
             dockerfile: 'Dockerfile'
             target: diki-ops
+            resource_labels:
+            - name: "gardener.cloud/cve-categorisation"
+              value:
+                network_exposure: 'private'
+                authentication_enforced: false
+                user_interaction: 'end-user'
+                confidentiality_requirement: 'low'
+                integrity_requirement: 'none'
+                availability_requirement: 'none'
   jobs:
     head-update:
       traits:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,8 +29,8 @@ diki:
                 confidentiality_requirement: 'high'
                 integrity_requirement: 'high'
                 availability_requirement: 'none'
-          # diki-ops is used for the priviledged pods created by diki on the control-plane and the evaluated cluster.
-          # it is a minimized image that has 2 commands: `chroot` and `nerdctl`
+          # diki-ops is used for the privileged pods created by diki on the evaluated clusters.
+          # It is a minimized image that is primarily used to run the following commands: `chroot` and `nerdctl`
           diki-ops:
             image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/diki-ops'
             dockerfile: 'Dockerfile'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,11 +22,11 @@ diki:
             resource_labels:
             - name: "gardener.cloud/cve-categorisation"
               value:
-                network_exposure: 'private'
+                network_exposure: 'protected'
                 authentication_enforced: false
-                user_interaction: 'gardener-operator'
+                user_interaction: 'end-user'
                 confidentiality_requirement: 'high'
-                integrity_requirement: 'low'
+                integrity_requirement: 'high'
                 availability_requirement: 'none'
           diki-ops:
             image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/diki-ops'
@@ -38,8 +38,8 @@ diki:
                 network_exposure: 'private'
                 authentication_enforced: false
                 user_interaction: 'end-user'
-                confidentiality_requirement: 'low'
-                integrity_requirement: 'none'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
                 availability_requirement: 'none'
   jobs:
     head-update:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -15,6 +15,7 @@ diki:
         - linux/amd64
         - linux/arm64
         dockerimages:
+          # diki is the image used to run diki with
           diki:
             image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/diki'
             dockerfile: 'Dockerfile'
@@ -28,6 +29,8 @@ diki:
                 confidentiality_requirement: 'high'
                 integrity_requirement: 'high'
                 availability_requirement: 'none'
+          # diki-ops is used for the priviledged pods created by diki on the control-plane and the evaluated cluster.
+          # it is a minimized image that has 2 commands: `chroot` and `nerdctl`
           diki-ops:
             image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/diki-ops'
             dockerfile: 'Dockerfile'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds CVE categorisation for both `diki` and `diki-ops` images

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
