### PR TITLE
Return Errored check result when pod cannot be found

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451.go
@@ -95,7 +95,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 
 			if len(pods) == 0 {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", seedTarget.With("namespace", r.ControlPlaneNamespace, "selector", podSelector.String())))
+				checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", seedTarget.With("namespace", r.ControlPlaneNamespace, "selector", podSelector.String())))
 				continue
 			}
 
@@ -110,7 +110,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 
 			if len(pods) == 0 {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", seedTarget.With("name", deploymentName, "kind", "Deployment", "namespace", r.ControlPlaneNamespace)))
+				checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", seedTarget.With("name", deploymentName, "kind", "Deployment", "namespace", r.ControlPlaneNamespace)))
 				continue
 			}
 
@@ -164,7 +164,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 	shootNodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allShootPods, shootNodes)
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", shootTarget.With("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", shootTarget.With("selector", kubeProxySelector.String())))
 	} else {
 		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, shootNodesAllocatablePods, shootTarget)
 		checkResults = append(checkResults, checks...)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451_test.go
@@ -318,12 +318,12 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		target := rule.NewTarget("cluster", "seed", "namespace", r.ControlPlaneNamespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-apiserver", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-controller-manager", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-scheduler", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found!", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-apiserver", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget("cluster", "shoot")),
 		}))
 	})

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
@@ -83,7 +83,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 
 			if len(pods) == 0 {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", seedTarget.With("namespace", r.ControlPlaneNamespace, "selector", podSelector.String())))
+				checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", seedTarget.With("namespace", r.ControlPlaneNamespace, "selector", podSelector.String())))
 				continue
 			}
 
@@ -98,7 +98,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 
 			if len(pods) == 0 {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", seedTarget.With("name", deploymentName, "kind", "Deployment", "namespace", r.ControlPlaneNamespace)))
+				checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", seedTarget.With("name", deploymentName, "kind", "Deployment", "namespace", r.ControlPlaneNamespace)))
 				continue
 			}
 
@@ -152,7 +152,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 	shootNodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allShootPods, shootNodes)
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", shootTarget.With("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", shootTarget.With("selector", kubeProxySelector.String())))
 	} else {
 		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, shootNodesAllocatablePods, shootTarget)
 		checkResults = append(checkResults, checks...)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
@@ -312,12 +312,12 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		target := rule.NewTarget("cluster", "seed", "namespace", r.ControlPlaneNamespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-apiserver", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-controller-manager", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-scheduler", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found!", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-apiserver", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget("cluster", "shoot")),
 		}))
 	})

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467.go
@@ -83,7 +83,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 
 			if len(pods) == 0 {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", seedTarget.With("namespace", r.ControlPlaneNamespace, "selector", podSelector.String())))
+				checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", seedTarget.With("namespace", r.ControlPlaneNamespace, "selector", podSelector.String())))
 				continue
 			}
 
@@ -98,7 +98,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 
 			if len(pods) == 0 {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", seedTarget.With("name", deploymentName, "kind", "Deployment", "namespace", r.ControlPlaneNamespace)))
+				checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", seedTarget.With("name", deploymentName, "kind", "Deployment", "namespace", r.ControlPlaneNamespace)))
 				continue
 			}
 
@@ -152,7 +152,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	shootNodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allShootPods, shootNodes)
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", shootTarget.With("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", shootTarget.With("selector", kubeProxySelector.String())))
 	} else {
 		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, shootNodesAllocatablePods, shootTarget)
 		checkResults = append(checkResults, checks...)

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
@@ -312,12 +312,12 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		target := rule.NewTarget("cluster", "seed", "namespace", r.ControlPlaneNamespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-apiserver", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-controller-manager", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-scheduler", "kind", "Deployment")),
-			rule.FailedCheckResult("Pods not found!", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-apiserver", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment")),
+			rule.ErroredCheckResult("pods not found", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget("cluster", "shoot")),
 		}))
 	})

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
@@ -116,7 +116,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 	image.WithOptionalTag(version.Get().GitVersion)
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", rule.NewTarget("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
 	} else {
 		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, nodesAllocatablePods, rule.NewTarget())
 		checkResults = append(checkResults, checks...)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
@@ -176,7 +176,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", rule.NewTarget("selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget()),
 		}))
 	})

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
@@ -102,7 +102,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 	image.WithOptionalTag(version.Get().GitVersion)
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", rule.NewTarget("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
 	} else {
 		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, nodesAllocatablePods, rule.NewTarget())
 		checkResults = append(checkResults, checks...)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
@@ -170,7 +170,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", rule.NewTarget("selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget()),
 		}))
 	})

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
@@ -102,7 +102,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	image.WithOptionalTag(version.Get().GitVersion)
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", rule.NewTarget("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
 	} else {
 		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, nodesAllocatablePods, rule.NewTarget())
 		checkResults = append(checkResults, checks...)

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
@@ -170,7 +170,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", rule.NewTarget("selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget()),
 		}))
 	})

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242451.go
@@ -85,7 +85,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", rule.NewTarget("namespace", r.Namespace, "selector", podSelector.String())))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("namespace", r.Namespace, "selector", podSelector.String())))
 			continue
 		}
 
@@ -100,7 +100,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", rule.NewTarget("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", rule.NewTarget("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
 			continue
 		}
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242451_test.go
@@ -254,10 +254,10 @@ var _ = Describe("#242451", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(ConsistOf([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "virtual-garden-kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "virtual-garden-kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "virtual-garden-kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "virtual-garden-kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
 		}))
 	})
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242466.go
@@ -73,7 +73,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", rule.NewTarget("namespace", r.Namespace, "selector", podSelector.String())))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("namespace", r.Namespace, "selector", podSelector.String())))
 			continue
 		}
 
@@ -88,7 +88,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", rule.NewTarget("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", rule.NewTarget("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
 			continue
 		}
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242466_test.go
@@ -251,10 +251,10 @@ var _ = Describe("#242466", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(ConsistOf([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "virtual-garden-kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "virtual-garden-kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "virtual-garden-kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "virtual-garden-kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
 		}))
 	})
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242467.go
@@ -73,7 +73,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", rule.NewTarget("namespace", r.Namespace, "selector", podSelector.String())))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("namespace", r.Namespace, "selector", podSelector.String())))
 			continue
 		}
 
@@ -88,7 +88,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", rule.NewTarget("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", rule.NewTarget("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
 			continue
 		}
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11/242467_test.go
@@ -251,10 +251,10 @@ var _ = Describe("#242467", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(ConsistOf([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "virtual-garden-kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "virtual-garden-kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "virtual-garden-kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "virtual-garden-kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
 		}))
 	})
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242445.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242445.go
@@ -87,7 +87,7 @@ func (r *Rule242445) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", target.With("namespace", r.Namespace, "selector", podSelector.String())))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", target.With("namespace", r.Namespace, "selector", podSelector.String())))
 			continue
 		}
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242445_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242445_test.go
@@ -171,8 +171,8 @@ var _ = Describe("#242445", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
 		}))
 	})
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242446.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242446.go
@@ -80,7 +80,7 @@ func (r *Rule242446) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", target.With("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", target.With("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
 			continue
 		}
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242446_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242446_test.go
@@ -253,9 +253,9 @@ var _ = Describe("#242446", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
 		}))
 	})
 
@@ -274,8 +274,8 @@ var _ = Describe("#242446", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
 		}))
 	})
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459.go
@@ -74,7 +74,7 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found!", target.With("namespace", r.Namespace, "selector", podSelector.String())))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", target.With("namespace", r.Namespace, "selector", podSelector.String())))
 			continue
 		}
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242459_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242459_test.go
@@ -170,8 +170,8 @@ var _ = Describe("#242459", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found!", target.With("selector", mainSelector.String())),
-			rule.FailedCheckResult("Pods not found!", target.With("selector", eventsSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
+			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
 		}))
 	})
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242460.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242460.go
@@ -68,7 +68,7 @@ func (r *Rule242460) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if len(pods) == 0 {
-			checkResults = append(checkResults, rule.FailedCheckResult("Pods not found for deployment!", target.With("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
+			checkResults = append(checkResults, rule.ErroredCheckResult("pods not found for deployment", target.With("name", deploymentName, "kind", "Deployment", "namespace", r.Namespace)))
 			continue
 		}
 

--- a/pkg/shared/ruleset/disak8sstig/v1r11/242460_test.go
+++ b/pkg/shared/ruleset/disak8sstig/v1r11/242460_test.go
@@ -252,9 +252,9 @@ var _ = Describe("#242460", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-apiserver", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
 		}))
 	})
 
@@ -273,8 +273,8 @@ var _ = Describe("#242460", func() {
 		target := rule.NewTarget("namespace", r.Namespace)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
-			rule.FailedCheckResult("Pods not found for deployment!", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment", "namespace", r.Namespace)),
+			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment", "namespace", r.Namespace)),
 		}))
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`Errored` suits this case better since the rule could not be checked, hence it cannot be `Failed`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Rules that cannot find specific pod now return `Errored` check result.
```
