### PR TITLE
Add `format` flag to `report generate` command

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -143,7 +143,7 @@ func addRunFlags(cmd *cobra.Command, opts *runOptions) {
 
 func addReportGenerateFlags(cmd *cobra.Command, opts *generateOptions) {
 	cmd.PersistentFlags().Var(cliflag.NewMapStringString(&opts.distinctBy), "distinct-by", "If set generates a merged report. The keys are the IDs for the providers which the merged report will include and the values are distinct metadata attributes to be used as IDs for the different reports.")
-	cmd.PersistentFlags().StringVar(&opts.format, "format", "html", "Format for the output report. Format can be one of 'html' or 'json'. Defaults to 'html'.")
+	cmd.PersistentFlags().StringVar(&opts.format, "format", "html", "Format for the output report. Format can be one of 'html' or 'json'.")
 }
 
 func addReportDiffFlags(cmd *cobra.Command, opts *diffOptions) {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `report generate` command now accepts a `--format` flag which determines the output format of the generated report. It can be set to one of `html` or `json`. Defaults to `html`.
```
