### PR TITLE
Retry rules that Error with known messages for managedk8s and virtualgarden providers

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -11,6 +11,8 @@ providers:                   # contains information about known providers
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
     version: v1r11
+    # args:
+    #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:
     # - ruleID: "242376"
     #   skip:

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -11,6 +11,8 @@ providers:               # contains information about known providers
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
     version: v1r11
+    # args:
+    #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:
     # - ruleID: "242376"
     #   skip:

--- a/pkg/provider/gardener/ruleset/disak8sstig/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/options.go
@@ -10,11 +10,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// CreateOption is a function that acts on a Ruleset
+// CreateOption is a function that acts on a [Ruleset]
 // and is used to construct such objects.
 type CreateOption func(*Ruleset)
 
-// WithVersion sets the version of a Ruleset.
+// WithVersion sets the version of a [Ruleset].
 func WithVersion(version string) CreateOption {
 	return func(r *Ruleset) {
 		r.version = version
@@ -28,28 +28,28 @@ func WithAdditionalOpsPodLabels(labels map[string]string) CreateOption {
 	}
 }
 
-// WithShootConfig sets the ShootConfig of a Ruleset.
+// WithShootConfig sets the ShootConfig of a [Ruleset].
 func WithShootConfig(config *rest.Config) CreateOption {
 	return func(r *Ruleset) {
 		r.ShootConfig = config
 	}
 }
 
-// WithSeedConfig sets the SeedConfig of a Ruleset.
+// WithSeedConfig sets the SeedConfig of a [Ruleset].
 func WithSeedConfig(config *rest.Config) CreateOption {
 	return func(r *Ruleset) {
 		r.SeedConfig = config
 	}
 }
 
-// WithShootNamespace sets the shootNamespace of a Ruleset.
+// WithShootNamespace sets the shootNamespace of a [Ruleset].
 func WithShootNamespace(shootNamespace string) CreateOption {
 	return func(r *Ruleset) {
 		r.shootNamespace = shootNamespace
 	}
 }
 
-// WithArgs sets the args of a Ruleset.
+// WithArgs sets the args of a [Ruleset].
 func WithArgs(args Args) CreateOption {
 	return func(r *Ruleset) {
 		switch {
@@ -63,7 +63,7 @@ func WithArgs(args Args) CreateOption {
 	}
 }
 
-// WithNumberOfWorkers sets the max number of Workers of a Ruleset.
+// WithNumberOfWorkers sets the max number of Workers of a [Ruleset].
 func WithNumberOfWorkers(numWorkers int) CreateOption {
 	return func(r *Ruleset) {
 		if numWorkers <= 0 {
@@ -73,7 +73,7 @@ func WithNumberOfWorkers(numWorkers int) CreateOption {
 	}
 }
 
-// WithLogger the logger of a Ruleset.
+// WithLogger the logger of a [Ruleset].
 func WithLogger(logger *slog.Logger) CreateOption {
 	return func(r *Ruleset) {
 		r.logger = logger

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -116,11 +116,12 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return fmt.Errorf("rule option 254800 error: %s", err.Error())
 	}
 
-	rcDikiPod := retry.RetryConditionFromRegex(
+	rcOpsPod := retry.RetryConditionFromRegex(
 		*retryerrors.OpsPodNotFoundRegexp,
 	)
 	rcFileChecks := retry.RetryConditionFromRegex(
 		*retryerrors.ContainerNotFoundOnNodeRegexp,
+		*retryerrors.ContainerFileNotFoundOnNodeRegexp,
 		*retryerrors.ContainerNotReadyRegexp,
 		*retryerrors.OpsPodNotFoundRegexp,
 	)
@@ -185,7 +186,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 					NodeGroupByLabels: workerPoolGroupByLabels,
 				},
 			}),
-			retry.WithRetryCondition(rcDikiPod),
+			retry.WithRetryCondition(rcOpsPod),
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
@@ -199,7 +200,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 					NodeGroupByLabels: workerPoolGroupByLabels,
 				},
 			}),
-			retry.WithRetryCondition(rcDikiPod),
+			retry.WithRetryCondition(rcOpsPod),
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		&sharedv1r11.Rule242395{Client: shootClient},
@@ -252,7 +253,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 					NodeGroupByLabels: workerPoolGroupByLabels,
 				},
 			}),
-			retry.WithRetryCondition(rcDikiPod),
+			retry.WithRetryCondition(rcOpsPod),
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		rule.NewSkipRule(

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
@@ -35,6 +35,20 @@ func WithConfig(config *rest.Config) CreateOption {
 	}
 }
 
+// WithArgs sets the args of a [Ruleset].
+func WithArgs(args Args) CreateOption {
+	return func(r *Ruleset) {
+		switch {
+		case args.MaxRetries == nil:
+			return
+		case *args.MaxRetries < 0:
+			panic("max retries should not be a negative number")
+		default:
+			r.args.MaxRetries = args.MaxRetries
+		}
+	}
+}
+
 // WithNumberOfWorkers sets the max number of Workers of a [Ruleset].
 func WithNumberOfWorkers(numWorkers int) CreateOption {
 	return func(r *Ruleset) {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -6,11 +6,13 @@ package disak8sstig
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/rule"
@@ -32,8 +34,14 @@ type Ruleset struct {
 	AdditionalOpsPodLabels map[string]string
 	Config                 *rest.Config
 	numWorkers             int
+	args                   Args
 	instanceID             string
 	logger                 *slog.Logger
+}
+
+// Args are Ruleset specific arguments.
+type Args struct {
+	MaxRetries *int `json:"maxRetries" yaml:"maxRetries"`
 }
 
 // New creates a new Ruleset.
@@ -41,6 +49,9 @@ func New(options ...CreateOption) (*Ruleset, error) {
 	r := &Ruleset{
 		rules:      map[string]rule.Rule{},
 		numWorkers: 5,
+		args: Args{
+			MaxRetries: ptr.To(1),
+		},
 		instanceID: uuid.New().String(),
 	}
 
@@ -68,10 +79,21 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, managedConfig *rest.Config) (*Ruleset, error) {
+	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
+	if err != nil {
+		return nil, err
+	}
+
+	var rulesetArgs Args
+	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
+		return nil, err
+	}
+
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
 		WithAdditionalOpsPodLabels(additionalOpsPodLabels),
 		WithConfig(managedConfig),
+		WithArgs(rulesetArgs),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
@@ -35,6 +35,20 @@ func WithRuntimeConfig(config *rest.Config) CreateOption {
 	}
 }
 
+// WithArgs sets the args of a [Ruleset].
+func WithArgs(args Args) CreateOption {
+	return func(r *Ruleset) {
+		switch {
+		case args.MaxRetries == nil:
+			return
+		case *args.MaxRetries < 0:
+			panic("max retries should not be a negative number")
+		default:
+			r.args.MaxRetries = args.MaxRetries
+		}
+	}
+}
+
 // WithNumberOfWorkers sets the max number of Workers of a [Ruleset].
 func WithNumberOfWorkers(numWorkers int) CreateOption {
 	return func(r *Ruleset) {

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
@@ -9,8 +9,10 @@ import (
 )
 
 var (
-	// ContainerNotFoundOnNodeRegexp regex to match container path on node not found
-	ContainerNotFoundOnNodeRegexp = regexp.MustCompile(`(?i)(/var/lib/kubelet/pods.*(No such file or directory|not found))`)
+	// ContainerNotFoundOnNodeRegexp regex to match container on node not found
+	ContainerNotFoundOnNodeRegexp = regexp.MustCompile(`(?i)(command /bin/sh /run/containerd.*not found)`)
+	// ContainerFileNotFoundOnNodeRegexp regex to match container file path on node not found
+	ContainerFileNotFoundOnNodeRegexp = regexp.MustCompile(`(?i)(command /bin/sh find.*No such file or directory)`)
 	// ContainerNotReadyRegexp regex to match container not yet in status or not running
 	ContainerNotReadyRegexp = regexp.MustCompile(`(?i)(container with name .* (not \(yet\) in status|not \(yet\) running))`)
 	// OpsPodNotFoundRegexp regex to match ops pod not found for DISA K8s STIG ruleset

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
@@ -16,10 +16,18 @@ var _ = Describe("retryerrors", func() {
 		func(s string, expectedResult bool) {
 			Expect(retryerrors.ContainerNotFoundOnNodeRegexp.MatchString(s)).To(Equal(expectedResult))
 		},
-		Entry("Should match container not found", "command /bin/sh find /var/lib/kubelet/pods/container-id -type f not found", true),
+		Entry("Should match container not found", "command /bin/sh /run/containerd/io.containerd.runtime.v2.task/k8s.io/id foo not found", true),
+		Entry("Should not match when it is found", "command /bin/sh /run/containerd/io.containerd.runtime.v2.task/k8s.io/id foo found", false),
+		Entry("Should not match when it is not container path", "command /bin/sh find /var/foo -type f not found", false),
+	)
+
+	DescribeTable("#ContainerFileNotFoundOnNodeRegexp",
+		func(s string, expectedResult bool) {
+			Expect(retryerrors.ContainerFileNotFoundOnNodeRegexp.MatchString(s)).To(Equal(expectedResult))
+		},
 		Entry("Should match container file not found", "command /bin/sh find /var/lib/kubelet/pods/container-id -type f No such file or directory", true),
-		Entry("Should not match when it is not found", "command /bin/sh find /var/lib/kubelet/pods/container-id -type f found", false),
-		Entry("Should not match when it is not container path", "command /bin/sh find /var/foo -type f No such file or directory", false),
+		Entry("Should not match when it is found", "command /bin/sh find /var/lib/kubelet/pods/container-id -type f found", false),
+		Entry("Should not match when it is not container file path", "command /bin/sh /run/containerd/io.containerd.runtime.v2.task/k8s.io/id foo No such file or directory", false),
 	)
 
 	DescribeTable("#ContainerNotReadyRegexp",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds retry logic to rules in the `managedk8s` and `virtualgarden` providers `disa-kubernetes-stig` ruleset. It adds them in a similar way to #257 

**Which issue(s) this PR fixes**:
Part of #253 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `disa-kubernetes-stig` ruleset rules for `virtualgarden` and `managedk8s` providers can now be retried if their results contain a known `Errored` message.
```
```feature user
The `disa-kubernetes-stig` ruleset config for `virtualgarden` and `managedk8s` providers has been enhanced with `maxRetries` setting, which sets the number of maximum retries for rule runs. Defaults to 1.
```
