### PR TITLE
Add glossary to html reports

### DIFF
--- a/pkg/report/difference.go
+++ b/pkg/report/difference.go
@@ -322,7 +322,7 @@ func rulesetDiffSummaryText(statusesCount map[rule.Status]int) string {
 			if summaryBuilder.Len() > 0 {
 				summaryBuilder.WriteString(", ")
 			}
-			summaryBuilder.WriteString(fmt.Sprintf("%dx %s %c", val, status, rule.GetStatusIcon(status)))
+			summaryBuilder.WriteString(fmt.Sprintf("%dx %s %c", val, status, rule.StatusIcon(status)))
 		}
 	}
 	if summaryBuilder.Len() == 0 {

--- a/pkg/report/merged_report.go
+++ b/pkg/report/merged_report.go
@@ -254,7 +254,7 @@ func mergedRulesetSummaryText(ruleset *MergedRuleset) string {
 			if len(summaryText) > 0 {
 				summaryText = fmt.Sprintf("%s, ", summaryText)
 			}
-			summaryText = fmt.Sprintf("%s%dx %s %c", summaryText, num, status, rule.GetStatusIcon(status))
+			summaryText = fmt.Sprintf("%s%dx %s %c", summaryText, num, status, rule.StatusIcon(status))
 		}
 	}
 	return summaryText

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -59,7 +59,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 
 	parsedReport, err := template.New(tmplReportName+".html").Funcs(template.FuncMap{
 		"getStatuses":        rule.Statuses,
-		"statusIcon":         rule.GetStatusIcon,
+		"statusIcon":         rule.StatusIcon,
 		"statusDescription":  rule.StatusDescription,
 		"time":               convTimeFunc,
 		"yamlFormat":         yamlFormat,
@@ -74,7 +74,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 
 	parsedMergedReport, err := template.New(tmplMergedReportName+".html").Funcs(template.FuncMap{
 		"getStatuses":              rule.Statuses,
-		"statusIcon":               rule.GetStatusIcon,
+		"statusIcon":               rule.StatusIcon,
 		"statusDescription":        rule.StatusDescription,
 		"time":                     convTimeFunc,
 		"yamlFormat":               yamlFormat,
@@ -91,7 +91,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 	parsedDifferenceReport, err := template.New(tmplDifferenceReportName+".html").Funcs(template.FuncMap{
 		"add":                           add,
 		"getStatuses":                   rule.Statuses,
-		"statusIcon":                    rule.GetStatusIcon,
+		"statusIcon":                    rule.StatusIcon,
 		"statusDescription":             rule.StatusDescription,
 		"rulesetDiffAddedSummaryText":   rulesetDiffAddedSummaryText,
 		"rulesetDiffRemovedSummaryText": rulesetDiffRemovedSummaryText,

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -60,7 +60,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 	parsedReport, err := template.New(tmplReportName+".html").Funcs(template.FuncMap{
 		"getStatuses":        rule.Statuses,
 		"statusIcon":         rule.GetStatusIcon,
-		"statusMeaning":      rule.GetStatusMeaning,
+		"statusDescription":  rule.StatusDescription,
 		"time":               convTimeFunc,
 		"yamlFormat":         yamlFormat,
 		"rulesetSummaryText": rulesetSummaryText,
@@ -75,7 +75,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 	parsedMergedReport, err := template.New(tmplMergedReportName+".html").Funcs(template.FuncMap{
 		"getStatuses":              rule.Statuses,
 		"statusIcon":               rule.GetStatusIcon,
-		"statusMeaning":            rule.GetStatusMeaning,
+		"statusDescription":        rule.StatusDescription,
 		"time":                     convTimeFunc,
 		"yamlFormat":               yamlFormat,
 		"mergedMetadataTexts":      metadataTextForMergedProvider,
@@ -92,7 +92,7 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 		"add":                           add,
 		"getStatuses":                   rule.Statuses,
 		"statusIcon":                    rule.GetStatusIcon,
-		"statusMeaning":                 rule.GetStatusMeaning,
+		"statusDescription":             rule.StatusDescription,
 		"rulesetDiffAddedSummaryText":   rulesetDiffAddedSummaryText,
 		"rulesetDiffRemovedSummaryText": rulesetDiffRemovedSummaryText,
 		"keyExists":                     keyExists,

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -59,7 +59,8 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 
 	parsedReport, err := template.New(tmplReportName+".html").Funcs(template.FuncMap{
 		"getStatuses":        rule.Statuses,
-		"icon":               rule.GetStatusIcon,
+		"statusIcon":         rule.GetStatusIcon,
+		"statusMeaning":      rule.GetStatusMeaning,
 		"time":               convTimeFunc,
 		"yamlFormat":         yamlFormat,
 		"rulesetSummaryText": rulesetSummaryText,
@@ -73,7 +74,8 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 
 	parsedMergedReport, err := template.New(tmplMergedReportName+".html").Funcs(template.FuncMap{
 		"getStatuses":              rule.Statuses,
-		"icon":                     rule.GetStatusIcon,
+		"statusIcon":               rule.GetStatusIcon,
+		"statusMeaning":            rule.GetStatusMeaning,
 		"time":                     convTimeFunc,
 		"yamlFormat":               yamlFormat,
 		"mergedMetadataTexts":      metadataTextForMergedProvider,
@@ -88,7 +90,9 @@ func NewHTMLRenderer() (*HTMLRenderer, error) {
 
 	parsedDifferenceReport, err := template.New(tmplDifferenceReportName+".html").Funcs(template.FuncMap{
 		"add":                           add,
-		"icon":                          rule.GetStatusIcon,
+		"getStatuses":                   rule.Statuses,
+		"statusIcon":                    rule.GetStatusIcon,
+		"statusMeaning":                 rule.GetStatusMeaning,
 		"rulesetDiffAddedSummaryText":   rulesetDiffAddedSummaryText,
 		"rulesetDiffRemovedSummaryText": rulesetDiffRemovedSummaryText,
 		"keyExists":                     keyExists,

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -134,7 +134,7 @@ func rulesetSummaryText(ruleset *Ruleset) string {
 			if len(summaryText) > 0 {
 				summaryText = fmt.Sprintf("%s, ", summaryText)
 			}
-			summaryText = fmt.Sprintf("%s%dx %s %c", summaryText, num, status, rule.GetStatusIcon(status))
+			summaryText = fmt.Sprintf("%s%dx %s %c", summaryText, num, status, rule.StatusIcon(status))
 		}
 	}
 	return summaryText

--- a/pkg/report/templates/html/difference_report.html
+++ b/pkg/report/templates/html/difference_report.html
@@ -62,7 +62,7 @@
             <ul class="tw-hidden">
                 {{- $statuses := getStatuses }}
                 {{- range $key, $value := $statuses }}
-                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusMeaning $value }}</li>
+                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusDescription $value }}</li>
                 {{- end }}
             </ul></span><br>
             {{- $IDAttr := .IdentityAttributes }}

--- a/pkg/report/templates/html/difference_report.html
+++ b/pkg/report/templates/html/difference_report.html
@@ -56,7 +56,7 @@
     <div class="tw-flex-col">
         <h1 class="tw-text-3xl tw-font-bold tw-pb-5 tw-pt-2 tw-flex tw-justify-center">Difference report</h1>
         <div class="tw-content tw-px-6">
-            <span><span class="tw-text-xl tw-font-bold">Legend</span>
+            <span><span class="tw-text-xl tw-font-bold">Glossary</span>
             <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
                     class="arrow right"></i></button>
             <ul class="tw-hidden">

--- a/pkg/report/templates/html/difference_report.html
+++ b/pkg/report/templates/html/difference_report.html
@@ -56,6 +56,15 @@
     <div class="tw-flex-col">
         <h1 class="tw-text-3xl tw-font-bold tw-pb-5 tw-pt-2 tw-flex tw-justify-center">Difference report</h1>
         <div class="tw-content tw-px-6">
+            <span><span class="tw-text-xl tw-font-bold">Legend</span>
+            <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
+                    class="arrow right"></i></button>
+            <ul class="tw-hidden">
+                {{- $statuses := getStatuses }}
+                {{- range $key, $value := $statuses }}
+                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusMeaning $value }}</li>
+                {{- end }}
+            </ul></span><br>
             {{- $IDAttr := .IdentityAttributes }}
             {{- range $index, $element := .DifferenceReports }}
             <label class="tw-font-bold tw-text-2xl">{{ add $index 1 }}. {{ .Title }}</label>
@@ -103,7 +112,7 @@
                                         <ul class="tw-list-inside tw-pl-5 tw-hidden">
                                             {{- range .Added }}
                                             <li>
-                                                <span class="tw-font-medium">{{ .Status }} &#{{ icon .Status }} {{ .Message }}</span>
+                                                <span class="tw-font-medium">{{ .Status }} &#{{ statusIcon .Status }} {{ .Message }}</span>
                                             </li>
                                             {{- end }}
                                         </ul>
@@ -117,7 +126,7 @@
                                         <ul class="tw-list-inside tw-pl-5 tw-hidden">
                                             {{- range .Removed }}
                                             <li>
-                                                <span class="tw-font-medium">{{ .Status }} &#{{ icon .Status }} {{ .Message }}</span>
+                                                <span class="tw-font-medium">{{ .Status }} &#{{ statusIcon .Status }} {{ .Message }}</span>
                                             </li>
                                             {{- end }}
                                         </ul>

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -73,7 +73,7 @@
             </div>
             </ul></span><br>
             {{- end}}
-            <span><span class="tw-text-xl tw-font-bold">Legend</span>
+            <span><span class="tw-text-xl tw-font-bold">Glossary</span>
             <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
                     class="arrow right"></i></button>
             <ul class="tw-hidden">

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -63,7 +63,7 @@
         <div class="tw-content tw-px-6">
             <span class="tw-text-2xl"><span class="tw-font-bold">Diki Version: </span>{{.DikiVersion}}</span><br>
             {{- if .Metadata}}
-            <span class="tw-text-2xl tw-font-bold">Metadata</span>
+            <span><span class="tw-text-2xl tw-font-bold">Metadata</span>
             <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
                     class="arrow right"></i></button>
             <ul class="tw-hidden">
@@ -71,8 +71,17 @@
                 <button onclick="cpCode(event)" class="tw-absolute tw-top-3 tw-right-3 tw-bg-gray-200 hover:tw-bg-gray-100 tw-rounded tw-p-1">Copy</button>
                 <pre class="tw-overflow-x-auto">{{ yamlFormat .Metadata }}</pre>
             </div>
-            </ul>
+            </ul></span><br>
             {{- end}}
+            <span><span class="tw-text-xl tw-font-bold">Legend</span>
+            <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
+                    class="arrow right"></i></button>
+            <ul class="tw-hidden">
+                {{- $statuses := getStatuses }}
+                {{- range $key, $value := $statuses }}
+                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusMeaning $value }}</li>
+                {{- end }}
+            </ul></span>
             {{- range .Providers }}
             <div>
                 <label class="tw-font-bold tw-text-xl">Provider {{ .Name }}</label><br>
@@ -98,7 +107,7 @@
                             <li>
                                 <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
                                         class="arrow right"></i></button>
-                                <span class="tw-text-lg">&#{{ icon $value }} {{ $value }}</span>
+                                <span class="tw-text-lg">&#{{ statusIcon $value }} {{ $value }}</span>
                                 <ul class="tw-list-inside tw-pl-5 tw-hidden">
                                     {{- range . }}
                                     <li>

--- a/pkg/report/templates/html/merged_report.html
+++ b/pkg/report/templates/html/merged_report.html
@@ -79,7 +79,7 @@
             <ul class="tw-hidden">
                 {{- $statuses := getStatuses }}
                 {{- range $key, $value := $statuses }}
-                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusMeaning $value }}</li>
+                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusDescription $value }}</li>
                 {{- end }}
             </ul></span>
             {{- range .Providers }}

--- a/pkg/report/templates/html/report.html
+++ b/pkg/report/templates/html/report.html
@@ -73,7 +73,7 @@
             </div>
             </ul></span><br>
             {{- end}}
-            <span><span class="tw-text-xl tw-font-bold">Legend</span>
+            <span><span class="tw-text-xl tw-font-bold">Glossary</span>
             <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
                     class="arrow right"></i></button>
             <ul class="tw-hidden">

--- a/pkg/report/templates/html/report.html
+++ b/pkg/report/templates/html/report.html
@@ -63,7 +63,7 @@
         <div class="tw-content tw-px-6">
             <span class="tw-text-2xl"><span class="tw-font-bold">Diki Version: </span>{{.DikiVersion}}</span><br>
             {{- if .Metadata}}
-            <span class="tw-text-2xl tw-font-bold">Metadata</span>
+            <span><span class="tw-text-2xl tw-font-bold">Metadata</span>
             <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
                     class="arrow right"></i></button>
             <ul class="tw-hidden">
@@ -71,8 +71,17 @@
                 <button onclick="cpCode(event)" class="tw-absolute tw-top-3 tw-right-3 tw-bg-gray-200 hover:tw-bg-gray-100 tw-rounded tw-p-1">Copy</button>
                 <pre class="tw-overflow-x-auto">{{ yamlFormat .Metadata }}</pre>
             </div>
-            </ul>
+            </ul></span><br>
             {{- end}}
+            <span><span class="tw-text-xl tw-font-bold">Legend</span>
+            <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
+                    class="arrow right"></i></button>
+            <ul class="tw-hidden">
+                {{- $statuses := getStatuses }}
+                {{- range $key, $value := $statuses }}
+                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusMeaning $value }}</li>
+                {{- end }}
+            </ul></span>
             {{- range .Providers }}
             <div>
                 <label class="tw-font-bold tw-text-xl">Provider {{ .Name }}</label>
@@ -95,7 +104,7 @@
                             <li>
                                 <button onclick="collapse(event)" class="tw-text-lg tw-pr-2"><i
                                         class="arrow right"></i></button>
-                                <span class="tw-text-lg">&#{{ icon $value }} {{ $value }}</span>
+                                <span class="tw-text-lg">&#{{ statusIcon $value }} {{ $value }}</span>
                                 <ul class="tw-list-inside tw-pl-5 tw-hidden">
                                     {{- range . }}
                                     <li>

--- a/pkg/report/templates/html/report.html
+++ b/pkg/report/templates/html/report.html
@@ -79,7 +79,7 @@
             <ul class="tw-hidden">
                 {{- $statuses := getStatuses }}
                 {{- range $key, $value := $statuses }}
-                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusMeaning $value }}</li>
+                <li>&#{{ statusIcon $value }} {{ $value }}: {{ statusDescription $value }}</li>
                 {{- end }}
             </ul></span>
             {{- range .Providers }}

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -126,17 +126,17 @@ func StatusIcon(status Status) rune {
 func StatusDescription(status Status) string {
 	switch status {
 	case Passed:
-		return "Ran rule check has been Fulfilled."
+		return "Rule check has been fulfilled."
 	case Failed:
-		return "Ran rule check has been Unfulfilled, can be considered a Finding."
+		return "Rule check has been unfulfilled, can be considered a finding."
 	case Errored:
-		return "Ran rule check has errored during execution. It cannot be determined if the check is Fulfilled or not."
+		return "Rule check has errored during runtime. It cannot be determined whether the check is fulfilled or not."
 	case Warning:
-		return "Ran rule check has encountered a condition where it cannot be determined if the check is Fulfilled or not."
+		return "Rule check has encountered an ambiguous condition or configuration preventing the ability to determine if the check is fulfilled or not."
 	case Skipped:
 		return "Rule check has been considered irrelevant for the specific scenario and will not be run."
 	case Accepted:
-		return "Rule check may or may not have been run, but it was decided by the user that the check is not a Finding."
+		return "Rule check may or may not have been run, but it was decided by the user that the check is not a finding."
 	case NotImplemented:
 		return "Rule check has not been implemented yet."
 	default:

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -122,8 +122,8 @@ func GetStatusIcon(status Status) rune {
 	}
 }
 
-// GetStatusMeaning returns the meaning of a given Status string
-func GetStatusMeaning(status Status) string {
+// StatusDescription returns the description of a given [Status] string.
+func StatusDescription(status Status) string {
 	switch status {
 	case Passed:
 		return "Ran rule check has been Fulfilled."

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -121,3 +121,25 @@ func GetStatusIcon(status Status) rune {
 		return '⚪'
 	}
 }
+
+// GetStatusMeaning returns the meaning of a given Status string
+func GetStatusMeaning(status Status) string {
+	switch status {
+	case Passed:
+		return "Ran rule check has been Fulfilled."
+	case Failed:
+		return "Ran rule check has been Unfulfilled, can be considered a Finding."
+	case Errored:
+		return "Ran rule check has errored during execution. It cannot be determined if the check is Fulfilled or not."
+	case Warning:
+		return "Ran rule check has encountered a condition where it cannot be determined if the check is Fulfilled or not."
+	case Skipped:
+		return "Rule check has been considered irrelevant for the specific scenario and will not be run."
+	case Accepted:
+		return "Rule check may or may not have been run, but it was decided by the user that the check is not a Finding."
+	case NotImplemented:
+		return "Rule check has not been implemented yet."
+	default:
+		return "Unknown"
+	}
+}

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -106,8 +106,8 @@ func (a Status) Less(b Status) bool {
 	return i < x
 }
 
-// GetStatusIcon returns the icon of a given Status string
-func GetStatusIcon(status Status) rune {
+// StatusIcon returns the icon of a given [Status] string.
+func StatusIcon(status Status) rune {
 	switch status {
 	case Passed:
 		return '🟢'

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -58,4 +58,40 @@ var _ = Describe("rule", func() {
 			Expect(len(tt)).To(Equal(2))
 		})
 	})
+
+	Describe("StatusIcon", func() {
+		It("should not return white circle for supported statuses", func() {
+			statuses := rule.Statuses()
+
+			for _, status := range statuses {
+				statusIcon := rule.StatusIcon(status)
+				Expect(statusIcon).To(Not(Equal('⚪')))
+			}
+		})
+
+		It("should return white circle for unsupported statuses", func() {
+			var status rule.Status = "unsupportedStatus"
+
+			statusIcon := rule.StatusIcon(status)
+			Expect(statusIcon).To((Equal('⚪')))
+		})
+	})
+
+	Describe("StatusDescription", func() {
+		It("should not return Unknown description for supported statuses", func() {
+			statuses := rule.Statuses()
+
+			for _, status := range statuses {
+				statusDescription := rule.StatusDescription(status)
+				Expect(statusDescription).To(Not(Equal("Unknown")))
+			}
+		})
+
+		It("should return Unknown description for unsupported statuses", func() {
+			var status rule.Status = "unsupportedStatus"
+
+			statusDescription := rule.StatusDescription(status)
+			Expect(statusDescription).To((Equal("Unknown")))
+		})
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds glossary to all `html` reports which contains the meanings of rule check statuses.

**Which issue(s) this PR fixes**:
Fixes #269 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Glossary has been added to html reports that explains rule statuses.
```
