### PR TITLE
Fix bug causing rules to Error with "could not find files in foo"

### DIFF
--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -98,7 +98,7 @@ func GetFileStatsByDir(
 		return fileStats, err
 	}
 	if len(statsRaw) == 0 {
-		fileNum, err := podExecutor.Execute(ctx, "/bin/sh", fmt.Sprintf(`ls %s | wc -l`, dirPath))
+		fileNum, err := podExecutor.Execute(ctx, "/bin/sh", fmt.Sprintf(`find %s -type f | wc -l`, dirPath))
 		if err != nil {
 			return fileStats, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug causing rules to Error with "could not find files in foo" when there were no regular files. This bug was caused due to using the `ls` command to search for any not checked files. The `ls` command also returns special files and directories which caused the function to error when there were no regular files.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A bug causing rules that check files on nodes to error with `could not find files in foo` when there were no regular files in `foo` was fixed.
```
