### PR TITLE
[DISA K8s STIG] Add kubeProxyDisabled option to rules

### DIFF
--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -73,7 +73,7 @@ providers:             # contains information about known providers
           groups: ["0", "65532"]
     - ruleID: "242451"
       args:
-      # kubeProxyDisabled: true
+        # kubeProxyDisabled: true
         expectedFileOwner:
           # users and groups default to ["0"]
           #

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -23,6 +23,9 @@ providers:             # contains information about known providers
     #   skip:
     #     enabled: true
     #     justification: "the whole rule is accepted for ... reasons"
+    # - ruleID: "242400"
+    #   args:
+    #     kubeProxyDisabled: true # skip kube-proxy check
     - ruleID: "242414"
       args:
         acceptedPods:

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -73,6 +73,7 @@ providers:             # contains information about known providers
           groups: ["0", "65532"]
     - ruleID: "242451"
       args:
+      # kubeProxyDisabled: true
         expectedFileOwner:
           # users and groups default to ["0"]
           #
@@ -80,6 +81,12 @@ providers:             # contains information about known providers
           # https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8
           users: ["0", "65532"]
           groups: ["0", "65532"]
+    # - ruleID: "242466"
+    #   args:
+    #     kubeProxyDisabled: true # skip kube-proxy check
+    # - ruleID: "242467"
+    #   args:
+    #     kubeProxyDisabled: true # skip kube-proxy check
     - ruleID: "245543"
       args:
         acceptedTokens:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -137,6 +137,7 @@ providers:                   # contains information about known providers
     #       groups: ["0"]
     # - ruleID: "242451"
     #   args:
+    #     kubeProxyDisabled: true
     #     kubeProxyMatchLabels:
     #       foo: bar
     #     nodeGroupByLabels:
@@ -157,12 +158,14 @@ providers:                   # contains information about known providers
     #       groups: ["0"]
     # - ruleID: "242466"
     #   args:
+    #     kubeProxyDisabled: true # skip kube-proxy check
     #     kubeProxyMatchLabels:
     #       foo: bar
     #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242467"
     #   args:
+    #     kubeProxyDisabled: true # skip kube-proxy check
     #     kubeProxyMatchLabels:
     #       foo: bar
     #     nodeGroupByLabels:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -56,6 +56,7 @@ providers:                   # contains information about known providers
     #     - foo
     # - ruleID: "242400"
     #   args:
+    #     kubeProxyDisabled: true
     #     kubeProxyMatchLabels:
     #       foo: bar
     # - ruleID: "242404"

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
@@ -38,7 +38,12 @@ type Rule242400 struct {
 	ClusterV1RESTClient   rest.Interface
 	ClusterPodContext     pod.PodContext
 	ControlPlaneNamespace string
+	Options               *Options242400
 	Logger                provider.Logger
+}
+
+type Options242400 struct {
+	KubeProxyDisabled bool `json:"kubeProxyDisabled" yaml:"kubeProxyDisabled"`
 }
 
 func (r *Rule242400) ID() string {
@@ -105,7 +110,42 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 		}, nil
 	}
 
+	// kubelet check
+	for _, node := range nodes {
+		target := shootTarget.With("kind", "node", "name", node.Name)
+		if !kubeutils.NodeReadyStatus(node) {
+			checkResults = append(checkResults, rule.WarningCheckResult("Node is not in Ready state.", target))
+			continue
+		}
+
+		kubeletConfig, err := kubeutils.GetNodeConfigz(ctx, r.ClusterV1RESTClient, node.Name)
+		if err != nil {
+			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), target))
+			continue
+		}
+
+		// featureGates.AllAlpha defaults to false. ref https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
+		allAlpha, ok := kubeletConfig.FeatureGates["AllAlpha"]
+		switch {
+		case !ok:
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s not set.", option), target))
+		case allAlpha:
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not allowed value.", option), target))
+		default:
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s set to allowed value.", option), target))
+		}
+	}
+
 	// kube-proxy check
+	if r.Options != nil && r.Options.KubeProxyDisabled {
+		checkResults = append(checkResults, rule.SkippedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()))
+		return rule.RuleResult{
+			RuleID:       r.ID(),
+			RuleName:     r.Name(),
+			CheckResults: checkResults,
+		}, nil
+	}
+
 	allPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
 	if err != nil {
 		checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "podList")))
@@ -133,32 +173,6 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 				checkResults = append(checkResults,
 					r.checkKubeProxy(ctx, pods, nodeName, image.String())...)
 			}
-		}
-	}
-
-	// kubelet check
-	for _, node := range nodes {
-		target := shootTarget.With("kind", "node", "name", node.Name)
-		if !kubeutils.NodeReadyStatus(node) {
-			checkResults = append(checkResults, rule.WarningCheckResult("Node is not in Ready state.", target))
-			continue
-		}
-
-		kubeletConfig, err := kubeutils.GetNodeConfigz(ctx, r.ClusterV1RESTClient, node.Name)
-		if err != nil {
-			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), target))
-			continue
-		}
-
-		// featureGates.AllAlpha defaults to false. ref https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
-		allAlpha, ok := kubeletConfig.FeatureGates["AllAlpha"]
-		switch {
-		case !ok:
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s not set.", option), target))
-		case allAlpha:
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not allowed value.", option), target))
-		default:
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s set to allowed value.", option), target))
 		}
 	}
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/images"
 	"github.com/gardener/diki/pkg/shared/provider"
+	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -38,12 +39,8 @@ type Rule242400 struct {
 	ClusterV1RESTClient   rest.Interface
 	ClusterPodContext     pod.PodContext
 	ControlPlaneNamespace string
-	Options               *Options242400
+	Options               *option.KubeProxyOptions
 	Logger                provider.Logger
-}
-
-type Options242400 struct {
-	KubeProxyDisabled bool `json:"kubeProxyDisabled" yaml:"kubeProxyDisabled"`
 }
 
 func (r *Rule242400) ID() string {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
@@ -135,7 +135,7 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/images"
 	"github.com/gardener/diki/pkg/shared/provider"
-	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400.go
@@ -138,7 +138,7 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.SkippedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
@@ -367,7 +367,7 @@ var _ = Describe("#242400", func() {
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 	})
 
-	It("should return skipped check result when kubeProxyDiabled option is set to true", func() {
+	It("should return accepted check result when kubeProxyDiabled option is set to true", func() {
 		node1 := plainNode.DeepCopy()
 		node1.ObjectMeta.Name = "node1"
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
@@ -394,7 +394,7 @@ var _ = Describe("#242400", func() {
 			rule.ErroredCheckResult("deployments.apps \"kube-apiserver\" not found", rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-apiserver", "namespace", "foo")),
 			rule.ErroredCheckResult("deployments.apps \"kube-controller-manager\" not found", rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-controller-manager", "namespace", "foo")),
 			rule.ErroredCheckResult("deployments.apps \"kube-scheduler\" not found", rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-scheduler", "namespace", "foo")),
-			rule.SkippedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()),
+			rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node1")),
 		}
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
@@ -29,6 +29,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -384,7 +385,7 @@ var _ = Describe("#242400", func() {
 			ControlPlaneClient:    fakeControlPlaneClient,
 			ControlPlaneNamespace: controlPlaneNamespace,
 			ClusterV1RESTClient:   fakeRESTClient,
-			Options: &v1r11.Options242400{
+			Options: &option.KubeProxyOptions{
 				KubeProxyDisabled: true,
 			},
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242400_test.go
@@ -395,7 +395,7 @@ var _ = Describe("#242400", func() {
 			rule.ErroredCheckResult("deployments.apps \"kube-apiserver\" not found", rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-apiserver", "namespace", "foo")),
 			rule.ErroredCheckResult("deployments.apps \"kube-controller-manager\" not found", rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-controller-manager", "namespace", "foo")),
 			rule.ErroredCheckResult("deployments.apps \"kube-scheduler\" not found", rule.NewTarget("cluster", "seed", "kind", "deployment", "name", "kube-scheduler", "namespace", "foo")),
-			rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()),
+			rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node1")),
 		}
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451.go
@@ -187,7 +187,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", shootTarget))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", shootTarget))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451_test.go
@@ -418,7 +418,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 2000")),
 				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination, ownerUser: 65532, expectedOwnerUsers: [0 1000]")),
 			}),
-		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+		Entry("should return accepted check result when kubeProxyDiabled option is set to true",
 			v1r11.Options242451{
 				KubeProxyOptions: option.KubeProxyOptions{
 					KubeProxyDisabled: true,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242451_test.go
@@ -438,7 +438,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /var/lib/certs/tls.crt, ownerUser: 0, ownerGroup: 0")),
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /var/lib/keys, ownerUser: 0, ownerGroup: 0")),
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /var/lib/certs, ownerUser: 0, ownerGroup: 0")),
-				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget("cluster", "shoot")),
+				rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget("cluster", "shoot")),
 			}),
 		Entry("should return failed checkResults when cert nor key files can be found in PKI dir", nil,
 			[][]string{{emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/images"
 	"github.com/gardener/diki/pkg/shared/provider"
+	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -36,6 +37,7 @@ type Rule242466 struct {
 	ControlPlaneNamespace  string
 	ControlPlanePodContext pod.PodContext
 	ClusterPodContext      pod.PodContext
+	Options                *option.KubeProxyOptions
 	Logger                 provider.Logger
 }
 
@@ -58,6 +60,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 		nodeLabels                 = []string{"worker.gardener.cloud/pool"}
 	)
 
+	// control plane check
 	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
@@ -133,13 +136,6 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 		}, nil
 	}
 
-	var pods []corev1.Pod
-	for _, p := range allShootPods {
-		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
-			pods = append(pods, p)
-		}
-	}
-
 	shootNodes, err := kubeutils.GetNodes(ctx, r.ClusterClient, 300)
 	if err != nil {
 		checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList")))
@@ -151,18 +147,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	shootNodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allShootPods, shootNodes)
 
-	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", shootTarget.With("selector", kubeProxySelector.String())))
-	} else {
-		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, shootNodesAllocatablePods, shootTarget)
-		checkResults = append(checkResults, checks...)
-
-		for nodeName, pods := range groupedShootPods {
-			checkResults = append(checkResults,
-				r.checkPods(ctx, r.ClusterClient, r.ClusterPodContext, pods, nodeName, image.String(), expectedFilePermissionsMax, shootTarget)...)
-		}
-	}
-
+	// kubelet check
 	selectedShootNodes, checks := kubeutils.SelectNodes(shootNodes, shootNodesAllocatablePods, nodeLabels)
 	checkResults = append(checkResults, checks...)
 
@@ -173,6 +158,35 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 	for _, node := range selectedShootNodes {
 		checkResults = append(checkResults,
 			r.checkKubelet(ctx, node.Name, image.String(), expectedFilePermissionsMax, shootTarget)...)
+	}
+
+	// kube-proxy check
+	if r.Options != nil && r.Options.KubeProxyDisabled {
+		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", shootTarget))
+		return rule.RuleResult{
+			RuleID:       r.ID(),
+			RuleName:     r.Name(),
+			CheckResults: checkResults,
+		}, nil
+	}
+
+	var pods []corev1.Pod
+	for _, p := range allShootPods {
+		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
+			pods = append(pods, p)
+		}
+	}
+
+	if len(pods) == 0 {
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", shootTarget.With("selector", kubeProxySelector.String())))
+	} else {
+		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, shootNodesAllocatablePods, shootTarget)
+		checkResults = append(checkResults, checks...)
+
+		for nodeName, pods := range groupedShootPods {
+			checkResults = append(checkResults,
+				r.checkPods(ctx, r.ClusterClient, r.ClusterPodContext, pods, nodeName, image.String(), expectedFilePermissionsMax, shootTarget)...)
+		}
 	}
 
 	return rule.RuleResult{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/images"
 	"github.com/gardener/diki/pkg/shared/provider"
-	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -60,13 +60,13 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 		nodeLabels                 = []string{"worker.gardener.cloud/pool"}
 	)
 
-	// control plane check
 	image, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {
 		return rule.RuleResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
+	// control plane check
 	seedTarget := rule.NewTarget("cluster", "seed")
 	allSeedPods, err := kubeutils.GetPods(ctx, r.ControlPlaneClient, "", labels.NewSelector(), 300)
 	if err != nil {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466.go
@@ -162,7 +162,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", shootTarget))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", shootTarget))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
@@ -401,7 +401,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 644")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/file1.crt, permissions: 664, expectedPermissionsMax: 644")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 644")),
-				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget("cluster", "shoot")),
+				rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget("cluster", "shoot")),
 			}),
 		Entry("should correctly return errored checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
@@ -388,7 +388,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("no '.crt' files found in PKI directory", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "directory", "/var/lib/kubelet/pki")),
 			}),
-		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+		Entry("should return accepted check result when kubeProxyDiabled option is set to true",
 			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
 			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
@@ -24,7 +24,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
-	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242466_test.go
@@ -24,6 +24,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -278,7 +279,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		controlPlaneDikiPod.Labels = map[string]string{}
 
 		clusterDikiPod = plainPod.DeepCopy()
-		clusterDikiPod.Name = fmt.Sprintf("diki-%s-%s", sharedv1r11.ID242466, "bbbbbbbbbb")
+		clusterDikiPod.Name = fmt.Sprintf("diki-%s-%s", sharedv1r11.ID242466, "cccccccccc")
 		clusterDikiPod.Namespace = "kube-system"
 		clusterDikiPod.Labels = map[string]string{}
 
@@ -292,7 +293,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		Expect(fakeControlPlaneClient.Create(ctx, kubeSchedulerRS)).To(Succeed())
 	})
 
-	It("should fail when pods cannot be found", func() {
+	It("should error when pods cannot be found", func() {
 		mainSelector := labels.SelectorFromSet(labels.Set{"instance": "etcd-main"})
 		eventsSelector := labels.SelectorFromSet(labels.Set{"instance": "etcd-events"})
 		kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
@@ -311,19 +312,19 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		ruleResult, err := r.Run(ctx)
 		target := rule.NewTarget("cluster", "seed", "namespace", r.ControlPlaneNamespace)
 		Expect(err).To(BeNil())
-		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
+		Expect(ruleResult.CheckResults).To(ConsistOf([]rule.CheckResult{
 			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
 			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
 			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-apiserver", "kind", "Deployment")),
 			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-controller-manager", "kind", "Deployment")),
 			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-scheduler", "kind", "Deployment")),
-			rule.ErroredCheckResult("pods not found", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget("cluster", "shoot")),
+			rule.ErroredCheckResult("pods not found", rule.NewTarget("cluster", "shoot", "selector", kubeProxySelector.String())),
 		}))
 	})
 
 	DescribeTable("Run cases",
-		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, expectedCheckResults []rule.CheckResult) {
+		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, option *option.KubeProxyOptions, expectedCheckResults []rule.CheckResult) {
 			Expect(fakeControlPlaneClient.Create(ctx, etcdMainPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, etcdEventsPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, kubeAPIServerPod)).To(Succeed())
@@ -345,18 +346,19 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				ControlPlaneNamespace:  Namespace,
 				ControlPlanePodContext: fakeControlPlanePodContext,
 				ClusterPodContext:      fakeClusterPodContext,
+				Options:                option,
 			}
 
 			ruleResult, err := r.Run(ctx)
 
 			Expect(err).To(BeNil())
-			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+			Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 		},
 		Entry("should return passed checkResults when files have expected permissions",
 			[][]string{{mounts, compliantStats, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{mounts, compliantStats}, {kubeletPID, kubeletCommand, tlsKubeletConfig, compliantCertStats}},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantCertStats}, {mounts, compliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}}, nil,
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 644")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
@@ -367,9 +369,9 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should return failed checkResults when files have too wide permissions",
 			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{mounts, nonCompliantStats}, {kubeletPID, kubeletCommand, "", nonCompliantStats}},
+			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}, {mounts, nonCompliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}}, nil,
 			[]rule.CheckResult{
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 664, expectedPermissionsMax: 644")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 644")),
@@ -380,42 +382,57 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should return failed checkResults when crt files cannot be found in PKI dir",
 			[][]string{{emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID, kubeletCommand, "", noCrtStats}},
+			[][]string{{kubeletPID, kubeletCommand, "", noCrtStats}, {emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("no '.crt' files found in PKI directory", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "directory", "/var/lib/kubelet/pki")),
 			}),
+		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
+			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}},
+			[][]error{{nil, nil, nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}},
+			&option.KubeProxyOptions{
+				KubeProxyDisabled: true,
+			},
+			[]rule.CheckResult{
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 664, expectedPermissionsMax: 644")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 644")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/file1.crt, permissions: 664, expectedPermissionsMax: 644")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 644")),
+				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget("cluster", "shoot")),
+			}),
 		Entry("should correctly return errored checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID}},
+			[][]string{{kubeletPID}, {emptyMounts}},
 			[][]error{{errors.New("foo"), nil, errors.New("bar"), nil, nil, nil}},
-			[][]error{{nil}, {errors.New("foo-bar")}},
+			[][]error{{errors.New("foo-bar")}, {nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("foo", rule.NewTarget("cluster", "seed", "name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.ErroredCheckResult("bar", rule.NewTarget("cluster", "seed", "name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.ErroredCheckResult("foo-bar", rule.NewTarget("cluster", "shoot", "name", "diki-242466-cccccccccc", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo-bar", rule.NewTarget("cluster", "shoot", "name", "diki-242466-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
 		Entry("should check files when GetMountedFilesStats errors",
 			[][]string{{mountsMulty, compliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID, kubeletCommandCert, "", compliantCertStats}},
+			[][]string{{kubeletPID, kubeletCommandCert, "", compliantCertStats}, {emptyMounts}},
 			[][]error{{nil, nil, errors.New("bar"), nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("bar", rule.NewTarget("cluster", "seed", "name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 644")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
-				rule.ErroredCheckResult("kubelet cert-dir flag set to empty", rule.NewTarget("cluster", "shoot", "name", "diki-242466-cccccccccc", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("kubelet cert-dir flag set to empty", rule.NewTarget("cluster", "shoot", "name", "diki-242466-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
 		Entry("should correctly return all checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID, kubeletCommand, tlsKubeletConfig}},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig}, {emptyMounts}},
 			[][]error{{errors.New("foo"), nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, errors.New("bar")}},
+			[][]error{{nil, nil, errors.New("bar")}, {nil, nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("foo", rule.NewTarget("cluster", "seed", "name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, permissions: 600")),
-				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("cluster", "shoot", "name", "diki-242466-cccccccccc", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("cluster", "shoot", "name", "diki-242466-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467.go
@@ -162,7 +162,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", shootTarget))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", shootTarget))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/images"
 	"github.com/gardener/diki/pkg/shared/provider"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -36,6 +37,7 @@ type Rule242467 struct {
 	ControlPlaneNamespace  string
 	ControlPlanePodContext pod.PodContext
 	ClusterPodContext      pod.PodContext
+	Options                *option.KubeProxyOptions
 	Logger                 provider.Logger
 }
 
@@ -64,6 +66,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
+	// control plane check
 	seedTarget := rule.NewTarget("cluster", "seed")
 	allSeedPods, err := kubeutils.GetPods(ctx, r.ControlPlaneClient, "", labels.NewSelector(), 300)
 	if err != nil {
@@ -133,13 +136,6 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 		}, nil
 	}
 
-	var pods []corev1.Pod
-	for _, p := range allShootPods {
-		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
-			pods = append(pods, p)
-		}
-	}
-
 	shootNodes, err := kubeutils.GetNodes(ctx, r.ClusterClient, 300)
 	if err != nil {
 		checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "nodeList")))
@@ -151,18 +147,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	shootNodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allShootPods, shootNodes)
 
-	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", shootTarget.With("selector", kubeProxySelector.String())))
-	} else {
-		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, shootNodesAllocatablePods, shootTarget)
-		checkResults = append(checkResults, checks...)
-
-		for nodeName, pods := range groupedShootPods {
-			checkResults = append(checkResults,
-				r.checkPods(ctx, r.ClusterClient, r.ClusterPodContext, pods, nodeName, image.String(), expectedFilePermissionsMax, shootTarget)...)
-		}
-	}
-
+	// kubelet check
 	selectedShootNodes, checks := kubeutils.SelectNodes(shootNodes, shootNodesAllocatablePods, nodeLabels)
 	checkResults = append(checkResults, checks...)
 
@@ -173,6 +158,35 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	for _, node := range selectedShootNodes {
 		checkResults = append(checkResults,
 			r.checkKubelet(ctx, node.Name, image.String(), expectedFilePermissionsMax, shootTarget)...)
+	}
+
+	// kube-proxy check
+	if r.Options != nil && r.Options.KubeProxyDisabled {
+		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", shootTarget))
+		return rule.RuleResult{
+			RuleID:       r.ID(),
+			RuleName:     r.Name(),
+			CheckResults: checkResults,
+		}, nil
+	}
+
+	var pods []corev1.Pod
+	for _, p := range allShootPods {
+		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
+			pods = append(pods, p)
+		}
+	}
+
+	if len(pods) == 0 {
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", shootTarget.With("selector", kubeProxySelector.String())))
+	} else {
+		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, shootNodesAllocatablePods, shootTarget)
+		checkResults = append(checkResults, checks...)
+
+		for nodeName, pods := range groupedShootPods {
+			checkResults = append(checkResults,
+				r.checkPods(ctx, r.ClusterClient, r.ClusterPodContext, pods, nodeName, image.String(), expectedFilePermissionsMax, shootTarget)...)
+		}
 	}
 
 	return rule.RuleResult{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
@@ -24,6 +24,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -278,7 +279,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		controlPlaneDikiPod.Labels = map[string]string{}
 
 		clusterDikiPod = plainPod.DeepCopy()
-		clusterDikiPod.Name = fmt.Sprintf("diki-%s-%s", sharedv1r11.ID242467, "bbbbbbbbbb")
+		clusterDikiPod.Name = fmt.Sprintf("diki-%s-%s", sharedv1r11.ID242467, "cccccccccc")
 		clusterDikiPod.Namespace = "kube-system"
 		clusterDikiPod.Labels = map[string]string{}
 
@@ -292,7 +293,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		Expect(fakeControlPlaneClient.Create(ctx, kubeSchedulerRS)).To(Succeed())
 	})
 
-	It("should fail when pods cannot be found", func() {
+	It("should error when pods cannot be found", func() {
 		mainSelector := labels.SelectorFromSet(labels.Set{"instance": "etcd-main"})
 		eventsSelector := labels.SelectorFromSet(labels.Set{"instance": "etcd-events"})
 		kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
@@ -311,7 +312,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		ruleResult, err := r.Run(ctx)
 		target := rule.NewTarget("cluster", "seed", "namespace", r.ControlPlaneNamespace)
 		Expect(err).To(BeNil())
-		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
+		Expect(ruleResult.CheckResults).To(ConsistOf([]rule.CheckResult{
 			rule.ErroredCheckResult("pods not found", target.With("selector", mainSelector.String())),
 			rule.ErroredCheckResult("pods not found", target.With("selector", eventsSelector.String())),
 			rule.ErroredCheckResult("pods not found for deployment", target.With("name", "kube-apiserver", "kind", "Deployment")),
@@ -323,7 +324,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 	})
 
 	DescribeTable("Run cases",
-		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, expectedCheckResults []rule.CheckResult) {
+		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, option *option.KubeProxyOptions, expectedCheckResults []rule.CheckResult) {
 			Expect(fakeControlPlaneClient.Create(ctx, etcdMainPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, etcdEventsPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, kubeAPIServerPod)).To(Succeed())
@@ -345,18 +346,19 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				ControlPlaneNamespace:  Namespace,
 				ControlPlanePodContext: fakeControlPlanePodContext,
 				ClusterPodContext:      fakeClusterPodContext,
+				Options:                option,
 			}
 
 			ruleResult, err := r.Run(ctx)
 
 			Expect(err).To(BeNil())
-			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+			Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 		},
 		Entry("should return passed checkResults when files have expected permissions",
 			[][]string{{mounts, compliantStats, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{mounts, compliantStats}, {kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}, {mounts, compliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}}, nil,
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 640")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
@@ -367,9 +369,9 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should return failed checkResults when files have too wide permissions",
 			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{mounts, nonCompliantStats}, {kubeletPID, kubeletCommand, "", nonCompliantStats}},
+			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}, {mounts, nonCompliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}}, nil,
 			[]rule.CheckResult{
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
@@ -380,42 +382,57 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should return failed checkResults when key files cannot be found in PKI dir",
 			[][]string{{emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID, kubeletCommand, "", noKeyStats}},
+			[][]string{{kubeletPID, kubeletCommand, "", noKeyStats}, {emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("no '.key' files found in PKI directory", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "directory", "/var/lib/kubelet/pki")),
 			}),
+		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
+			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}},
+			[][]error{{nil, nil, nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}},
+			&option.KubeProxyOptions{
+				KubeProxyDisabled: true,
+			},
+			[]rule.CheckResult{
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
+				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget("cluster", "shoot")),
+			}),
 		Entry("should correctly return errored checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID}},
+			[][]string{{kubeletPID}, {emptyMounts}},
 			[][]error{{errors.New("foo"), nil, errors.New("bar"), nil, nil, nil}},
-			[][]error{{nil}, {errors.New("foo-bar")}},
+			[][]error{{errors.New("foo-bar")}, {nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("foo", rule.NewTarget("cluster", "seed", "name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.ErroredCheckResult("bar", rule.NewTarget("cluster", "seed", "name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.ErroredCheckResult("foo-bar", rule.NewTarget("cluster", "shoot", "name", "diki-242467-cccccccccc", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo-bar", rule.NewTarget("cluster", "shoot", "name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
 		Entry("should check files when GetMountedFilesStats errors",
 			[][]string{{mountsMulty, compliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID, kubeletCommandCert, "", compliantKeyStats}},
+			[][]string{{kubeletPID, kubeletCommandCert, "", compliantKeyStats}, {emptyMounts}},
 			[][]error{{nil, nil, errors.New("bar"), nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]error{{nil, nil, nil, nil}, {nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("bar", rule.NewTarget("cluster", "seed", "name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 640")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
-				rule.ErroredCheckResult("kubelet cert-dir flag set to empty", rule.NewTarget("cluster", "shoot", "name", "diki-242467-cccccccccc", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("kubelet cert-dir flag set to empty", rule.NewTarget("cluster", "shoot", "name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
 		Entry("should correctly return all checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
-			[][]string{{emptyMounts}, {kubeletPID, kubeletCommand, tlsKubeletConfig}},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig}, {emptyMounts}},
 			[][]error{{errors.New("foo"), nil, nil, nil, nil, nil}},
-			[][]error{{nil, nil}, {nil, nil, errors.New("bar")}},
+			[][]error{{nil, nil, errors.New("bar")}, {nil}}, nil,
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("foo", rule.NewTarget("cluster", "seed", "name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("cluster", "seed", "name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.key, permissions: 600")),
-				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("cluster", "shoot", "name", "diki-242467-cccccccccc", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("cluster", "shoot", "name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 			}),
 	)
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
@@ -388,7 +388,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("no '.key' files found in PKI directory", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "directory", "/var/lib/kubelet/pki")),
 			}),
-		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+		Entry("should return accepted check result when kubeProxyDiabled option is set to true",
 			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
 			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/242467_test.go
@@ -401,7 +401,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "shoot", "name", "node01", "kind", "node", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
-				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget("cluster", "shoot")),
+				rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget("cluster", "shoot")),
 			}),
 		Entry("should correctly return errored checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
@@ -5,7 +5,7 @@
 package v1r11
 
 import (
-	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
@@ -10,5 +10,10 @@ import (
 )
 
 type RuleOption interface {
-	Options242400 | option.Options242414 | option.Options242415 | sharedv1r11.Options245543 | sharedv1r11.Options254800 | option.FileOwnerOptions
+	option.Options242414 |
+		option.Options242415 |
+		sharedv1r11.Options245543 |
+		sharedv1r11.Options254800 |
+		option.FileOwnerOptions |
+		option.KubeProxyOptions
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
@@ -12,6 +12,7 @@ import (
 type RuleOption interface {
 	option.Options242414 |
 		option.Options242415 |
+		Options242451 |
 		sharedv1r11.Options245543 |
 		sharedv1r11.Options254800 |
 		option.FileOwnerOptions |

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11/options.go
@@ -10,5 +10,5 @@ import (
 )
 
 type RuleOption interface {
-	option.Options242414 | option.Options242415 | sharedv1r11.Options245543 | sharedv1r11.Options254800 | option.FileOwnerOptions
+	Options242400 | option.Options242414 | option.Options242415 | sharedv1r11.Options245543 | sharedv1r11.Options254800 | option.FileOwnerOptions
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -111,6 +111,10 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	if err != nil {
 		return fmt.Errorf("rule option 242466 error: %s", err.Error())
 	}
+	opts242467, err := getV1R11OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedv1r11.ID242467].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242467 error: %s", err.Error())
+	}
 	opts242451, err := getV1R11OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedv1r11.ID242451].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242451 error: %s", err.Error())
@@ -615,6 +619,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 				ControlPlanePodContext: seedPodContext,
 				ClusterPodContext:      shootPodContext,
 				ControlPlaneNamespace:  r.shootNamespace,
+				Options:                opts242467,
 			}),
 			retry.WithRetryCondition(rcFileChecks),
 			retry.WithMaxRetries(*r.args.MaxRetries),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -107,6 +107,10 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	if err != nil {
 		return fmt.Errorf("rule option 242446 error: %s", err.Error())
 	}
+	opts242466, err := getV1R11OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedv1r11.ID242466].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242466 error: %s", err.Error())
+	}
 	opts242451, err := getV1R11OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedv1r11.ID242451].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242451 error: %s", err.Error())
@@ -596,6 +600,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 				ControlPlanePodContext: seedPodContext,
 				ClusterPodContext:      shootPodContext,
 				ControlPlaneNamespace:  r.shootNamespace,
+				Options:                opts242466,
 			}),
 			retry.WithRetryCondition(rcFileChecks),
 			retry.WithMaxRetries(*r.args.MaxRetries),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -87,7 +87,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
-	opts242400, err := getV1R11OptionOrNil[v1r11.Options242400](ruleOptions[sharedv1r11.ID242400].Args)
+	opts242400, err := getV1R11OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedv1r11.ID242400].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242400 error: %s", err.Error())
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -87,6 +87,10 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		return err
 	}
 
+	opts242400, err := getV1R11OptionOrNil[v1r11.Options242400](ruleOptions[sharedv1r11.ID242400].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242400 error: %s", err.Error())
+	}
 	opts242414, err := getV1R11OptionOrNil[option.Options242414](ruleOptions[sharedv1r11.ID242414].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242414 error: %s", err.Error())
@@ -236,6 +240,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 				ClusterPodContext:     shootPodContext,
 				ClusterV1RESTClient:   shootClientSet.CoreV1().RESTClient(),
 				ControlPlaneNamespace: r.shootNamespace,
+				Options:               opts242400,
 			}),
 			retry.WithRetryCondition(rcFileChecks),
 			retry.WithMaxRetries(*r.args.MaxRetries),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -107,6 +107,10 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	if err != nil {
 		return fmt.Errorf("rule option 242446 error: %s", err.Error())
 	}
+	opts242451, err := getV1R11OptionOrNil[v1r11.Options242451](ruleOptions[sharedv1r11.ID242451].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242451 error: %s", err.Error())
+	}
 	opts242466, err := getV1R11OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedv1r11.ID242466].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242466 error: %s", err.Error())
@@ -114,10 +118,6 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 	opts242467, err := getV1R11OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedv1r11.ID242467].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242467 error: %s", err.Error())
-	}
-	opts242451, err := getV1R11OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedv1r11.ID242451].Args)
-	if err != nil {
-		return fmt.Errorf("rule option 242451 error: %s", err.Error())
 	}
 	opts245543, err := getV1R11OptionOrNil[sharedv1r11.Options245543](ruleOptions[sharedv1r11.ID245543].Args)
 	if err != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400.go
@@ -44,6 +44,7 @@ type Rule242400 struct {
 }
 
 type Options242400 struct {
+	option.KubeProxyOptions
 	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
 }
 
@@ -81,7 +82,42 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.WarningCheckResult("No nodes found.", rule.NewTarget())), nil
 	}
 
+	// kubelet check
+	for _, node := range nodes {
+		target := rule.NewTarget("kind", "node", "name", node.Name)
+		if !kubeutils.NodeReadyStatus(node) {
+			checkResults = append(checkResults, rule.WarningCheckResult("Node is not in Ready state.", target))
+			continue
+		}
+
+		kubeletConfig, err := kubeutils.GetNodeConfigz(ctx, r.V1RESTClient, node.Name)
+		if err != nil {
+			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), target))
+			continue
+		}
+
+		// featureGates.AllAlpha defaults to false. ref https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
+		allAlpha, ok := kubeletConfig.FeatureGates["AllAlpha"]
+		switch {
+		case !ok:
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s not set.", option), target))
+		case allAlpha:
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not allowed value.", option), target))
+		default:
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s set to allowed value.", option), target))
+		}
+	}
+
 	// kube-proxy check
+	if r.Options != nil && r.Options.KubeProxyDisabled {
+		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()))
+		return rule.RuleResult{
+			RuleID:       r.ID(),
+			RuleName:     r.Name(),
+			CheckResults: checkResults,
+		}, nil
+	}
+
 	allPods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)
 	if err != nil {
 		checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "podList")))
@@ -108,32 +144,6 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 			for nodeName, pods := range groupedPods {
 				checkResults = append(checkResults, r.checkKubeProxy(ctx, pods, nodeName, image.String())...)
 			}
-		}
-	}
-
-	// kubelet check
-	for _, node := range nodes {
-		target := rule.NewTarget("kind", "node", "name", node.Name)
-		if !kubeutils.NodeReadyStatus(node) {
-			checkResults = append(checkResults, rule.WarningCheckResult("Node is not in Ready state.", target))
-			continue
-		}
-
-		kubeletConfig, err := kubeutils.GetNodeConfigz(ctx, r.V1RESTClient, node.Name)
-		if err != nil {
-			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), target))
-			continue
-		}
-
-		// featureGates.AllAlpha defaults to false. ref https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
-		allAlpha, ok := kubeletConfig.FeatureGates["AllAlpha"]
-		switch {
-		case !ok:
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s not set.", option), target))
-		case allAlpha:
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not allowed value.", option), target))
-		default:
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Option %s set to allowed value.", option), target))
 		}
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400.go
@@ -110,7 +110,7 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
@@ -321,7 +321,7 @@ var _ = Describe("#242400", func() {
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 	})
 
-	It("should return skipped check result when kubeProxyDiabled option is set to true", func() {
+	It("should return accepted check result when kubeProxyDiabled option is set to true", func() {
 		node1 := plainNode.DeepCopy()
 		node1.ObjectMeta.Name = "node1"
 		Expect(fakeClient.Create(ctx, node1)).To(Succeed())

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
@@ -347,7 +347,7 @@ var _ = Describe("#242400", func() {
 		ruleResult, err := r.Run(ctx)
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()),
+			rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("kind", "node", "name", "node1")),
 		}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242400_test.go
@@ -28,6 +28,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -313,6 +314,40 @@ var _ = Describe("#242400", func() {
 
 		expectedCheckResults := []rule.CheckResult{
 			rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget("selector", "role=proxy")),
+			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("kind", "node", "name", "node1")),
+		}
+
+		Expect(err).To(BeNil())
+		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
+	})
+
+	It("should return skipped check result when kubeProxyDiabled option is set to true", func() {
+		node1 := plainNode.DeepCopy()
+		node1.ObjectMeta.Name = "node1"
+		Expect(fakeClient.Create(ctx, node1)).To(Succeed())
+
+		fakeRESTClient = &manualfake.RESTClient{
+			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
+			NegotiatedSerializer: scheme.Codecs,
+			Client: manualfake.CreateHTTPClient(func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(podSecurityNotSetNodeConfig)))}, nil
+			}),
+		}
+		r := &v1r11.Rule242400{
+			InstanceID:   instanceID,
+			Client:       fakeClient,
+			PodContext:   fakePodContext,
+			V1RESTClient: fakeRESTClient,
+			Options: &v1r11.Options242400{
+				KubeProxyOptions: option.KubeProxyOptions{
+					KubeProxyDisabled: true,
+				},
+			},
+		}
+		ruleResult, err := r.Run(ctx)
+
+		expectedCheckResults := []rule.CheckResult{
+			rule.AcceptedCheckResult("Kube-proxy is disabled for cluster.", rule.NewTarget()),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("kind", "node", "name", "node1")),
 		}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
@@ -41,6 +41,7 @@ type Rule242451 struct {
 }
 
 type Options242451 struct {
+	option.KubeProxyOptions
 	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
 	NodeGroupByLabels    []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 	*option.FileOwnerOptions
@@ -97,12 +98,6 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "podList"))), nil
 	}
 
-	for _, p := range allPods {
-		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
-			pods = append(pods, p)
-		}
-	}
-
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "nodeList"))), nil
@@ -115,18 +110,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
-	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
-	} else {
-		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, nodesAllocatablePods, rule.NewTarget())
-		checkResults = append(checkResults, checks...)
-
-		for nodeName, pods := range groupedShootPods {
-			checkResults = append(checkResults,
-				r.checkPods(ctx, pods, nodeName, image.String(), options)...)
-		}
-	}
-
+	// kubelet check
 	selectedShootNodes, checks := kubeutils.SelectNodes(nodes, nodesAllocatablePods, nodeLabels)
 	checkResults = append(checkResults, checks...)
 
@@ -137,6 +121,34 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 	for _, node := range selectedShootNodes {
 		checkResults = append(checkResults,
 			r.checkKubelet(ctx, node.Name, image.String(), options)...)
+	}
+
+	// kube-proxy check
+	if r.Options != nil && r.Options.KubeProxyDisabled {
+		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()))
+		return rule.RuleResult{
+			RuleID:       r.ID(),
+			RuleName:     r.Name(),
+			CheckResults: checkResults,
+		}, nil
+	}
+
+	for _, p := range allPods {
+		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
+			pods = append(pods, p)
+		}
+	}
+
+	if len(pods) == 0 {
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
+	} else {
+		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, nodesAllocatablePods, rule.NewTarget())
+		checkResults = append(checkResults, checks...)
+
+		for nodeName, pods := range groupedShootPods {
+			checkResults = append(checkResults,
+				r.checkPods(ctx, pods, nodeName, image.String(), options)...)
+		}
 	}
 
 	return rule.RuleResult{

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451.go
@@ -125,7 +125,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
@@ -302,7 +302,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/certs/tls.crt, ownerUser: 0, ownerGroup: 0")),
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/keys, ownerUser: 0, ownerGroup: 0")),
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/certs, ownerUser: 0, ownerGroup: 0")),
-				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()),
+				rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()),
 			}),
 		Entry("should correctly return errored checkResults when commands error", nil,
 			[][]string{{kubeletPID}, {mounts, mounts, compliantStats2}},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242451_test.go
@@ -289,7 +289,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 2000")),
 				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /destination, ownerUser: 65532, expectedOwnerUsers: [0 1000]")),
 			}),
-		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+		Entry("should return accepted check result when kubeProxyDiabled option is set to true",
 			v1r11.Options242451{
 				KubeProxyOptions: option.KubeProxyOptions{
 					KubeProxyDisabled: true,

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466.go
@@ -111,7 +111,7 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
@@ -263,7 +263,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			[][]error{{nil, nil, nil, nil}, {nil, nil}},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/certs/tls.crt, permissions: 644")),
-				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()),
+				rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()),
 			}),
 		Entry("should correctly return errored checkResults when commands error", nil,
 			[][]string{{kubeletPID}, {mounts, mounts, compliantStats2}},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242466_test.go
@@ -253,7 +253,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.WarningCheckResult("Node is missing a label", rule.NewTarget("name", "node01", "kind", "node", "label", "foo")),
 				rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget()),
 			}),
-		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+		Entry("should return accepted check result when kubeProxyDiabled option is set to true",
 			v1r11.Options242466{
 				KubeProxyOptions: option.KubeProxyOptions{
 					KubeProxyDisabled: true,

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
@@ -111,7 +111,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	// kube-proxy check
 	if r.Options != nil && r.Options.KubeProxyDisabled {
-		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()))
+		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()))
 		return rule.RuleResult{
 			RuleID:       r.ID(),
 			RuleName:     r.Name(),

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467.go
@@ -41,6 +41,7 @@ type Rule242467 struct {
 }
 
 type Options242467 struct {
+	option.KubeProxyOptions
 	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
 	NodeGroupByLabels    []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
@@ -83,12 +84,6 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "podList"))), nil
 	}
 
-	for _, p := range allPods {
-		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
-			pods = append(pods, p)
-		}
-	}
-
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)
 	if err != nil {
 		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "nodeList"))), nil
@@ -101,18 +96,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
-	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
-	} else {
-		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, nodesAllocatablePods, rule.NewTarget())
-		checkResults = append(checkResults, checks...)
-
-		for nodeName, pods := range groupedShootPods {
-			checkResults = append(checkResults,
-				r.checkPods(ctx, pods, nodeName, image.String(), expectedFilePermissionsMax)...)
-		}
-	}
-
+	// kubelet check
 	selectedShootNodes, checks := kubeutils.SelectNodes(nodes, nodesAllocatablePods, nodeLabels)
 	checkResults = append(checkResults, checks...)
 
@@ -123,6 +107,34 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	for _, node := range selectedShootNodes {
 		checkResults = append(checkResults,
 			r.checkKubelet(ctx, node.Name, image.String(), expectedFilePermissionsMax)...)
+	}
+
+	// kube-proxy check
+	if r.Options != nil && r.Options.KubeProxyDisabled {
+		checkResults = append(checkResults, rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()))
+		return rule.RuleResult{
+			RuleID:       r.ID(),
+			RuleName:     r.Name(),
+			CheckResults: checkResults,
+		}, nil
+	}
+
+	for _, p := range allPods {
+		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
+			pods = append(pods, p)
+		}
+	}
+
+	if len(pods) == 0 {
+		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
+	} else {
+		groupedShootPods, checks := kubeutils.SelectPodOfReferenceGroup(pods, nodesAllocatablePods, rule.NewTarget())
+		checkResults = append(checkResults, checks...)
+
+		for nodeName, pods := range groupedShootPods {
+			checkResults = append(checkResults,
+				r.checkPods(ctx, pods, nodeName, image.String(), expectedFilePermissionsMax)...)
+		}
 	}
 
 	return rule.RuleResult{

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
@@ -250,7 +250,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}},
 			[][]error{{nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()),
+				rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/keys/tls.key, permissions: 640")),
 			}),
 		Entry("should check only nodes wtih labels",

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
@@ -241,7 +241,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/keys/tls.key, permissions: 640")),
 			}),
-		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+		Entry("should return accepted check result when kubeProxyDiabled option is set to true",
 			v1r11.Options242467{
 				KubeProxyOptions: option.KubeProxyOptions{
 					KubeProxyDisabled: true,

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11/242467_test.go
@@ -23,6 +23,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedv1r11 "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/v1r11"
 )
 
@@ -75,7 +76,8 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		kubeProxyPod1  *corev1.Pod
 		kubeProxyPod2  *corev1.Pod
 		fooPod         *corev1.Pod
-		dikiPod        *corev1.Pod
+		dikiPod1       *corev1.Pod
+		dikiPod2       *corev1.Pod
 		ctx            = context.TODO()
 	)
 
@@ -151,10 +153,14 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		fooPod = plainPod.DeepCopy()
 		fooPod.Name = "foo"
 
-		dikiPod = plainPod.DeepCopy()
-		dikiPod.Name = fmt.Sprintf("diki-%s-%s", sharedv1r11.ID242467, "aaaaaaaaaa")
-		dikiPod.Namespace = "kube-system"
-		dikiPod.Labels = map[string]string{}
+		dikiPod1 = plainPod.DeepCopy()
+		dikiPod1.Name = fmt.Sprintf("diki-%s-%s", sharedv1r11.ID242467, "aaaaaaaaaa")
+		dikiPod1.Namespace = "kube-system"
+		dikiPod1.Labels = map[string]string{}
+		dikiPod2 = plainPod.DeepCopy()
+		dikiPod2.Name = fmt.Sprintf("diki-%s-%s", sharedv1r11.ID242467, "bbbbbbbbbb")
+		dikiPod2.Namespace = "kube-system"
+		dikiPod2.Labels = map[string]string{}
 	})
 
 	It("should fail when etcd pods cannot be found", func() {
@@ -169,7 +175,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
-		Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
+		Expect(ruleResult.CheckResults).To(ConsistOf([]rule.CheckResult{
 			rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget()),
 		}))
@@ -181,7 +187,8 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			Expect(fakeClient.Create(ctx, kubeProxyPod1)).To(Succeed())
 			Expect(fakeClient.Create(ctx, kubeProxyPod2)).To(Succeed())
 			Expect(fakeClient.Create(ctx, fooPod)).To(Succeed())
-			Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
+			Expect(fakeClient.Create(ctx, dikiPod1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, dikiPod2)).To(Succeed())
 
 			fakePodContext = fakepod.NewFakeSimplePodContext(executeReturnString, executeReturnError)
 			r := &v1r11.Rule242467{
@@ -195,10 +202,10 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			ruleResult, err := r.Run(ctx)
 
 			Expect(err).To(BeNil())
-			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+			Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 		},
 		Entry("should return passed checkResults when files have expected permissions", nil,
-			[][]string{{mounts, compliantStats, mounts, compliantStats2}, {kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}, {mounts, compliantStats, mounts, compliantStats2}},
 			[][]error{{nil, nil, nil, nil}, {nil, nil, nil, nil}},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 600")),
@@ -207,8 +214,8 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/keys/tls.key, permissions: 640")),
 			}),
 		Entry("should return failed checkResults when files have too wide permissions", nil,
-			[][]string{{mounts, nonCompliantStats, emptyMounts}, {kubeletPID, kubeletCommand, "", nonCompliantStats}},
-			[][]error{{nil, nil, nil}, {nil, nil, nil, nil}},
+			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}, {mounts, nonCompliantStats, emptyMounts}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil, nil}},
 			[]rule.CheckResult{
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
@@ -216,8 +223,8 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
 			}),
 		Entry("should return failed checkResults when key files cannot be found in PKI dir", nil,
-			[][]string{{emptyMounts, emptyMounts}, {kubeletPID, kubeletCommand, "", noKeyStats}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]string{{kubeletPID, kubeletCommand, "", noKeyStats}, {emptyMounts, emptyMounts}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}},
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("no '.key' files found in PKI directory", rule.NewTarget("name", "node01", "kind", "node", "directory", "/var/lib/kubelet/pki")),
 			}),
@@ -227,11 +234,23 @@ tlsCertFile: /var/lib/certs/tls.crt`
 					"component": "kube-proxy",
 				},
 			},
-			[][]string{{mounts, compliantStats}, {kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}},
-			[][]error{{nil, nil}, {nil, nil, nil, nil}},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}, {mounts, compliantStats}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil}},
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/keys/tls.key, permissions: 640")),
+			}),
+		Entry("should return skipped check result when kubeProxyDiabled option is set to true",
+			v1r11.Options242467{
+				KubeProxyOptions: option.KubeProxyOptions{
+					KubeProxyDisabled: true,
+				},
+			},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}},
+			[][]error{{nil, nil, nil, nil}},
+			[]rule.CheckResult{
+				rule.AcceptedCheckResult("Kube-proxy is disabled for cluster", rule.NewTarget()),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "node01", "kind", "node", "details", "fileName: /var/lib/keys/tls.key, permissions: 640")),
 			}),
 		Entry("should check only nodes wtih labels",
@@ -247,30 +266,30 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget()),
 			}),
 		Entry("should correctly return errored checkResults when commands error", nil,
-			[][]string{{mounts, mounts, compliantStats2}, {kubeletPID}},
-			[][]error{{errors.New("foo"), nil, errors.New("bar")}, {errors.New("foo-bar")}},
+			[][]string{{kubeletPID}, {mounts, mounts, compliantStats2}},
+			[][]error{{errors.New("foo-bar")}, {errors.New("foo"), nil, errors.New("bar")}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.ErroredCheckResult("foo-bar", rule.NewTarget("name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo-bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 			}),
 		Entry("should check files when GetMountedFilesStats errors", nil,
-			[][]string{{mountsMulty, compliantStats, emptyMounts, emptyMounts},
-				{kubeletPID, kubeletCommandCert, "", compliantKeyStats}},
-			[][]error{{nil, nil, errors.New("bar"), nil, nil}, {nil, nil, nil, nil}},
+			[][]string{{kubeletPID, kubeletCommandCert, "", compliantKeyStats},
+				{mountsMulty, compliantStats, emptyMounts, emptyMounts}},
+			[][]error{{nil, nil, nil, nil}, {nil, nil, errors.New("bar"), nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
-				rule.ErroredCheckResult("kubelet cert-dir flag set to empty", rule.NewTarget("name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("kubelet cert-dir flag set to empty", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 			}),
 		Entry("should correctly return all checkResults when commands error", nil,
-			[][]string{{mounts, mounts, compliantStats2}, {kubeletPID, kubeletCommand, tlsKubeletConfig}},
-			[][]error{{errors.New("foo"), nil, nil}, {nil, nil, errors.New("bar")}},
+			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig}, {mounts, mounts, compliantStats2}},
+			[][]error{{nil, nil, errors.New("bar")}, {errors.New("foo"), nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.key, permissions: 600")),
-				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 			}),
 	)
 })

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -141,3 +141,8 @@ func ValidateLabelNames(labelNames []string, fldPath *field.Path) field.ErrorLis
 	}
 	return allErrs
 }
+
+// KubeProxyOptions contains options for kube-proxy rules
+type KubeProxyOptions struct {
+	KubeProxyDisabled bool `json:"kubeProxyDisabled" yaml:"kubeProxyDisabled"`
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add a new rule option `kubeProxyDisabled` to rules that check the `kube-proxy` while checking other components as well. When the `kubeProxyDisabled` is set to `true` the `kube-proxy` check will be skipped.

This change is needed since a cluster can work without `kube-proxy` and adding the option will provide a way for rules that check not only the `kube-proxy` to skip only the `kube-proxy` check.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A new rule option `kubeProxyDisabled` is added to rules that check many components, which contain the `kube-proxy`. Setting this option to `true` would skip only the `kube-proxy` check in the rule. Defaults to `true`.
```
