### PR TITLE
Consistently use namespaceMatchLabels across rules

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -26,25 +26,9 @@ providers:                   # contains information about known providers
     #       kind: "Pod"
     #       matchLabels:
     #         foo: bar
+    #       # only namespaces in ["default", "kube-public", "kube-node-lease" are meaningful to be selected with namespaceMatchLabels
     #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: default
-    #         # only namespaces in ["default", "kube-public", "kube-node-lease" can be selected with namespaceMatchLabels
-    #       justification: "justification"
-    #     - apiVersion: "v1"
-    #       kind: "Pod"
-    #       matchLabels:
     #         foo: bar
-    #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: kube-public
-    #         # only namespaces in ["default", "kube-public", "kube-node-lease" can be selected with namespaceMatchLabels
-    #       justification: "justification"
-    #     - apiVersion: "v1"
-    #       kind: "Pod"
-    #       matchLabels:
-    #         foo: bar
-    #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: kube-node-lease
-    #         # only namespaces in ["default", "kube-public", "kube-node-lease" can be selected with namespaceMatchLabels
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted
@@ -116,24 +100,12 @@ providers:                   # contains information about known providers
     #     acceptedPods:
     #     - podMatchLabels:
     #         foo: bar
+    #       # only pods in namespaces ["kube-system", "kube-public", "kube-node-lease"] are meaningful be selected with namespaceMatchLabels
     #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: kube-system
-    #       only pods in namespaces ["kube-system", "kube-public", "kube-node-lease"] can be selected with namespaceMatchLabels
+    #         foo: bar
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted
-    #       status: Passed
-    #     - podMatchLabels:
-    #         foo: bar
-    #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: kube-public
-    #       justification: "justification"
-    #       status: Passed    
-    #     - podMatchLabels:
-    #         foo: bar
-    #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: kube-node-lease
-    #       justification: "justification"
     #       status: Passed
     # - ruleID: "242442"
     #   args:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -26,11 +26,25 @@ providers:                   # contains information about known providers
     #       kind: "Pod"
     #       matchLabels:
     #         foo: bar
-    #       # Defaults to ["default", "kube-public", "kube-node-lease"]
-    #       namespaceNames:
-    #       - default
-    #       - kube-public
-    #       - kube-node-lease
+    #       namespaceMatchLabels:
+    #         kubernetes.io/metadata.name: default
+    #         # only namespaces in ["default", "kube-public", "kube-node-lease" can be selected with namespaceMatchLabels
+    #       justification: "justification"
+    #     - apiVersion: "v1"
+    #       kind: "Pod"
+    #       matchLabels:
+    #         foo: bar
+    #       namespaceMatchLabels:
+    #         kubernetes.io/metadata.name: kube-public
+    #         # only namespaces in ["default", "kube-public", "kube-node-lease" can be selected with namespaceMatchLabels
+    #       justification: "justification"
+    #     - apiVersion: "v1"
+    #       kind: "Pod"
+    #       matchLabels:
+    #         foo: bar
+    #       namespaceMatchLabels:
+    #         kubernetes.io/metadata.name: kube-node-lease
+    #         # only namespaces in ["default", "kube-public", "kube-node-lease" can be selected with namespaceMatchLabels
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted
@@ -102,13 +116,24 @@ providers:                   # contains information about known providers
     #     acceptedPods:
     #     - podMatchLabels:
     #         foo: bar
-    #       namespaceNames:
-    #       - kube-system
-    #       - kube-public
-    #       - kube-node-lease
+    #       namespaceMatchLabels:
+    #         kubernetes.io/metadata.name: kube-system
+    #       only pods in namespaces ["kube-system", "kube-public", "kube-node-lease"] can be selected with namespaceMatchLabels
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted
+    #       status: Passed
+    #     - podMatchLabels:
+    #         foo: bar
+    #       namespaceMatchLabels:
+    #         kubernetes.io/metadata.name: kube-public
+    #       justification: "justification"
+    #       status: Passed    
+    #     - podMatchLabels:
+    #         foo: bar
+    #       namespaceMatchLabels:
+    #         kubernetes.io/metadata.name: kube-node-lease
+    #       justification: "justification"
     #       status: Passed
     # - ruleID: "242442"
     #   args:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -29,7 +29,7 @@ providers:                   # contains information about known providers
     #       # only pods in namespaces ["default", "kube-public", "kube-node-lease"] are meaningful to be selected with namespaceMatchLabels
     #       # since the rule does not perform checks on objects in namespaces different from the listed above
     #       namespaceMatchLabels:
-    #          kubernetes.io/metadata.name: default
+    #         kubernetes.io/metadata.name: default
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -26,7 +26,7 @@ providers:                   # contains information about known providers
     #       kind: "Pod"
     #       matchLabels:
     #         foo: bar
-    #       # only pods in ["default", "kube-public", "kube-node-lease"] are meaningful to be selected with namespaceMatchLabels
+    #       # only pods in namespaces ["default", "kube-public", "kube-node-lease"] are meaningful to be selected with namespaceMatchLabels
     #       # since the rule does not perform checks on objects in namespaces different from the listed above
     #       namespaceMatchLabels:
     #          kubernetes.io/metadata.name: default

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -26,7 +26,7 @@ providers:                   # contains information about known providers
     #       kind: "Pod"
     #       matchLabels:
     #         foo: bar
-    #       # only namespaces in ["default", "kube-public", "kube-node-lease" are meaningful to be selected with namespaceMatchLabels
+    #       # only pods in ["default", "kube-public", "kube-node-lease"] are meaningful to be selected with namespaceMatchLabels
     #       # since the rule does not perform checks on objects in namespaces different from the listed above
     #       namespaceMatchLabels:
     #          kubernetes.io/metadata.name: default

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -27,8 +27,9 @@ providers:                   # contains information about known providers
     #       matchLabels:
     #         foo: bar
     #       # only namespaces in ["default", "kube-public", "kube-node-lease" are meaningful to be selected with namespaceMatchLabels
+    #       # since the rule does not perform checks on objects in namespaces different from the listed above
     #       namespaceMatchLabels:
-    #         foo: bar
+    #          kubernetes.io/metadata.name: default
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted
@@ -100,9 +101,10 @@ providers:                   # contains information about known providers
     #     acceptedPods:
     #     - podMatchLabels:
     #         foo: bar
-    #       # only pods in namespaces ["kube-system", "kube-public", "kube-node-lease"] are meaningful be selected with namespaceMatchLabels
+    #       # only pods in namespaces ["kube-system", "kube-public", "kube-node-lease"] are meaningful to be selected with namespaceMatchLabels
+    #       # since the rule does not perform checks on objects in namespaces different from the listed above
     #       namespaceMatchLabels:
-    #         foo: bar
+    #         kubernetes.io/metadata.name: kube-system
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted

--- a/example/guides/partial-disa-k8s-stig-shoot.yaml
+++ b/example/guides/partial-disa-k8s-stig-shoot.yaml
@@ -60,11 +60,6 @@ providers:
           namespaceMatchLabels:
             kubernetes.io/metadata.name: kube-system
           justification: "Pods managed by Gardener are not considered as user pods"
-        - podMatchLabels:
-            label: exception
-          namespaceMatchLabels:
-            value: example
-          justification: "justification"
     - ruleID: "242449" 
       args:
         nodeGroupByLabels:

--- a/example/guides/partial-disa-k8s-stig-shoot.yaml
+++ b/example/guides/partial-disa-k8s-stig-shoot.yaml
@@ -57,12 +57,15 @@ providers:
         acceptedPods:
         - podMatchLabels:
             resources.gardener.cloud/managed-by: gardener
-          namespaceNames:
-          - kube-system
-          - kube-public
-          - kube-node-lease
+          namespaceMatchLabels:
+            kubernetes.io/metadata.name: kube-system
           justification: "Pods managed by Gardener are not considered as user pods"
-    - ruleID: "242449"
+        - podMatchLabels:
+            label: exception
+          namespaceMatchLabels:
+            value: example
+          justification: "justification"
+    - ruleID: "242449" 
       args:
         nodeGroupByLabels:
         - worker.gardener.cloud/pool

--- a/example/guides/partial-disa-k8s-stig-shoot.yaml
+++ b/example/guides/partial-disa-k8s-stig-shoot.yaml
@@ -60,7 +60,7 @@ providers:
           namespaceMatchLabels:
             kubernetes.io/metadata.name: kube-system
           justification: "Pods managed by Gardener are not considered as user pods"
-    - ruleID: "242449" 
+    - ruleID: "242449"
       args:
         nodeGroupByLabels:
         - worker.gardener.cloud/pool

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -152,15 +152,19 @@ var _ = Describe("#242414", func() {
 		options = option.Options242414{
 			AcceptedPods: []option.AcceptedPods242414{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
-					Ports:                []int32{58},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
+					},
+					Ports: []int32{58},
 				},
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
-					Justification:        "foo justify",
-					Ports:                []int32{53},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
+					Justification: "foo justify",
+					Ports:         []int32{53},
 				},
 			},
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -152,14 +152,14 @@ var _ = Describe("#242414", func() {
 		options = option.Options242414{
 			AcceptedPods: []option.AcceptedPods242414{
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{"foo": "bar"},
 						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
 					},
 					Ports: []int32{58},
 				},
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{"foo": "bar"},
 						NamespaceMatchLabels: map[string]string{"foo": "bar"},
 					},

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
@@ -152,7 +152,7 @@ var _ = Describe("#242415", func() {
 		options = &option.Options242415{
 			AcceptedPods: []option.AcceptedPods242415{
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{"foo": "bar"},
 						NamespaceMatchLabels: map[string]string{"foo": "bar"},
 					},

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
@@ -152,8 +152,10 @@ var _ = Describe("#242415", func() {
 		options = &option.Options242415{
 			AcceptedPods: []option.AcceptedPods242415{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
 					EnvironmentVariables: []string{"SECRET_TEST"},
 				},
 			},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -352,29 +352,7 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
-							resourcesv1alpha1.ManagedBy: "gardener",
-						},
-							NamespaceMatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "kube-public",
-							},
-						},
-						Justification: "Gardener managed pods are not user pods",
-						Status:        "Passed",
-					},
-					{
-						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
-							resourcesv1alpha1.ManagedBy: "gardener",
-						},
-							NamespaceMatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "kube-node-lease",
-							},
-						},
-						Justification: "Gardener managed pods are not user pods",
-						Status:        "Passed",
-					},
-					{
-						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+						PodSelector: option.PodSelector{PodMatchLabels: map[string]string{
 							resourcesv1alpha1.ManagedBy: "gardener",
 						},
 							NamespaceMatchLabels: map[string]string{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -352,9 +352,10 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodSelector: option.PodSelector{PodMatchLabels: map[string]string{
-							resourcesv1alpha1.ManagedBy: "gardener",
-						},
+						PodSelector: option.PodSelector{
+							PodMatchLabels: map[string]string{
+								resourcesv1alpha1.ManagedBy: "gardener",
+							},
 							NamespaceMatchLabels: map[string]string{
 								"kubernetes.io/metadata.name": "kube-system",
 							},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v1r11_ruleset.go
@@ -352,12 +352,37 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodMatchLabels: map[string]string{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
 							resourcesv1alpha1.ManagedBy: "gardener",
 						},
-						NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
-						Justification:  "Gardener managed pods are not user pods",
-						Status:         "Passed",
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-public",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-node-lease",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
 					},
 				},
 			},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
@@ -350,29 +350,7 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
-							resourcesv1alpha1.ManagedBy: "gardener",
-						},
-							NamespaceMatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "kube-public",
-							},
-						},
-						Justification: "Gardener managed pods are not user pods",
-						Status:        "Passed",
-					},
-					{
-						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
-							resourcesv1alpha1.ManagedBy: "gardener",
-						},
-							NamespaceMatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "kube-node-lease",
-							},
-						},
-						Justification: "Gardener managed pods are not user pods",
-						Status:        "Passed",
-					},
-					{
-						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+						PodSelector: option.PodSelector{PodMatchLabels: map[string]string{
 							resourcesv1alpha1.ManagedBy: "gardener",
 						},
 							NamespaceMatchLabels: map[string]string{

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
@@ -350,9 +350,10 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodSelector: option.PodSelector{PodMatchLabels: map[string]string{
-							resourcesv1alpha1.ManagedBy: "gardener",
-						},
+						PodSelector: option.PodSelector{
+							PodMatchLabels: map[string]string{
+								resourcesv1alpha1.ManagedBy: "gardener",
+							},
 							NamespaceMatchLabels: map[string]string{
 								"kubernetes.io/metadata.name": "kube-system",
 							},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r1_ruleset.go
@@ -156,9 +156,7 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 		&sharedrules.Rule242380{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242381{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242382{Client: seedClient, Namespace: r.shootNamespace},
-		&sharedrules.Rule242383{
-			Client: shootClient,
-		},
+		&sharedrules.Rule242383{Client: shootClient},
 		rule.NewSkipRule(
 			sharedrules.ID242384,
 			"The Kubernetes Scheduler must have secure binding (MEDIUM 242384)",
@@ -352,12 +350,37 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodMatchLabels: map[string]string{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
 							resourcesv1alpha1.ManagedBy: "gardener",
 						},
-						NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
-						Justification:  "Gardener managed pods are not user pods",
-						Status:         "Passed",
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-public",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-node-lease",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{PodMatchLabels: map[string]string{
+							resourcesv1alpha1.ManagedBy: "gardener",
+						},
+							NamespaceMatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							},
+						},
+						Justification: "Gardener managed pods are not user pods",
+						Status:        "Passed",
 					},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
@@ -31,7 +31,6 @@ var _ = Describe("#242414", func() {
 
 	BeforeEach(func() {
 		client = fakeclient.NewClientBuilder().Build()
-
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespaceName,
@@ -40,7 +39,6 @@ var _ = Describe("#242414", func() {
 				},
 			},
 		}
-
 		plainPod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespaceName,
@@ -68,6 +66,7 @@ var _ = Describe("#242414", func() {
 		pod1 := plainPod.DeepCopy()
 		pod1.Name = "pod1"
 		Expect(client.Create(ctx, pod1)).To(Succeed())
+
 		pod2 := plainPod.DeepCopy()
 		pod2.Name = "pod2"
 		Expect(client.Create(ctx, pod2)).To(Succeed())
@@ -96,6 +95,7 @@ var _ = Describe("#242414", func() {
 		pod1 := plainPod.DeepCopy()
 		pod1.Name = "pod1"
 		Expect(client.Create(ctx, pod1)).To(Succeed())
+
 		pod2 := plainPod.DeepCopy()
 		pod2.Name = "pod2"
 		pod2.Spec.Containers[0].Ports[0].HostPort = 1011
@@ -124,14 +124,14 @@ var _ = Describe("#242414", func() {
 		options = option.Options242414{
 			AcceptedPods: []option.AcceptedPods242414{
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{"foo": "bar"},
 						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
 					},
 					Ports: []int32{58},
 				},
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{"foo": "bar"},
 						NamespaceMatchLabels: map[string]string{"foo": "bar"},
 					},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
@@ -124,15 +124,19 @@ var _ = Describe("#242414", func() {
 		options = option.Options242414{
 			AcceptedPods: []option.AcceptedPods242414{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
-					Ports:                []int32{58},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
+					},
+					Ports: []int32{58},
 				},
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
-					Justification:        "foo justify",
-					Ports:                []int32{53},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
+					Justification: "foo justify",
+					Ports:         []int32{53},
 				},
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
@@ -109,8 +109,10 @@ var _ = Describe("#242415", func() {
 		options = &option.Options242415{
 			AcceptedPods: []option.AcceptedPods242415{
 				{
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{"foo": "bar"},
+						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					},
 					EnvironmentVariables: []string{"SECRET_TEST"},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
@@ -109,7 +109,7 @@ var _ = Describe("#242415", func() {
 		options = &option.Options242415{
 			AcceptedPods: []option.AcceptedPods242415{
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{"foo": "bar"},
 						NamespaceMatchLabels: map[string]string{"foo": "bar"},
 					},

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -18,16 +18,16 @@ type Option interface {
 	Validate() field.ErrorList
 }
 
-// PodAttributesLabels contains generalized options for matching entities by their attribute labels
-type PodAttributesLabels struct {
+// PodSelector contains generalized options for matching entities by their attribute labels
+type PodSelector struct {
 	PodMatchLabels       map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
 	NamespaceMatchLabels map[string]string `json:"namespaceMatchLabels" yaml:"namespaceMatchLabels"`
 }
 
-var _ Option = (*PodAttributesLabels)(nil)
+var _ Option = (*PodSelector)(nil)
 
-// Validate validates that option label matching configurations are in a correct format
-func (e PodAttributesLabels) Validate() field.ErrorList {
+// Validate validates that option configurations are correctly defined
+func (e PodSelector) Validate() field.ErrorList {
 	var (
 		allErrs  field.ErrorList
 		rootPath = field.NewPath("acceptedPods")
@@ -43,7 +43,6 @@ func (e PodAttributesLabels) Validate() field.ErrorList {
 
 	allErrs = append(allErrs, metav1validation.ValidateLabels(e.NamespaceMatchLabels, rootPath.Child("namespaceMatchLabels"))...)
 	allErrs = append(allErrs, metav1validation.ValidateLabels(e.PodMatchLabels, rootPath.Child("podMatchLabels"))...)
-
 	return allErrs
 }
 
@@ -99,7 +98,7 @@ var _ Option = (*Options242414)(nil)
 
 // AcceptedPods242414 contains option specifications for appected pods
 type AcceptedPods242414 struct {
-	PodAttributesLabels
+	PodSelector
 	Justification string  `json:"justification" yaml:"justification"`
 	Ports         []int32 `json:"ports" yaml:"ports"`
 }
@@ -111,9 +110,7 @@ func (o Options242414) Validate() field.ErrorList {
 		rootPath = field.NewPath("acceptedPods")
 	)
 	for _, p := range o.AcceptedPods {
-
 		allErrs = append(allErrs, p.Validate()...)
-
 		if len(p.Ports) == 0 {
 			allErrs = append(allErrs, field.Required(rootPath.Child("ports"), "must not be empty"))
 		}
@@ -135,7 +132,7 @@ var _ Option = (*Options242415)(nil)
 
 // AcceptedPods242415 contains option specifications for appected pods
 type AcceptedPods242415 struct {
-	PodAttributesLabels
+	PodSelector
 	Justification        string   `json:"justification" yaml:"justification"`
 	EnvironmentVariables []string `json:"environmentVariables" yaml:"environmentVariables"`
 }
@@ -147,9 +144,7 @@ func (o Options242415) Validate() field.ErrorList {
 		rootPath = field.NewPath("acceptedPods")
 	)
 	for _, p := range o.AcceptedPods {
-
 		allErrs = append(allErrs, p.Validate()...)
-
 		if len(p.EnvironmentVariables) == 0 {
 			allErrs = append(allErrs, field.Required(rootPath.Child("environmentVariables"), "must not be empty"))
 		}

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -26,6 +26,7 @@ type PodAttributesLabels struct {
 
 var _ Option = (*PodAttributesLabels)(nil)
 
+// Validate validates that option label matching configurations are in a correct format
 func (e PodAttributesLabels) Validate() field.ErrorList {
 	var (
 		allErrs  field.ErrorList

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -30,7 +30,7 @@ var _ Option = (*PodSelector)(nil)
 func (e PodSelector) Validate() field.ErrorList {
 	var (
 		allErrs  field.ErrorList
-		rootPath = field.NewPath("acceptedPods")
+		rootPath = field.NewPath("")
 	)
 
 	if len(e.NamespaceMatchLabels) == 0 {
@@ -96,7 +96,7 @@ type Options242414 struct {
 
 var _ Option = (*Options242414)(nil)
 
-// AcceptedPods242414 contains option specifications for appected pods
+// AcceptedPods242414 contains option specifications for accepted pods
 type AcceptedPods242414 struct {
 	PodSelector
 	Justification string  `json:"justification" yaml:"justification"`
@@ -130,7 +130,7 @@ type Options242415 struct {
 
 var _ Option = (*Options242415)(nil)
 
-// AcceptedPods242415 contains option specifications for appected pods
+// AcceptedPods242415 contains option specifications for accepted pods
 type AcceptedPods242415 struct {
 	PodSelector
 	Justification        string   `json:"justification" yaml:"justification"`

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -22,9 +22,7 @@ var _ = Describe("options", func() {
 					Groups: []string{"", "asd", "111"},
 				},
 			}
-
 			result := options.Validate()
-
 			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
 				"Field":    Equal("expectedFileOwner.users"),
@@ -44,10 +42,9 @@ var _ = Describe("options", func() {
 			))
 		})
 	})
-	Describe("#ValidatePodAttributeOptions", func() {
+	Describe("#ValidatePodSelector", func() {
 		It("should correctly validate labels", func() {
-
-			podAttributes := []option.PodAttributesLabels{
+			podAttributes := []option.PodSelector{
 				{
 					NamespaceMatchLabels: map[string]string{"_foo": "bar"},
 					PodMatchLabels:       map[string]string{"foo": "bar."},
@@ -85,7 +82,6 @@ var _ = Describe("options", func() {
 			}
 
 			var result field.ErrorList
-
 			for _, p := range podAttributes {
 				result = append(result, p.Validate()...)
 			}
@@ -129,7 +125,6 @@ var _ = Describe("options", func() {
 					"Field":  Equal("acceptedPods.podMatchLabels"),
 					"Detail": Equal("must not be empty"),
 				}))))
-
 		})
 	})
 	Describe("#ValidateOptions242414", func() {
@@ -137,7 +132,7 @@ var _ = Describe("options", func() {
 			options := option.Options242414{
 				AcceptedPods: []option.AcceptedPods242414{
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels: map[string]string{
 								"foo": "bar",
 							},
@@ -147,7 +142,7 @@ var _ = Describe("options", func() {
 						},
 					},
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels: map[string]string{
 								"foo": "bar",
 							},
@@ -158,7 +153,7 @@ var _ = Describe("options", func() {
 						Ports: []int32{0, 100},
 					},
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels: map[string]string{
 								"foo": "bar",
 							},
@@ -193,7 +188,7 @@ var _ = Describe("options", func() {
 			options := option.Options242415{
 				AcceptedPods: []option.AcceptedPods242415{
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels: map[string]string{
 								"foo": "bar",
 							},
@@ -204,7 +199,7 @@ var _ = Describe("options", func() {
 						EnvironmentVariables: []string{"asd=dsa"},
 					},
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels: map[string]string{
 								"foo": "bar",
 							},

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -44,31 +44,127 @@ var _ = Describe("options", func() {
 			))
 		})
 	})
+	Describe("#ValidatePodAttributeOptions", func() {
+		It("should correctly validate labels", func() {
+
+			podAttributes := []option.PodAttributesLabels{
+				{
+					NamespaceMatchLabels: map[string]string{"_foo": "bar"},
+					PodMatchLabels:       map[string]string{"foo": "bar."},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"fo?o": "bar"},
+					PodMatchLabels:       map[string]string{"foo": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodMatchLabels:       map[string]string{"at_ta": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"this": "is_a"},
+					PodMatchLabels:       map[string]string{"Valid": "label-pair"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"foo": "ba/r"},
+					PodMatchLabels:       map[string]string{"at$a": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"label": "value"},
+				},
+				{
+					PodMatchLabels: map[string]string{"label": "value"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{},
+					PodMatchLabels:       map[string]string{"at_ta": "bar"},
+				},
+				{
+					NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					PodMatchLabels:       map[string]string{},
+				},
+			}
+
+			var result field.ErrorList
+
+			for _, p := range podAttributes {
+				result = append(result, p.Validate()...)
+			}
+
+			Expect(result).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"BadValue": Equal("_foo"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.podMatchLabels"),
+					"BadValue": Equal("bar."),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"BadValue": Equal("fo?o"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"BadValue": Equal("ba/r"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("acceptedPods.podMatchLabels"),
+					"BadValue": Equal("at$a"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.namespaceMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.namespaceMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.podMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("acceptedPods.podMatchLabels"),
+					"Detail": Equal("must not be empty"),
+				}))))
+
+		})
+	})
 	Describe("#ValidateOptions242414", func() {
 		It("should correctly validate options", func() {
 			options := option.Options242414{
 				AcceptedPods: []option.AcceptedPods242414{
 					{
-						PodMatchLabels: map[string]string{},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"-foo": "bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "!bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						Ports: []int32{0, 100},
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"foo": "?bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							".foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						Ports: []int32{-1},
 					},
@@ -77,26 +173,7 @@ var _ = Describe("options", func() {
 
 			result := options.Validate()
 
-			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("acceptedPods.podMatchLabels"),
-				"BadValue": Equal("-foo"),
-			})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal("!bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("?bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal(".foo"),
-				})),
+			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
 					"Field":  Equal("acceptedPods.ports"),
@@ -116,54 +193,32 @@ var _ = Describe("options", func() {
 			options := option.Options242415{
 				AcceptedPods: []option.AcceptedPods242415{
 					{
-						PodMatchLabels: map[string]string{},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "bar",
-						},
-						EnvironmentVariables: []string{"asd"},
-					},
-					{
-						PodMatchLabels: map[string]string{
-							"-foo": "bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							"foo": "!bar",
-						},
-					},
-					{
-						PodMatchLabels: map[string]string{
-							"foo": "?bar",
-						},
-						NamespaceMatchLabels: map[string]string{
-							".foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						EnvironmentVariables: []string{"asd=dsa"},
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+							NamespaceMatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
 					},
 				},
 			}
 
 			result := options.Validate()
 
-			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("acceptedPods.podMatchLabels"),
-				"BadValue": Equal("-foo"),
-			})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal("!bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("?bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
-					"BadValue": Equal(".foo"),
-				})),
+			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
 					"Field":  Equal("acceptedPods.environmentVariables"),

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -89,40 +89,40 @@ var _ = Describe("options", func() {
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"Field":    Equal("[].namespaceMatchLabels"),
 					"BadValue": Equal("_foo"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
+					"Field":    Equal("[].podMatchLabels"),
 					"BadValue": Equal("bar."),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"Field":    Equal("[].namespaceMatchLabels"),
 					"BadValue": Equal("fo?o"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.namespaceMatchLabels"),
+					"Field":    Equal("[].namespaceMatchLabels"),
 					"BadValue": Equal("ba/r"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
+					"Field":    Equal("[].podMatchLabels"),
 					"BadValue": Equal("at$a"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("acceptedPods.namespaceMatchLabels"),
+					"Field":  Equal("[].namespaceMatchLabels"),
 					"Detail": Equal("must not be empty"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("acceptedPods.namespaceMatchLabels"),
+					"Field":  Equal("[].namespaceMatchLabels"),
 					"Detail": Equal("must not be empty"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("acceptedPods.podMatchLabels"),
+					"Field":  Equal("[].podMatchLabels"),
 					"Detail": Equal("must not be empty"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("acceptedPods.podMatchLabels"),
+					"Field":  Equal("[].podMatchLabels"),
 					"Detail": Equal("must not be empty"),
 				}))))
 		})

--- a/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
-// TODO: add checks for validate
 var _ = Describe("#242383", func() {
 	var (
 		fakeClient     client.Client
@@ -53,7 +52,7 @@ var _ = Describe("#242383", func() {
 		options = &rules.Options242383{
 			AcceptedResources: []rules.AcceptedResources242383{
 				{
-					SelectResource: rules.SelectResource{
+					ResourceSelector: rules.ResourceSelector{
 						APIVersion:           "v1",
 						Kind:                 "Pod",
 						MatchLabels:          map[string]string{},
@@ -61,7 +60,7 @@ var _ = Describe("#242383", func() {
 					},
 				},
 				{
-					SelectResource: rules.SelectResource{
+					ResourceSelector: rules.ResourceSelector{
 						APIVersion:           "v1",
 						Kind:                 "Pod",
 						MatchLabels:          map[string]string{},
@@ -88,7 +87,6 @@ var _ = Describe("#242383", func() {
 	})
 
 	It("should return passed checkResult when no user resources are present in system namespaces", func() {
-
 		kubernetesService := &corev1.Service{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
@@ -128,9 +126,9 @@ var _ = Describe("#242383", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedResources[0].SelectResource.MatchLabels["label"] = "value"
+		options.AcceptedResources[0].ResourceSelector.MatchLabels["label"] = "value"
 		options.AcceptedResources[0].Status = "Passed"
-		options.AcceptedResources[1].SelectResource.MatchLabels["label"] = "value"
+		options.AcceptedResources[1].ResourceSelector.MatchLabels["label"] = "value"
 		options.AcceptedResources[1].Status = "Passed"
 		r := &rules.Rule242383{
 			Client:  fakeClient,
@@ -181,7 +179,6 @@ var _ = Describe("#242383", func() {
 	})
 
 	It("should return correct checkResult when different resources are present", func() {
-
 		pod := plainPod.DeepCopy()
 		pod.Name = "foo"
 		pod.Namespace = "default"
@@ -233,7 +230,6 @@ var _ = Describe("#242383", func() {
 		}
 
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
-
 	})
 
 	It("should return correct checkResult when different statuses are used", func() {
@@ -262,18 +258,18 @@ var _ = Describe("#242383", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedResources[0].SelectResource.MatchLabels["foo"] = "bar"
-		options.AcceptedResources[0].SelectResource.MatchLabels["bar"] = "foo"
+		options.AcceptedResources[0].ResourceSelector.MatchLabels["foo"] = "bar"
+		options.AcceptedResources[0].ResourceSelector.MatchLabels["bar"] = "foo"
 		options.AcceptedResources[0].Status = "Accepted"
 		options.AcceptedResources[0].Justification = "Accept pod."
 
-		options.AcceptedResources[1].SelectResource.MatchLabels["foo"] = "bar"
-		options.AcceptedResources[1].SelectResource.MatchLabels["bar"] = "foo"
+		options.AcceptedResources[1].ResourceSelector.MatchLabels["foo"] = "bar"
+		options.AcceptedResources[1].ResourceSelector.MatchLabels["bar"] = "foo"
 		options.AcceptedResources[1].Status = "Accepted"
 		options.AcceptedResources[1].Justification = "Accept pod."
 
 		options.AcceptedResources = append(options.AcceptedResources, rules.AcceptedResources242383{
-			SelectResource: rules.SelectResource{
+			ResourceSelector: rules.ResourceSelector{
 				APIVersion:           "v1",
 				Kind:                 "*",
 				MatchLabels:          map[string]string{"foo": "bar"},
@@ -281,7 +277,7 @@ var _ = Describe("#242383", func() {
 			},
 		})
 		options.AcceptedResources = append(options.AcceptedResources, rules.AcceptedResources242383{
-			SelectResource: rules.SelectResource{
+			ResourceSelector: rules.ResourceSelector{
 				APIVersion:           "v1",
 				Kind:                 "*",
 				MatchLabels:          map[string]string{"foo-bar": "bar"},
@@ -312,7 +308,7 @@ var _ = Describe("#242383", func() {
 			options = &rules.Options242383{
 				AcceptedResources: []rules.AcceptedResources242383{
 					{
-						SelectResource: rules.SelectResource{
+						ResourceSelector: rules.ResourceSelector{
 							APIVersion:           "v1",
 							Kind:                 "Pod",
 							MatchLabels:          map[string]string{"bar": "foo"},
@@ -321,7 +317,7 @@ var _ = Describe("#242383", func() {
 						Status: "Passed",
 					},
 					{
-						SelectResource: rules.SelectResource{
+						ResourceSelector: rules.ResourceSelector{
 							APIVersion:           "apps/v1",
 							Kind:                 "Service",
 							MatchLabels:          map[string]string{"bar": "foo"},
@@ -330,7 +326,7 @@ var _ = Describe("#242383", func() {
 						Status: "Passed",
 					},
 					{
-						SelectResource: rules.SelectResource{
+						ResourceSelector: rules.ResourceSelector{
 							APIVersion:           "v1",
 							Kind:                 "Deployment",
 							MatchLabels:          map[string]string{"-foo": "bar"},
@@ -339,7 +335,7 @@ var _ = Describe("#242383", func() {
 						Status: "Accepted",
 					},
 					{
-						SelectResource: rules.SelectResource{
+						ResourceSelector: rules.ResourceSelector{
 							APIVersion:           "v1",
 							Kind:                 "Service",
 							MatchLabels:          map[string]string{},
@@ -348,7 +344,7 @@ var _ = Describe("#242383", func() {
 						Status: "Accepted",
 					},
 					{
-						SelectResource: rules.SelectResource{
+						ResourceSelector: rules.ResourceSelector{
 							APIVersion:           "fake",
 							Kind:                 "Service",
 							MatchLabels:          map[string]string{"foo": "?bar"},

--- a/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
@@ -52,7 +52,7 @@ var _ = Describe("#242383", func() {
 		options = &rules.Options242383{
 			AcceptedResources: []rules.AcceptedResources242383{
 				{
-					ResourceSelector: rules.ResourceSelector{
+					ObjectSelector: rules.ObjectSelector{
 						APIVersion:           "v1",
 						Kind:                 "Pod",
 						MatchLabels:          map[string]string{},
@@ -60,7 +60,7 @@ var _ = Describe("#242383", func() {
 					},
 				},
 				{
-					ResourceSelector: rules.ResourceSelector{
+					ObjectSelector: rules.ObjectSelector{
 						APIVersion:           "v1",
 						Kind:                 "Pod",
 						MatchLabels:          map[string]string{},
@@ -69,21 +69,25 @@ var _ = Describe("#242383", func() {
 				},
 			},
 		}
-		kubeNodeLeaseNamespace := plainNamespace.DeepCopy()
-		kubeNodeLeaseNamespace.Name = "default"
-		kubeNodeLeaseNamespace.Labels["random_1"] = "value_1"
 
-		kubeSystemNamespace := plainNamespace.DeepCopy()
-		kubeSystemNamespace.Name = "kube-system"
-		kubeSystemNamespace.Labels["random_2"] = "value_2"
+		defaultNamespace := plainNamespace.DeepCopy()
+		defaultNamespace.Name = "default"
+		defaultNamespace.Labels["random_1"] = "value_1"
+		defaultNamespace.Labels["kubernetes.io/metadata.name"] = "default"
+
+		kubeNodeLeaseNamespace := plainNamespace.DeepCopy()
+		kubeNodeLeaseNamespace.Name = "kude-node-lease"
+		kubeNodeLeaseNamespace.Labels["random_2"] = "value_2"
+		kubeNodeLeaseNamespace.Labels["kubernetes.io/metadata.name"] = "kube-node-lease"
 
 		kubePublicNamespace := plainNamespace.DeepCopy()
 		kubePublicNamespace.Name = "kube-public"
 		kubePublicNamespace.Labels["random_2"] = "value_2"
+		kubePublicNamespace.Labels["kubernetes.io/metadata.name"] = "kube-public"
 
+		Expect(fakeClient.Create(ctx, defaultNamespace)).To(Succeed())
 		Expect(fakeClient.Create(ctx, kubeNodeLeaseNamespace)).To(Succeed())
 		Expect(fakeClient.Create(ctx, kubePublicNamespace)).To(Succeed())
-		Expect(fakeClient.Create(ctx, kubeSystemNamespace)).To(Succeed())
 	})
 
 	It("should return passed checkResult when no user resources are present in system namespaces", func() {
@@ -126,9 +130,9 @@ var _ = Describe("#242383", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedResources[0].ResourceSelector.MatchLabels["label"] = "value"
+		options.AcceptedResources[0].ObjectSelector.MatchLabels["label"] = "value"
 		options.AcceptedResources[0].Status = "Passed"
-		options.AcceptedResources[1].ResourceSelector.MatchLabels["label"] = "value"
+		options.AcceptedResources[1].ObjectSelector.MatchLabels["label"] = "value"
 		options.AcceptedResources[1].Status = "Passed"
 		r := &rules.Rule242383{
 			Client:  fakeClient,
@@ -258,18 +262,18 @@ var _ = Describe("#242383", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedResources[0].ResourceSelector.MatchLabels["foo"] = "bar"
-		options.AcceptedResources[0].ResourceSelector.MatchLabels["bar"] = "foo"
+		options.AcceptedResources[0].ObjectSelector.MatchLabels["foo"] = "bar"
+		options.AcceptedResources[0].ObjectSelector.MatchLabels["bar"] = "foo"
 		options.AcceptedResources[0].Status = "Accepted"
 		options.AcceptedResources[0].Justification = "Accept pod."
 
-		options.AcceptedResources[1].ResourceSelector.MatchLabels["foo"] = "bar"
-		options.AcceptedResources[1].ResourceSelector.MatchLabels["bar"] = "foo"
+		options.AcceptedResources[1].ObjectSelector.MatchLabels["foo"] = "bar"
+		options.AcceptedResources[1].ObjectSelector.MatchLabels["bar"] = "foo"
 		options.AcceptedResources[1].Status = "Accepted"
 		options.AcceptedResources[1].Justification = "Accept pod."
 
 		options.AcceptedResources = append(options.AcceptedResources, rules.AcceptedResources242383{
-			ResourceSelector: rules.ResourceSelector{
+			ObjectSelector: rules.ObjectSelector{
 				APIVersion:           "v1",
 				Kind:                 "*",
 				MatchLabels:          map[string]string{"foo": "bar"},
@@ -277,7 +281,7 @@ var _ = Describe("#242383", func() {
 			},
 		})
 		options.AcceptedResources = append(options.AcceptedResources, rules.AcceptedResources242383{
-			ResourceSelector: rules.ResourceSelector{
+			ObjectSelector: rules.ObjectSelector{
 				APIVersion:           "v1",
 				Kind:                 "*",
 				MatchLabels:          map[string]string{"foo-bar": "bar"},
@@ -308,7 +312,7 @@ var _ = Describe("#242383", func() {
 			options = &rules.Options242383{
 				AcceptedResources: []rules.AcceptedResources242383{
 					{
-						ResourceSelector: rules.ResourceSelector{
+						ObjectSelector: rules.ObjectSelector{
 							APIVersion:           "v1",
 							Kind:                 "Pod",
 							MatchLabels:          map[string]string{"bar": "foo"},
@@ -317,7 +321,7 @@ var _ = Describe("#242383", func() {
 						Status: "Passed",
 					},
 					{
-						ResourceSelector: rules.ResourceSelector{
+						ObjectSelector: rules.ObjectSelector{
 							APIVersion:           "apps/v1",
 							Kind:                 "Service",
 							MatchLabels:          map[string]string{"bar": "foo"},
@@ -326,7 +330,7 @@ var _ = Describe("#242383", func() {
 						Status: "Passed",
 					},
 					{
-						ResourceSelector: rules.ResourceSelector{
+						ObjectSelector: rules.ObjectSelector{
 							APIVersion:           "v1",
 							Kind:                 "Deployment",
 							MatchLabels:          map[string]string{"-foo": "bar"},
@@ -335,7 +339,7 @@ var _ = Describe("#242383", func() {
 						Status: "Accepted",
 					},
 					{
-						ResourceSelector: rules.ResourceSelector{
+						ObjectSelector: rules.ObjectSelector{
 							APIVersion:           "v1",
 							Kind:                 "Service",
 							MatchLabels:          map[string]string{},
@@ -344,7 +348,7 @@ var _ = Describe("#242383", func() {
 						Status: "Accepted",
 					},
 					{
-						ResourceSelector: rules.ResourceSelector{
+						ObjectSelector: rules.ObjectSelector{
 							APIVersion:           "fake",
 							Kind:                 "Service",
 							MatchLabels:          map[string]string{"foo": "?bar"},

--- a/pkg/shared/ruleset/disak8sstig/rules/242417.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417.go
@@ -84,7 +84,7 @@ func (r *Rule242417) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	allNamespaces, err := kubeutils.GetNamespaces(ctx, r.Client)
 	if err != nil {
-		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("", ""))), nil
+		return rule.SingleCheckResult(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), nil
 	}
 
 	for _, namespace := range systemNamespaces {

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -47,13 +47,13 @@ var _ = Describe("#242417", func() {
 		options = &rules.Options242417{
 			AcceptedPods: []rules.AcceptedPods242417{
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{},
 						NamespaceMatchLabels: map[string]string{"random1": "value1"},
 					},
 				},
 				{
-					PodAttributesLabels: option.PodAttributesLabels{
+					PodSelector: option.PodSelector{
 						PodMatchLabels:       map[string]string{},
 						NamespaceMatchLabels: map[string]string{"random2": "value2"},
 					},
@@ -190,14 +190,14 @@ var _ = Describe("#242417", func() {
 		options.AcceptedPods[0].Justification = "Accept pod."
 
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodAttributesLabels: option.PodAttributesLabels{
+			PodSelector: option.PodSelector{
 				PodMatchLabels:       map[string]string{"foo": "bar"},
 				NamespaceMatchLabels: map[string]string{"functionality": "system"},
 			},
 		})
 
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodAttributesLabels: option.PodAttributesLabels{
+			PodSelector: option.PodSelector{
 				PodMatchLabels:       map[string]string{"foo-bar": "bar"},
 				NamespaceMatchLabels: map[string]string{"functionality": "system"},
 			},
@@ -226,28 +226,28 @@ var _ = Describe("#242417", func() {
 			options = &rules.Options242417{
 				AcceptedPods: []rules.AcceptedPods242417{
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
 							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},
 						Status: "Passed",
 					},
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
 							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},
 						Status: "Accepted",
 					},
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
 							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},
 						Status: "fake",
 					},
 					{
-						PodAttributesLabels: option.PodAttributesLabels{
+						PodSelector: option.PodSelector{
 							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
 							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -23,9 +23,8 @@ import (
 
 var _ = Describe("#242417", func() {
 	var (
-		fakeClient client.Client
-		plainPod   *corev1.Pod
-		//WE ADD A FAKE NAMESPACE IN ORDER TO MIMIC CUSTOM LABELING
+		fakeClient     client.Client
+		plainPod       *corev1.Pod
 		plainNamespace *corev1.Namespace
 		options        *rules.Options242417
 		ctx            = context.TODO()

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -17,6 +17,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -24,8 +25,10 @@ var _ = Describe("#242417", func() {
 	var (
 		fakeClient client.Client
 		plainPod   *corev1.Pod
-		options    *rules.Options242417
-		ctx        = context.TODO()
+		//WE ADD A FAKE NAMESPACE IN ORDER TO MIMIC CUSTOM LABELING
+		plainNamespace *corev1.Namespace
+		options        *rules.Options242417
+		ctx            = context.TODO()
 	)
 
 	BeforeEach(func() {
@@ -36,14 +39,44 @@ var _ = Describe("#242417", func() {
 				Labels:    map[string]string{},
 			},
 		}
+		plainNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "",
+				Labels: map[string]string{"functionality": "system"},
+			},
+		}
 		options = &rules.Options242417{
 			AcceptedPods: []rules.AcceptedPods242417{
 				{
-					PodMatchLabels: map[string]string{},
-					NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{},
+						NamespaceMatchLabels: map[string]string{"random1": "value1"},
+					},
+				},
+				{
+					PodAttributesLabels: option.PodAttributesLabels{
+						PodMatchLabels:       map[string]string{},
+						NamespaceMatchLabels: map[string]string{"random2": "value2"},
+					},
 				},
 			},
 		}
+		kubeNodeLeaseNamespace := plainNamespace.DeepCopy()
+		kubeNodeLeaseNamespace.Name = "kube-node-lease"
+		kubeNodeLeaseNamespace.Labels["random1"] = "value1"
+
+		kubeSystemNamespace := plainNamespace.DeepCopy()
+		kubeSystemNamespace.Name = "kube-system"
+		kubeSystemNamespace.Labels["random1"] = "value1"
+
+		kubePublicNamespace := plainNamespace.DeepCopy()
+		kubePublicNamespace.Name = "kube-public"
+		kubePublicNamespace.Labels["random2"] = "value2"
+
+		Expect(fakeClient.Create(ctx, kubeNodeLeaseNamespace)).To(Succeed())
+		Expect(fakeClient.Create(ctx, kubePublicNamespace)).To(Succeed())
+		Expect(fakeClient.Create(ctx, kubeSystemNamespace)).To(Succeed())
+
 	})
 
 	It("should return passed checkResult when no user pods are present in system namespaces", func() {
@@ -66,11 +99,15 @@ var _ = Describe("#242417", func() {
 		pod4 := plainPod.DeepCopy()
 		pod4.Name = "bar"
 		pod4.Namespace = "kube-node-lease"
+		pod4.Labels["i_am"] = "privileged"
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
 		options.AcceptedPods[0].PodMatchLabels["label"] = "value"
 		options.AcceptedPods[0].Status = "Passed"
+		options.AcceptedPods[1].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[1].Status = "Passed"
+
 		r := &rules.Rule242417{
 			Client:  fakeClient,
 			Options: options,
@@ -104,7 +141,11 @@ var _ = Describe("#242417", func() {
 		pod3.Labels["label"] = "gardener"
 		Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
 
-		r := &rules.Rule242417{Client: fakeClient}
+		options.AcceptedPods[0].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[0].Status = "Passed"
+
+		r := &rules.Rule242417{Client: fakeClient,
+			Options: options}
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
@@ -126,20 +167,20 @@ var _ = Describe("#242417", func() {
 		Expect(fakeClient.Create(ctx, pod1)).To(Succeed())
 
 		pod2 := plainPod.DeepCopy()
-		pod2.Name = "bar"
+		pod2.Name = "pod2"
 		pod2.Namespace = "kube-system"
 		pod2.Labels["foo"] = "bar"
 		pod2.Labels["bar"] = "foo"
 		Expect(fakeClient.Create(ctx, pod2)).To(Succeed())
 
 		pod3 := plainPod.DeepCopy()
-		pod3.Name = "bar"
+		pod3.Name = "pod3"
 		pod3.Namespace = "kube-public"
 		pod3.Labels["foo"] = "bar"
 		Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
 
 		pod4 := plainPod.DeepCopy()
-		pod4.Name = "bar"
+		pod4.Name = "pod4"
 		pod4.Namespace = "kube-node-lease"
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
@@ -148,20 +189,22 @@ var _ = Describe("#242417", func() {
 		options.AcceptedPods[0].PodMatchLabels["bar"] = "foo"
 		options.AcceptedPods[0].Status = "Accepted"
 		options.AcceptedPods[0].Justification = "Accept pod."
-		options.AcceptedPods[0].NamespaceNames = []string{"kube-system"}
+
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodMatchLabels: map[string]string{
-				"foo": "bar",
+			PodAttributesLabels: option.PodAttributesLabels{
+				PodMatchLabels:       map[string]string{"foo": "bar"},
+				NamespaceMatchLabels: map[string]string{"functionality": "system"},
 			},
-			NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
 		})
+
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodMatchLabels: map[string]string{
-				"foo-bar": "bar",
+			PodAttributesLabels: option.PodAttributesLabels{
+				PodMatchLabels:       map[string]string{"foo-bar": "bar"},
+				NamespaceMatchLabels: map[string]string{"functionality": "system"},
 			},
-			NamespaceNames: []string{"kube-system", "kube-public", "kube-node-lease"},
-			Status:         "fake",
+			Status: "fake",
 		})
+
 		r := &rules.Rule242417{
 			Client:  fakeClient,
 			Options: options,
@@ -172,8 +215,8 @@ var _ = Describe("#242417", func() {
 
 		expectedCheckResults := []rule.CheckResult{
 			rule.WarningCheckResult("unrecognized status: fake", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod")),
-			rule.AcceptedCheckResult("Accept pod.", rule.NewTarget("name", "bar", "namespace", "kube-system", "kind", "pod")),
-			rule.AcceptedCheckResult("Accepted user pod in system namespaces.", rule.NewTarget("name", "bar", "namespace", "kube-public", "kind", "pod")),
+			rule.AcceptedCheckResult("Accept pod.", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod")),
+			rule.AcceptedCheckResult("Accepted user pod in system namespaces.", rule.NewTarget("name", "pod3", "namespace", "kube-public", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
@@ -184,23 +227,31 @@ var _ = Describe("#242417", func() {
 			options = &rules.Options242417{
 				AcceptedPods: []rules.AcceptedPods242417{
 					{
-						PodMatchLabels: map[string]string{},
-						NamespaceNames: []string{"default", "kube-public", "kube-node-lease"},
-						Status:         "Passed",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						},
+						Status: "Passed",
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"-foo": "bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},
-						NamespaceNames: []string{"kube-system"},
-						Status:         "Accepted",
+						Status: "Accepted",
 					},
 					{
-						PodMatchLabels: map[string]string{
-							"foo": "?bar",
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
 						},
-						NamespaceNames: []string{},
-						Status:         "asd",
+						Status: "fake",
+					},
+					{
+						PodAttributesLabels: option.PodAttributesLabels{
+							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
+							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						},
 					},
 				},
 			}
@@ -209,26 +260,10 @@ var _ = Describe("#242417", func() {
 
 			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("acceptedPods.namespaceNames"),
-				"BadValue": Equal("default"),
-				"Detail":   Equal("must be one of 'kube-system', 'kube-public' or 'kube-node-lease'"),
+				"Field":    Equal("acceptedPods.status"),
+				"BadValue": Equal("fake"),
+				"Detail":   Equal("must be one of 'Passed' or 'Accepted'"),
 			})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("-foo"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.podMatchLabels"),
-					"BadValue": Equal("?bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.status"),
-					"BadValue": Equal("asd"),
-					"Detail":   Equal("must be one of 'Passed' or 'Accepted'"),
-				})),
 			))
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the accepted pod structs implemented for rules #242414 and #242415 by aggregating the label matching options into a singular shared structure.
The accepted pod struct for #242417 is refactored to utilize the new structure and now can add exemptions from the ruleset checks by matching namespaces by labels.
The accepted pod struct for #242383 is refactored as well to use namespace labels for matching its rule exemptions.

**Which issue(s) this PR fixes**:
Fixes #286

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
This change affects only the `managedk8s` provider. Configuration for DISA K8s STIG rules `242383` and `242417` now does not accept namespace names directly but rely on matching namespaces by labels. Please, see [the example configuration options](https://github.com/gardener/diki/blob/main/example/config/managedk8s.yaml) for more details.
```