### PR TITLE
Generated summary reports should contain provider metadata

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -404,7 +404,7 @@ func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.Provide
 		if err != nil {
 			return err
 		}
-		providerResults := []provider.ProviderResult{{ProviderID: p.ID(), ProviderName: p.Name(), RulesetResults: []ruleset.RulesetResult{res}}}
+		providerResults := []provider.ProviderResult{{ProviderID: p.ID(), ProviderName: p.Name(), Metadata: p.Metadata(), RulesetResults: []ruleset.RulesetResult{res}}}
 
 		if len(outputPath) > 0 {
 			reportOpts := []report.ReportOption{}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the constructor of the ProviderResult struct when initialized (in the case we have both ruleset-id and ruleset-version flags specified) by adding the missing metadata field from the provider in question that is used for the ruleset run.

**Which issue(s) this PR fixes**:
Fixes #296 

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       bugfix
- target_group:   user
-->
```bugfix user
A bug causing generated summary reports to not contain `provider.metadata`, when `--ruleset-id` and `--ruleset-version` flags are set, was fixed.
```
