### PR TITLE
Consistently use namespaceMatchLabels across rules #286

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -152,15 +152,19 @@ var _ = Describe("#242414", func() {
 		options = option.Options242414{
 			AcceptedPods: []option.AcceptedPods242414{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
-					Ports:                []int32{58},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
+					},
+					Ports: []int32{58},
 				},
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
-					Justification:        "foo justify",
-					Ports:                []int32{53},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
+					Justification: "foo justify",
+					Ports:         []int32{53},
 				},
 			},
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
@@ -152,8 +152,10 @@ var _ = Describe("#242415", func() {
 		options = &option.Options242415{
 			AcceptedPods: []option.AcceptedPods242415{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
 					EnvironmentVariables: []string{"SECRET_TEST"},
 				},
 			},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -352,12 +352,37 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodMatchLabels: map[string]string{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
 							resourcesv1alpha1.ManagedBy: "gardener",
 						},
-						NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
-						Justification:  "Gardener managed pods are not user pods",
-						Status:         "Passed",
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-public",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-node-lease",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
 					},
 				},
 			},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
@@ -156,9 +156,7 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 		&sharedrules.Rule242380{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242381{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242382{Client: seedClient, Namespace: r.shootNamespace},
-		&sharedrules.Rule242383{
-			Client: shootClient,
-		},
+		&sharedrules.Rule242383{Client: shootClient},
 		rule.NewSkipRule(
 			sharedrules.ID242384,
 			"The Kubernetes Scheduler must have secure binding (MEDIUM 242384)",
@@ -352,12 +350,37 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodMatchLabels: map[string]string{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
 							resourcesv1alpha1.ManagedBy: "gardener",
 						},
-						NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
-						Justification:  "Gardener managed pods are not user pods",
-						Status:         "Passed",
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-public",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-node-lease",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
 					},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
@@ -124,15 +124,19 @@ var _ = Describe("#242414", func() {
 		options = option.Options242414{
 			AcceptedPods: []option.AcceptedPods242414{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
-					Ports:                []int32{58},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
+					},
+					Ports: []int32{58},
 				},
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
-					Justification:        "foo justify",
-					Ports:                []int32{53},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
+					Justification: "foo justify",
+					Ports:         []int32{53},
 				},
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
@@ -109,8 +109,10 @@ var _ = Describe("#242415", func() {
 		options = &option.Options242415{
 			AcceptedPods: []option.AcceptedPods242415{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
 					EnvironmentVariables: []string{"SECRET_TEST"},
 				},
 			},

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -44,31 +44,127 @@ var _ = Describe("options", func() {
 			))
 		})
 	})
+	Describe("#ValidatePodAttributeOptions", func() {
+		It("should correctly validate labels", func() {
+
+			podAttributes := []option.PodAttributesLabels{
+				{
+					NamespaceMatchLabels: map[string]string{"_foo": "bar"},
+					PodMatchLabels:       map[string]string{"foo": "bar."},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"fo?o": "bar"},
+					PodMatchLabels:       map[string]string{"foo": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodMatchLabels:       map[string]string{"at_ta": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"this": "is_a"},
+					PodMatchLabels:       map[string]string{"Valid": "label-pair"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"foo": "ba/r"},
+					PodMatchLabels:       map[string]string{"at$a": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"label": "value"},
+				},
+				{
+					PodMatchLabels: map[string]string{"label": "value"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{},
+					PodMatchLabels:       map[string]string{"at_ta": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodMatchLabels:       map[string]string{},
+				},
+			}
+
+			var result field.ErrorList
+
+			for _, p := range podAttributes {
+				result = append(result, p.Validate()...)
+			}
+
+			Expect(result).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"BadValue": Equal("_foo"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.podMatchLabels"),
+					"BadValue": Equal("bar."),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"BadValue": Equal("fo?o"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"BadValue": Equal("ba/r"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.podMatchLabels"),
+					"BadValue": Equal("at$a"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.namespaceMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.namespaceMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.podMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.podMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				}))))
+
+		})
+	})
 	Describe("#ValidateOptions242414", func() {
 		It("should correctly validate options", func() {
 			options := option.Options242414{
 				AcceptedPods: []option.AcceptedPods242414{
 					{
-						PodMatchLabels: map[string]string{},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"-foo": "bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "!bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						Ports: []int32{0, 100},
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"foo": "?bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							".foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						Ports: []int32{-1},
 					},
@@ -77,26 +173,7 @@ var _ = Describe("options", func() {
 
 			result := options.Validate()
 
-			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("acceptedPods.podMatchLabels"),
-				"BadValue": Equal("-foo"),
-			})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal("!bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("?bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal(".foo"),
-				})),
+			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
 					"Field":  Equal("acceptedPods.ports"),
@@ -116,54 +193,32 @@ var _ = Describe("options", func() {
 			options := option.Options242415{
 				AcceptedPods: []option.AcceptedPods242415{
 					{
-						PodMatchLabels: map[string]string{},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "bar",
-						},
-						EnvironmentVariables: []string{"asd"},
-					},
-					{
-						PodMatchLabels: map[string]string{
-							"-foo": "bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "!bar",
-						},
-					},
-					{
-						PodMatchLabels: map[string]string{
-							"foo": "?bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							".foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						EnvironmentVariables: []string{"asd=dsa"},
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
 					},
 				},
 			}
 
 			result := options.Validate()
 
-			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("acceptedPods.podMatchLabels"),
-				"BadValue": Equal("-foo"),
-			})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal("!bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("?bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal(".foo"),
-				})),
+			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
 					"Field":  Equal("acceptedPods.environmentVariables"),

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -17,6 +17,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -24,8 +25,10 @@ var _ = Describe("#242417", func() {
 	var (
 		fakeClient client.Client
 		plainPod   *corev1.Pod
-		options    *rules.Options242417
-		ctx        = context.TODO()
+		//WE ADD A FAKE NAMESPACE IN ORDER TO MIMIC CUSTOM LABELING
+		plainNamespace *corev1.Namespace
+		options        *rules.Options242417
+		ctx            = context.TODO()
 	)
 
 	BeforeEach(func() {
@@ -36,14 +39,44 @@ var _ = Describe("#242417", func() {
 				Labels:    map[string]string{},
 			},
 		}
+		plainNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "",
+				Labels: map[string]string{"functionality": "system"},
+			},
+		}
 		options = &rules.Options242417{
 			AcceptedPods: []rules.AcceptedPods242417{
 				{
-					PodMatchLabels: map[string]string{},
-					NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{},
+						NamespaceMatchLabels: map[string]string{"random1": "value1"},
+					},
+				},
+				{
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{},
+						NamespaceMatchLabels: map[string]string{"random2": "value2"},
+					},
 				},
 			},
 		}
+		kubeNodeLeaseNamespace := plainNamespace.DeepCopy()
+		kubeNodeLeaseNamespace.Name = "kube-node-lease"
+		kubeNodeLeaseNamespace.Labels["random1"] = "value1"
+
+		kubeSystemNamespace := plainNamespace.DeepCopy()
+		kubeSystemNamespace.Name = "kube-system"
+		kubeSystemNamespace.Labels["random1"] = "value1"
+
+		kubePublicNamespace := plainNamespace.DeepCopy()
+		kubePublicNamespace.Name = "kube-public"
+		kubePublicNamespace.Labels["random2"] = "value2"
+
+		Expect(fakeClient.Create(ctx, kubeNodeLeaseNamespace)).To(Succeed())
+		Expect(fakeClient.Create(ctx, kubePublicNamespace)).To(Succeed())
+		Expect(fakeClient.Create(ctx, kubeSystemNamespace)).To(Succeed())
+
 	})
 
 	It("should return passed checkResult when no user pods are present in system namespaces", func() {
@@ -66,11 +99,15 @@ var _ = Describe("#242417", func() {
 		pod4 := plainPod.DeepCopy()
 		pod4.Name = "bar"
 		pod4.Namespace = "kube-node-lease"
+		pod4.Labels["i_am"] = "privileged"
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
 		options.AcceptedPods[0].PodMatchLabels["label"] = "value"
 		options.AcceptedPods[0].Status = "Passed"
+		options.AcceptedPods[1].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[1].Status = "Passed"
+
 		r := &rules.Rule242417{
 			Client:  fakeClient,
 			Options: options,
@@ -104,7 +141,11 @@ var _ = Describe("#242417", func() {
 		pod3.Labels["label"] = "gardener"
 		Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
 
-		r := &rules.Rule242417{Client: fakeClient}
+		options.AcceptedPods[0].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[0].Status = "Passed"
+
+		r := &rules.Rule242417{Client: fakeClient,
+			Options: options}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
@@ -126,20 +167,20 @@ var _ = Describe("#242417", func() {
 		Expect(fakeClient.Create(ctx, pod1)).To(Succeed())
 
 		pod2 := plainPod.DeepCopy()
-		pod2.Name = "bar"
+		pod2.Name = "pod2"
 		pod2.Namespace = "kube-system"
 		pod2.Labels["foo"] = "bar"
 		pod2.Labels["bar"] = "foo"
 		Expect(fakeClient.Create(ctx, pod2)).To(Succeed())
 
 		pod3 := plainPod.DeepCopy()
-		pod3.Name = "bar"
+		pod3.Name = "pod3"
 		pod3.Namespace = "kube-public"
 		pod3.Labels["foo"] = "bar"
 		Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
 
 		pod4 := plainPod.DeepCopy()
-		pod4.Name = "bar"
+		pod4.Name = "pod4"
 		pod4.Namespace = "kube-node-lease"
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
@@ -148,20 +189,22 @@ var _ = Describe("#242417", func() {
 		options.AcceptedPods[0].PodMatchLabels["bar"] = "foo"
 		options.AcceptedPods[0].Status = "Accepted"
 		options.AcceptedPods[0].Justification = "Accept pod."
-		options.AcceptedPods[0].NamespaceNames = []string{"kube-system"}
+
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodMatchLabels: map[string]string{
-				"foo": "bar",
+			PodAttributesLabels: option.PodAttributesLabels{
+				PodMatchLabels:       map[string]string{"foo": "bar"},
+				NamespaceMatchLabels: map[string]string{"functionality": "system"},
 			},
-			NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
 		})
+
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodMatchLabels: map[string]string{
-				"foo-bar": "bar",
+			PodAttributesLabels: option.PodAttributesLabels{
+				PodMatchLabels:       map[string]string{"foo-bar": "bar"},
+				NamespaceMatchLabels: map[string]string{"functionality": "system"},
 			},
-			NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
-			Status:         "fake",
+			Status: "fake",
 		})
+
 		r := &rules.Rule242417{
 			Client:  fakeClient,
 			Options: options,
@@ -172,8 +215,8 @@ var _ = Describe("#242417", func() {
 
 		expectedCheckResults := []rule.CheckResult{
 			rule.WarningCheckResult("unrecognized status: fake", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod")),
-			rule.AcceptedCheckResult("Accept pod.", rule.NewTarget("name", "bar", "namespace", "kube-system", "kind", "pod")),
-			rule.AcceptedCheckResult("Accepted user pod in system namespaces.", rule.NewTarget("name", "bar", "namespace", "kube-public", "kind", "pod")),
+			rule.AcceptedCheckResult("Accept pod.", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod")),
+			rule.AcceptedCheckResult("Accepted user pod in system namespaces.", rule.NewTarget("name", "pod3", "namespace", "kube-public", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
@@ -184,23 +227,31 @@ var _ = Describe("#242417", func() {
 			options = &rules.Options242417{
 				AcceptedPods: []rules.AcceptedPods242417{
 					{
-						PodMatchLabels: map[string]string{},
-						NamespaceNames: []string{"default", "kube-public", "kube-node-lease"},
-						Status:         "Passed",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						},
+						Status: "Passed",
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"-foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},
-						NamespaceNames: []string{"kube-system"},
-						Status:         "Accepted",
+						Status: "Accepted",
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"foo": "?bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},
-						NamespaceNames: []string{},
-						Status:         "asd",
+						Status: "fake",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						},
 					},
 				},
 			}
@@ -209,26 +260,10 @@ var _ = Describe("#242417", func() {
 
 			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("acceptedPods.namespaceNames"),
-				"BadValue": Equal("default"),
-				"Detail":   Equal("must be one of 'kube-system', 'kube-public' or 'kube-node-lease'"),
+				"Field":    Equal("acceptedPods.status"),
+				"BadValue": Equal("fake"),
+				"Detail":   Equal("must be one of 'Passed' or 'Accepted'"),
 			})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("-foo"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("?bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.status"),
-					"BadValue": Equal("asd"),
-					"Detail":   Equal("must be one of 'Passed' or 'Accepted'"),
-				})),
 			))
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the accepted pod structs implemented for rules #242414 and #242415 by aggregating the label matching options into a singular shared structure. 
The accepted pod struct for #242417 is refactored to utilize the new structure and now can add exemptions from the ruleset checks by matching namespaces by labels.
The accepted pod struct for #242383 is refactored as well to use namespace labels for matching its rule exemptions.

**Which issue(s) this PR fixes**:
Fixes #286 

**Special notes for your reviewer**:

**Release note**:

<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The implementation is a breaking change that will affect the structure of the .yaml configuration files used by the end users for configuring their accepted pods.
```
