### PR TITLE
Return Errored check result when kube-proxy pod cannot be found

### DIFF
--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242442.go
@@ -63,7 +63,7 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	if len(kubeProxyPods) == 0 {
-		return rule.SingleCheckResult(r, rule.FailedCheckResult("Kube-proxy pods not found!", rule.NewTarget("selector", kubeProxySelector.String()))), nil
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget("selector", kubeProxySelector.String()))), nil
 	}
 
 	for _, pod := range kubeProxyPods {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242442_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242442_test.go
@@ -188,7 +188,7 @@ var _ = Describe("#242442", func() {
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 	})
-	It("should faild when pods cannot be found", func() {
+	It("should return errored result when kube-proxy pods cannot be found", func() {
 		kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
 		r := &v1r11.Rule242442{Client: client}
 
@@ -196,7 +196,7 @@ var _ = Describe("#242442", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.FailedCheckResult("Kube-proxy pods not found!", rule.NewTarget("selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242447.go
@@ -79,7 +79,7 @@ func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	if len(pods) == 0 {
-		return rule.SingleCheckResult(r, rule.FailedCheckResult("Kube-proxy pods not found!", target.With("selector", kubeProxySelector.String()))), nil
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult("kube-proxy pods not found", target.With("selector", kubeProxySelector.String()))), nil
 	}
 
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242447_test.go
@@ -147,7 +147,7 @@ var _ = Describe("#242447", func() {
 		dikiPod.Labels = map[string]string{}
 	})
 
-	It("should fail when kube-proxy pods cannot be found", func() {
+	It("should return errored result when kube-proxy pods cannot be found", func() {
 		Expect(fakeClient.Create(ctx, Node)).To(Succeed())
 		Expect(fakeClient.Create(ctx, fooPod)).To(Succeed())
 		kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
@@ -162,7 +162,7 @@ var _ = Describe("#242447", func() {
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Kube-proxy pods not found!", rule.NewTarget("selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
 		}))
 	})
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242448.go
@@ -96,7 +96,7 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	if len(pods) == 0 {
-		return rule.SingleCheckResult(r, rule.FailedCheckResult("Kube-proxy pods not found!", target.With("selector", kubeProxySelector.String()))), nil
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult("kube-proxy pods not found", target.With("selector", kubeProxySelector.String()))), nil
 	}
 
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242448_test.go
@@ -148,7 +148,7 @@ var _ = Describe("#242448", func() {
 		dikiPod.Labels = map[string]string{}
 	})
 
-	It("should fail when kube-proxy pods cannot be found", func() {
+	It("should return errored result when kube-proxy pods cannot be found", func() {
 		Expect(fakeClient.Create(ctx, Node)).To(Succeed())
 		Expect(fakeClient.Create(ctx, fooPod)).To(Succeed())
 		kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
@@ -163,7 +163,7 @@ var _ = Describe("#242448", func() {
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Kube-proxy pods not found!", rule.NewTarget("selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
 		}))
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improved `kube-proxy` rules by making them return `Errored` check result when the `kube-proxy` pod cannot be found. `Errored` suits this case better since the rule could not be checked, hence it cannot be `Failed`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Rules that cannot find `kube-proxy` pod now return `Errored` check result.
```
