### PR TITLE
Improve consistency in log messages 

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -188,9 +188,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			V1RESTClient: shootClientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242393)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242393)),
 			retry.WithBaseRule(&sharedrules.Rule242393{
-				Logger:     r.Logger().With("rule", sharedrules.ID242393),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242393),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -202,9 +202,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242394)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242394)),
 			retry.WithBaseRule(&sharedrules.Rule242394{
-				Logger:     r.Logger().With("rule", sharedrules.ID242394),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242394),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -239,9 +239,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			V1RESTClient:      shootClientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242400)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242400)),
 			retry.WithBaseRule(&rules.Rule242400{
-				Logger:                r.Logger().With("rule", sharedrules.ID242400),
+				Logger:                r.Logger().With("rule_id", sharedrules.ID242400),
 				InstanceID:            r.instanceID,
 				ControlPlaneClient:    seedClient,
 				ClusterClient:         shootClient,
@@ -256,9 +256,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		&sharedrules.Rule242402{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242403{Client: seedClient, Namespace: r.shootNamespace},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242404)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242404)),
 			retry.WithBaseRule(&sharedrules.Rule242404{
-				Logger:     r.Logger().With("rule", sharedrules.ID242404),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242404),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -276,9 +276,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242406)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242406)),
 			retry.WithBaseRule(&sharedrules.Rule242406{
-				Logger:     r.Logger().With("rule", sharedrules.ID242406),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242406),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -291,9 +291,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242407)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242407)),
 			retry.WithBaseRule(&sharedrules.Rule242407{
-				Logger:     r.Logger().With("rule", sharedrules.ID242407),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242407),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -413,9 +413,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242445)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242445)),
 			retry.WithBaseRule(&sharedrules.Rule242445{
-				Logger:     r.Logger().With("rule", sharedrules.ID242445),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242445),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -426,9 +426,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242446)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242446)),
 			retry.WithBaseRule(&sharedrules.Rule242446{
-				Logger:     r.Logger().With("rule", sharedrules.ID242446),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242446),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -439,9 +439,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242447)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242447)),
 			retry.WithBaseRule(&sharedrules.Rule242447{
-				Logger:     r.Logger().With("rule", sharedrules.ID242447),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242447),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -450,9 +450,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242448)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242448)),
 			retry.WithBaseRule(&sharedrules.Rule242448{
-				Logger:     r.Logger().With("rule", sharedrules.ID242448),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242448),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -464,9 +464,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242449)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242449)),
 			retry.WithBaseRule(&sharedrules.Rule242449{
-				Logger:     r.Logger().With("rule", sharedrules.ID242449),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242449),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -478,9 +478,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242450)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242450)),
 			retry.WithBaseRule(&sharedrules.Rule242450{
-				Logger:     r.Logger().With("rule", sharedrules.ID242450),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242450),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -493,9 +493,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242451)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242451)),
 			retry.WithBaseRule(&rules.Rule242451{
-				Logger:                 r.Logger().With("rule", sharedrules.ID242451),
+				Logger:                 r.Logger().With("rule_id", sharedrules.ID242451),
 				InstanceID:             r.instanceID,
 				ControlPlaneClient:     seedClient,
 				ClusterClient:          shootClient,
@@ -508,9 +508,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242452)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242452)),
 			retry.WithBaseRule(&sharedrules.Rule242452{
-				Logger:     r.Logger().With("rule", sharedrules.ID242452),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242452),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -522,9 +522,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242453)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242453)),
 			retry.WithBaseRule(&sharedrules.Rule242453{
-				Logger:     r.Logger().With("rule", sharedrules.ID242453),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242453),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -561,9 +561,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242459)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242459)),
 			retry.WithBaseRule(&sharedrules.Rule242459{
-				Logger:     r.Logger().With("rule", sharedrules.ID242459),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242459),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -573,9 +573,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242460)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242460)),
 			retry.WithBaseRule(&sharedrules.Rule242460{
-				Logger:     r.Logger().With("rule", sharedrules.ID242460),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242460),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -595,9 +595,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242466)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242466)),
 			retry.WithBaseRule(&rules.Rule242466{
-				Logger:                 r.Logger().With("rule", sharedrules.ID242466),
+				Logger:                 r.Logger().With("rule_id", sharedrules.ID242466),
 				InstanceID:             r.instanceID,
 				ControlPlaneClient:     seedClient,
 				ClusterClient:          shootClient,
@@ -610,9 +610,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242467)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242467)),
 			retry.WithBaseRule(&rules.Rule242467{
-				Logger:                 r.Logger().With("rule", sharedrules.ID242467),
+				Logger:                 r.Logger().With("rule_id", sharedrules.ID242467),
 				InstanceID:             r.instanceID,
 				ControlPlaneClient:     seedClient,
 				ClusterClient:          shootClient,

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
@@ -188,9 +188,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			V1RESTClient: shootClientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242393)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242393)),
 			retry.WithBaseRule(&sharedrules.Rule242393{
-				Logger:     r.Logger().With("rule", sharedrules.ID242393),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242393),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -202,9 +202,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242394)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242394)),
 			retry.WithBaseRule(&sharedrules.Rule242394{
-				Logger:     r.Logger().With("rule", sharedrules.ID242394),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242394),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -239,9 +239,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			V1RESTClient:      shootClientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242400)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242400)),
 			retry.WithBaseRule(&rules.Rule242400{
-				Logger:                r.Logger().With("rule", sharedrules.ID242400),
+				Logger:                r.Logger().With("rule_id", sharedrules.ID242400),
 				InstanceID:            r.instanceID,
 				ControlPlaneClient:    seedClient,
 				ClusterClient:         shootClient,
@@ -256,9 +256,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 		&sharedrules.Rule242402{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242403{Client: seedClient, Namespace: r.shootNamespace},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242404)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242404)),
 			retry.WithBaseRule(&sharedrules.Rule242404{
-				Logger:     r.Logger().With("rule", sharedrules.ID242404),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242404),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -276,9 +276,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242406)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242406)),
 			retry.WithBaseRule(&sharedrules.Rule242406{
-				Logger:     r.Logger().With("rule", sharedrules.ID242406),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242406),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -291,9 +291,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242407)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242407)),
 			retry.WithBaseRule(&sharedrules.Rule242407{
-				Logger:     r.Logger().With("rule", sharedrules.ID242407),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242407),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -413,9 +413,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242445)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242445)),
 			retry.WithBaseRule(&sharedrules.Rule242445{
-				Logger:     r.Logger().With("rule", sharedrules.ID242445),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242445),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -426,9 +426,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242446)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242446)),
 			retry.WithBaseRule(&sharedrules.Rule242446{
-				Logger:     r.Logger().With("rule", sharedrules.ID242446),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242446),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -439,9 +439,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242447)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242447)),
 			retry.WithBaseRule(&sharedrules.Rule242447{
-				Logger:     r.Logger().With("rule", sharedrules.ID242447),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242447),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -450,9 +450,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242448)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242448)),
 			retry.WithBaseRule(&sharedrules.Rule242448{
-				Logger:     r.Logger().With("rule", sharedrules.ID242448),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242448),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -464,9 +464,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242449)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242449)),
 			retry.WithBaseRule(&sharedrules.Rule242449{
-				Logger:     r.Logger().With("rule", sharedrules.ID242449),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242449),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -478,9 +478,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242450)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242450)),
 			retry.WithBaseRule(&sharedrules.Rule242450{
-				Logger:     r.Logger().With("rule", sharedrules.ID242450),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242450),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -493,9 +493,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242451)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242451)),
 			retry.WithBaseRule(&rules.Rule242451{
-				Logger:                 r.Logger().With("rule", sharedrules.ID242451),
+				Logger:                 r.Logger().With("rule_id", sharedrules.ID242451),
 				InstanceID:             r.instanceID,
 				ControlPlaneClient:     seedClient,
 				ClusterClient:          shootClient,
@@ -508,9 +508,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242452)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242452)),
 			retry.WithBaseRule(&sharedrules.Rule242452{
-				Logger:     r.Logger().With("rule", sharedrules.ID242452),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242452),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -522,9 +522,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242453)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242453)),
 			retry.WithBaseRule(&sharedrules.Rule242453{
-				Logger:     r.Logger().With("rule", sharedrules.ID242453),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242453),
 				InstanceID: r.instanceID,
 				Client:     shootClient,
 				PodContext: shootPodContext,
@@ -561,9 +561,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242459)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242459)),
 			retry.WithBaseRule(&sharedrules.Rule242459{
-				Logger:     r.Logger().With("rule", sharedrules.ID242459),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242459),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -573,9 +573,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242460)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242460)),
 			retry.WithBaseRule(&sharedrules.Rule242460{
-				Logger:     r.Logger().With("rule", sharedrules.ID242460),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242460),
 				InstanceID: r.instanceID,
 				Client:     seedClient,
 				PodContext: seedPodContext,
@@ -595,9 +595,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242466)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242466)),
 			retry.WithBaseRule(&rules.Rule242466{
-				Logger:                 r.Logger().With("rule", sharedrules.ID242466),
+				Logger:                 r.Logger().With("rule_id", sharedrules.ID242466),
 				InstanceID:             r.instanceID,
 				ControlPlaneClient:     seedClient,
 				ClusterClient:          shootClient,
@@ -610,9 +610,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242467)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242467)),
 			retry.WithBaseRule(&rules.Rule242467{
-				Logger:                 r.Logger().With("rule", sharedrules.ID242467),
+				Logger:                 r.Logger().With("rule_id", sharedrules.ID242467),
 				InstanceID:             r.instanceID,
 				ControlPlaneClient:     seedClient,
 				ClusterClient:          shootClient,

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v1r11_ruleset.go
@@ -242,9 +242,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			V1RESTClient: clientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242393)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242393)),
 			retry.WithBaseRule(&sharedrules.Rule242393{
-				Logger:     r.Logger().With("rule", sharedrules.ID242393),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242393),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -254,9 +254,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242394)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242394)),
 			retry.WithBaseRule(&sharedrules.Rule242394{
-				Logger:     r.Logger().With("rule", sharedrules.ID242394),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242394),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -267,9 +267,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 		),
 		&sharedrules.Rule242395{Client: client},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242396)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242396)),
 			retry.WithBaseRule(&sharedrules.Rule242396{
-				Logger:     r.Logger().With("rule", sharedrules.ID242396),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242396),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -295,9 +295,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			V1RESTClient:      clientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242400)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242400)),
 			retry.WithBaseRule(&rules.Rule242400{
-				Logger:       r.Logger().With("rule", sharedrules.ID242400),
+				Logger:       r.Logger().With("rule_id", sharedrules.ID242400),
 				InstanceID:   r.instanceID,
 				Client:       client,
 				PodContext:   podContext,
@@ -321,9 +321,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242404)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242404)),
 			retry.WithBaseRule(&sharedrules.Rule242404{
-				Logger:     r.Logger().With("rule", sharedrules.ID242404),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242404),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -339,9 +339,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242406)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242406)),
 			retry.WithBaseRule(&sharedrules.Rule242406{
-				Logger:     r.Logger().With("rule", sharedrules.ID242406),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242406),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -351,9 +351,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242407)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242407)),
 			retry.WithBaseRule(&sharedrules.Rule242407{
-				Logger:     r.Logger().With("rule", sharedrules.ID242407),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242407),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -552,9 +552,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242447)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242447)),
 			retry.WithBaseRule(&sharedrules.Rule242447{
-				Logger:     r.Logger().With("rule", sharedrules.ID242447),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242447),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -564,9 +564,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242448)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242448)),
 			retry.WithBaseRule(&sharedrules.Rule242448{
-				Logger:     r.Logger().With("rule", sharedrules.ID242448),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242448),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -576,9 +576,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242449)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242449)),
 			retry.WithBaseRule(&sharedrules.Rule242449{
-				Logger:     r.Logger().With("rule", sharedrules.ID242449),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242449),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -588,9 +588,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242450)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242450)),
 			retry.WithBaseRule(&sharedrules.Rule242450{
-				Logger:     r.Logger().With("rule", sharedrules.ID242450),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242450),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -600,9 +600,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242451)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242451)),
 			retry.WithBaseRule(&rules.Rule242451{
-				Logger:     r.Logger().With("rule", sharedrules.ID242451),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242451),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -612,9 +612,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242452)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242452)),
 			retry.WithBaseRule(&sharedrules.Rule242452{
-				Logger:     r.Logger().With("rule", sharedrules.ID242452),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242452),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -624,9 +624,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242453)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242453)),
 			retry.WithBaseRule(&sharedrules.Rule242453{
-				Logger:     r.Logger().With("rule", sharedrules.ID242453),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242453),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -702,9 +702,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242466)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242466)),
 			retry.WithBaseRule(&rules.Rule242466{
-				Logger:     r.Logger().With("rule", sharedrules.ID242466),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242466),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -714,9 +714,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242467)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242467)),
 			retry.WithBaseRule(&rules.Rule242467{
-				Logger:     r.Logger().With("rule", sharedrules.ID242467),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242467),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r1_ruleset.go
@@ -242,9 +242,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			V1RESTClient: clientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242393)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242393)),
 			retry.WithBaseRule(&sharedrules.Rule242393{
-				Logger:     r.Logger().With("rule", sharedrules.ID242393),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242393),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -254,9 +254,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242394)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242394)),
 			retry.WithBaseRule(&sharedrules.Rule242394{
-				Logger:     r.Logger().With("rule", sharedrules.ID242394),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242394),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -267,9 +267,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 		),
 		&sharedrules.Rule242395{Client: client},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242396)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242396)),
 			retry.WithBaseRule(&sharedrules.Rule242396{
-				Logger:     r.Logger().With("rule", sharedrules.ID242396),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242396),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -295,9 +295,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			V1RESTClient:      clientSet.CoreV1().RESTClient(),
 		},
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242400)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242400)),
 			retry.WithBaseRule(&rules.Rule242400{
-				Logger:       r.Logger().With("rule", sharedrules.ID242400),
+				Logger:       r.Logger().With("rule_id", sharedrules.ID242400),
 				InstanceID:   r.instanceID,
 				Client:       client,
 				PodContext:   podContext,
@@ -321,9 +321,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242404)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242404)),
 			retry.WithBaseRule(&sharedrules.Rule242404{
-				Logger:     r.Logger().With("rule", sharedrules.ID242404),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242404),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -339,9 +339,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242406)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242406)),
 			retry.WithBaseRule(&sharedrules.Rule242406{
-				Logger:     r.Logger().With("rule", sharedrules.ID242406),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242406),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -351,9 +351,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242407)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242407)),
 			retry.WithBaseRule(&sharedrules.Rule242407{
-				Logger:     r.Logger().With("rule", sharedrules.ID242407),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242407),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -552,9 +552,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242447)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242447)),
 			retry.WithBaseRule(&sharedrules.Rule242447{
-				Logger:     r.Logger().With("rule", sharedrules.ID242447),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242447),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -564,9 +564,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242448)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242448)),
 			retry.WithBaseRule(&sharedrules.Rule242448{
-				Logger:     r.Logger().With("rule", sharedrules.ID242448),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242448),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -576,9 +576,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242449)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242449)),
 			retry.WithBaseRule(&sharedrules.Rule242449{
-				Logger:     r.Logger().With("rule", sharedrules.ID242449),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242449),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -588,9 +588,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242450)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242450)),
 			retry.WithBaseRule(&sharedrules.Rule242450{
-				Logger:     r.Logger().With("rule", sharedrules.ID242450),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242450),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -600,9 +600,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242451)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242451)),
 			retry.WithBaseRule(&rules.Rule242451{
-				Logger:     r.Logger().With("rule", sharedrules.ID242451),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242451),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -612,9 +612,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242452)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242452)),
 			retry.WithBaseRule(&sharedrules.Rule242452{
-				Logger:     r.Logger().With("rule", sharedrules.ID242452),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242452),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -624,9 +624,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242453)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242453)),
 			retry.WithBaseRule(&sharedrules.Rule242453{
-				Logger:     r.Logger().With("rule", sharedrules.ID242453),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242453),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -702,9 +702,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242466)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242466)),
 			retry.WithBaseRule(&rules.Rule242466{
-				Logger:     r.Logger().With("rule", sharedrules.ID242466),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242466),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,
@@ -714,9 +714,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242467)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242467)),
 			retry.WithBaseRule(&rules.Rule242467{
-				Logger:     r.Logger().With("rule", sharedrules.ID242467),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242467),
 				InstanceID: r.instanceID,
 				Client:     client,
 				PodContext: podContext,

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -443,9 +443,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242445)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242445)),
 			retry.WithBaseRule(&sharedrules.Rule242445{
-				Logger:             r.Logger().With("rule", sharedrules.ID242445),
+				Logger:             r.Logger().With("rule_id", sharedrules.ID242445),
 				InstanceID:         r.instanceID,
 				Client:             runtimeClient,
 				Namespace:          ns,
@@ -458,9 +458,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242446)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242446)),
 			retry.WithBaseRule(&sharedrules.Rule242446{
-				Logger:          r.Logger().With("rule", sharedrules.ID242446),
+				Logger:          r.Logger().With("rule_id", sharedrules.ID242446),
 				InstanceID:      r.instanceID,
 				Client:          runtimeClient,
 				Namespace:       ns,
@@ -496,9 +496,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242451)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242451)),
 			retry.WithBaseRule(&rules.Rule242451{
-				Logger:     r.Logger().With("rule", sharedrules.ID242451),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242451),
 				InstanceID: r.instanceID,
 				Client:     runtimeClient,
 				Namespace:  ns,
@@ -545,9 +545,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242459)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242459)),
 			retry.WithBaseRule(&sharedrules.Rule242459{
-				Logger:             r.Logger().With("rule", sharedrules.ID242459),
+				Logger:             r.Logger().With("rule_id", sharedrules.ID242459),
 				InstanceID:         r.instanceID,
 				Client:             runtimeClient,
 				Namespace:          ns,
@@ -559,9 +559,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242460)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242460)),
 			retry.WithBaseRule(&sharedrules.Rule242460{
-				Logger:          r.Logger().With("rule", sharedrules.ID242460),
+				Logger:          r.Logger().With("rule_id", sharedrules.ID242460),
 				InstanceID:      r.instanceID,
 				Client:          runtimeClient,
 				Namespace:       ns,
@@ -602,9 +602,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242466)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242466)),
 			retry.WithBaseRule(&rules.Rule242466{
-				Logger:     r.Logger().With("rule", sharedrules.ID242466),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242466),
 				InstanceID: r.instanceID,
 				Client:     runtimeClient,
 				Namespace:  ns,
@@ -614,9 +614,9 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242467)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242467)),
 			retry.WithBaseRule(&rules.Rule242467{
-				Logger:     r.Logger().With("rule", sharedrules.ID242467),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242467),
 				InstanceID: r.instanceID,
 				Client:     runtimeClient,
 				Namespace:  ns,

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r1_ruleset.go
@@ -443,9 +443,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242445)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242445)),
 			retry.WithBaseRule(&sharedrules.Rule242445{
-				Logger:             r.Logger().With("rule", sharedrules.ID242445),
+				Logger:             r.Logger().With("rule_id", sharedrules.ID242445),
 				InstanceID:         r.instanceID,
 				Client:             runtimeClient,
 				Namespace:          ns,
@@ -458,9 +458,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242446)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242446)),
 			retry.WithBaseRule(&sharedrules.Rule242446{
-				Logger:          r.Logger().With("rule", sharedrules.ID242446),
+				Logger:          r.Logger().With("rule_id", sharedrules.ID242446),
 				InstanceID:      r.instanceID,
 				Client:          runtimeClient,
 				Namespace:       ns,
@@ -496,9 +496,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242451)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242451)),
 			retry.WithBaseRule(&rules.Rule242451{
-				Logger:     r.Logger().With("rule", sharedrules.ID242451),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242451),
 				InstanceID: r.instanceID,
 				Client:     runtimeClient,
 				Namespace:  ns,
@@ -545,9 +545,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242459)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242459)),
 			retry.WithBaseRule(&sharedrules.Rule242459{
-				Logger:             r.Logger().With("rule", sharedrules.ID242459),
+				Logger:             r.Logger().With("rule_id", sharedrules.ID242459),
 				InstanceID:         r.instanceID,
 				Client:             runtimeClient,
 				Namespace:          ns,
@@ -559,9 +559,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242460)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242460)),
 			retry.WithBaseRule(&sharedrules.Rule242460{
-				Logger:          r.Logger().With("rule", sharedrules.ID242460),
+				Logger:          r.Logger().With("rule_id", sharedrules.ID242460),
 				InstanceID:      r.instanceID,
 				Client:          runtimeClient,
 				Namespace:       ns,
@@ -602,9 +602,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			rule.Skipped,
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242466)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242466)),
 			retry.WithBaseRule(&rules.Rule242466{
-				Logger:     r.Logger().With("rule", sharedrules.ID242466),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242466),
 				InstanceID: r.instanceID,
 				Client:     runtimeClient,
 				Namespace:  ns,
@@ -614,9 +614,9 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			retry.WithMaxRetries(*r.args.MaxRetries),
 		),
 		retry.New(
-			retry.WithLogger(r.Logger().With("rule", sharedrules.ID242467)),
+			retry.WithLogger(r.Logger().With("rule_id", sharedrules.ID242467)),
 			retry.WithBaseRule(&rules.Rule242467{
-				Logger:     r.Logger().With("rule", sharedrules.ID242467),
+				Logger:     r.Logger().With("rule_id", sharedrules.ID242467),
 				InstanceID: r.instanceID,
 				Client:     runtimeClient,
 				Namespace:  ns,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes all instances of `rule` to `rule_id` in log messages.

**Which issue(s) this PR fixes**:
Fixes #290 

**Special notes for your reviewer**:
cc @AleksandarSavchev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Log messages now consistently use `rule_id` instead of both `rule_id` and `rule` to identify the rule.
```
