### PR TITLE
Check for proxy container if kube-proxy is not present

### DIFF
--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -164,6 +164,7 @@ func GetMountedFilesStats(
 }
 
 // GetContainerID returns the container ID specified in the container status by container name
+// The first container name that exists in status is selected
 func GetContainerID(pod corev1.Pod, containerNames ...string) (string, error) {
 	for _, containerName := range containerNames {
 		containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {

--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -163,7 +163,7 @@ func GetMountedFilesStats(
 	return stats, err
 }
 
-// GetContainerID returns the container ID specified in the container statust by container name
+// GetContainerID returns the container ID specified in the container status by container name
 func GetContainerID(pod corev1.Pod, containerNames ...string) (string, error) {
 	for _, containerName := range containerNames {
 		containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
@@ -184,7 +184,7 @@ func GetContainerID(pod corev1.Pod, containerNames ...string) (string, error) {
 			return "", fmt.Errorf("cannot handle container with name %s", containerName)
 		}
 	}
-	return "", fmt.Errorf("container with any of the specified names in the list %s not (yet) in status", containerNames)
+	return "", fmt.Errorf("container with name in %v not (yet) in status", containerNames)
 }
 
 // GetContainerMounts returns the container mounts of a container

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -251,7 +251,7 @@ var _ = Describe("utils", func() {
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
 			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
-			Expect(err).To(MatchError("container with any of the specified names in the list [foo] not (yet) in status\ncontainer with name bar not (yet) running\ncannot handle container with name baz"))
+			Expect(err).To(MatchError("container with name in [foo] not (yet) in status\ncontainer with name bar not (yet) running\ncannot handle container with name baz"))
 			Expect(result).To(Equal(map[string][]utils.FileStats{}))
 		})
 
@@ -310,7 +310,7 @@ var _ = Describe("utils", func() {
 			Entry("should return correct containerID",
 				"test", "test", "containerd://1", "1", BeNil()),
 			Entry("should return error when containerStatus missing",
-				"test", "test2", "containerd://1", "", MatchError("container with any of the specified names in the list [test] not (yet) in status")),
+				"test", "test2", "containerd://1", "", MatchError("container with name in [test] not (yet) in status")),
 			Entry("should return error when containerID is empty",
 				"test", "test", "", "", MatchError("container with name test not (yet) running")),
 			Entry("should return error when containerID is not recognized",

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -251,7 +251,7 @@ var _ = Describe("utils", func() {
 			fakePodExecutor = fakepod.NewFakePodExecutor(executeReturnString, executeReturnError)
 			result, err := utils.GetMountedFilesStats(ctx, "", fakePodExecutor, pod, []string{"/lib/modules"})
 
-			Expect(err).To(MatchError("container with name foo not (yet) in status\ncontainer with name bar not (yet) running\ncannot handle container with name baz"))
+			Expect(err).To(MatchError("container with any of the specified names in the list [foo] not (yet) in status\ncontainer with name bar not (yet) running\ncannot handle container with name baz"))
 			Expect(result).To(Equal(map[string][]utils.FileStats{}))
 		})
 
@@ -310,7 +310,7 @@ var _ = Describe("utils", func() {
 			Entry("should return correct containerID",
 				"test", "test", "containerd://1", "1", BeNil()),
 			Entry("should return error when containerStatus missing",
-				"test", "test2", "containerd://1", "", MatchError("container with name test not (yet) in status")),
+				"test", "test2", "containerd://1", "", MatchError("container with any of the specified names in the list [test] not (yet) in status")),
 			Entry("should return error when containerID is empty",
 				"test", "test", "", "", MatchError("container with name test not (yet) running")),
 			Entry("should return error when containerID is not recognized",

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -403,14 +403,13 @@ func GetKubeletCommand(ctx context.Context, podExecutor pod.PodExecutor) (string
 // GetContainerCommand returns the used container command
 func GetContainerCommand(pod corev1.Pod, containerNames ...string) (string, error) {
 	for _, containerName := range containerNames {
-		container, found := GetContainerFromPod(&pod, containerName)
-		if found {
+		if container, found := GetContainerFromPod(&pod, containerName); found {
 			rawCommand := strings.Join(append(container.Command, container.Args...), " ")
 			return rawCommand, nil
 		}
 	}
 
-	return "", fmt.Errorf("Pod does not contain a container with name in %v", containerNames)
+	return "", fmt.Errorf("pod does not contain a container with name in %v", containerNames)
 }
 
 // FindFileMountSource returns a mounted file's source location on the host

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -401,6 +401,7 @@ func GetKubeletCommand(ctx context.Context, podExecutor pod.PodExecutor) (string
 }
 
 // GetContainerCommand returns the used container command
+// The first container name that exists in the Pod is selected
 func GetContainerCommand(pod corev1.Pod, containerNames ...string) (string, error) {
 	for _, containerName := range containerNames {
 		if container, found := GetContainerFromPod(&pod, containerName); found {

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -402,25 +402,15 @@ func GetKubeletCommand(ctx context.Context, podExecutor pod.PodExecutor) (string
 
 // GetContainerCommand returns the used container command
 func GetContainerCommand(pod corev1.Pod, containerNames ...string) (string, error) {
-	var (
-		container corev1.Container
-		found     = false
-	)
-
 	for _, containerName := range containerNames {
-		var foundContainer corev1.Container
-		foundContainer, found = GetContainerFromPod(&pod, containerName)
+		container, found := GetContainerFromPod(&pod, containerName)
 		if found {
-			container = foundContainer
-			break
+			rawCommand := strings.Join(append(container.Command, container.Args...), " ")
+			return rawCommand, nil
 		}
 	}
 
-	if !found {
-		return "", fmt.Errorf("pod does not contain any of the containers specified in the provided list: %s", containerNames)
-	}
-	rawCommand := strings.Join(append(container.Command, container.Args...), " ")
-	return rawCommand, nil
+	return "", fmt.Errorf("Pod does not contain any of the containers specified in the provided list: %s", containerNames)
 }
 
 // FindFileMountSource returns a mounted file's source location on the host

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -401,12 +401,24 @@ func GetKubeletCommand(ctx context.Context, podExecutor pod.PodExecutor) (string
 }
 
 // GetContainerCommand returns the used container command
-func GetContainerCommand(pod corev1.Pod, containerName string) (string, error) {
-	container, found := GetContainerFromPod(&pod, containerName)
-	if !found {
-		return "", fmt.Errorf("pod does not contain %s container", containerName)
+func GetContainerCommand(pod corev1.Pod, containerNames ...string) (string, error) {
+	var (
+		container corev1.Container
+		found     = false
+	)
+
+	for _, containerName := range containerNames {
+		var foundContainer corev1.Container
+		foundContainer, found = GetContainerFromPod(&pod, containerName)
+		if found {
+			container = foundContainer
+			break
+		}
 	}
 
+	if !found {
+		return "", fmt.Errorf("pod does not contain any of the containers specified in the provided list: %s", containerNames)
+	}
 	rawCommand := strings.Join(append(container.Command, container.Args...), " ")
 	return rawCommand, nil
 }

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -410,7 +410,7 @@ func GetContainerCommand(pod corev1.Pod, containerNames ...string) (string, erro
 		}
 	}
 
-	return "", fmt.Errorf("Pod does not contain any of the containers specified in the provided list: %s", containerNames)
+	return "", fmt.Errorf("Pod does not contain a container with name in %v", containerNames)
 }
 
 // FindFileMountSource returns a mounted file's source location on the host

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -1310,7 +1310,7 @@ var _ = Describe("utils", func() {
 				"/bin/sh -c exec kube-proxy --kubeconfig=/var/lib/kube-proxy/kubeconfig", BeNil()),
 			Entry("should return error when container is not found", "not-bar",
 				[]string{}, []string{},
-				"", MatchError("Pod does not contain a container with name in [not-bar]")),
+				"", MatchError("pod does not contain a container with name in [not-bar]")),
 		)
 	})
 

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -1310,7 +1310,7 @@ var _ = Describe("utils", func() {
 				"/bin/sh -c exec kube-proxy --kubeconfig=/var/lib/kube-proxy/kubeconfig", BeNil()),
 			Entry("should return error when container is not found", "not-bar",
 				[]string{}, []string{},
-				"", MatchError("pod does not contain any of the containers specified in the provided list: [not-bar]")),
+				"", MatchError("Pod does not contain any of the containers specified in the provided list: [not-bar]")),
 		)
 	})
 

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -1310,7 +1310,7 @@ var _ = Describe("utils", func() {
 				"/bin/sh -c exec kube-proxy --kubeconfig=/var/lib/kube-proxy/kubeconfig", BeNil()),
 			Entry("should return error when container is not found", "not-bar",
 				[]string{}, []string{},
-				"", MatchError("Pod does not contain any of the containers specified in the provided list: [not-bar]")),
+				"", MatchError("Pod does not contain a container with name in [not-bar]")),
 		)
 	})
 

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -1310,7 +1310,7 @@ var _ = Describe("utils", func() {
 				"/bin/sh -c exec kube-proxy --kubeconfig=/var/lib/kube-proxy/kubeconfig", BeNil()),
 			Entry("should return error when container is not found", "not-bar",
 				[]string{}, []string{},
-				"", MatchError("pod does not contain not-bar container")),
+				"", MatchError("pod does not contain any of the containers specified in the provided list: [not-bar]")),
 		)
 	})
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -249,31 +249,31 @@ func (r *Rule242400) checkKubeProxy(
 
 		var allAlpha *bool
 		if len(configPath) != 0 {
-			proxyContainerID, err := intutils.GetContainerID(pod, kubeProxyContainerNames...)
+			kubeProxyContainerID, err := intutils.GetContainerID(pod, kubeProxyContainerNames...)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue
 			}
 
-			proxyMounts, err := intutils.GetContainerMounts(ctx, execContainerPath, podExecutor, proxyContainerID)
+			kubeProxyMounts, err := intutils.GetContainerMounts(ctx, execContainerPath, podExecutor, kubeProxyContainerID)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), execPodTarget))
 				continue
 			}
 
-			configSourcePath, err := kubeutils.FindFileMountSource(configPath, proxyMounts)
+			configSourcePath, err := kubeutils.FindFileMountSource(configPath, kubeProxyMounts)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue
 			}
 
-			proxyConfig, err := kubeutils.GetKubeProxyConfig(ctx, podExecutor, configSourcePath)
+			kubeProxyConfig, err := kubeutils.GetKubeProxyConfig(ctx, podExecutor, configSourcePath)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), execPodTarget))
 				continue
 			}
 
-			if val, ok := proxyConfig.FeatureGates["AllAlpha"]; ok {
+			if val, ok := kubeProxyConfig.FeatureGates["AllAlpha"]; ok {
 				allAlpha = &val
 			}
 		} else {

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -187,11 +187,11 @@ func (r *Rule242400) checkKubeProxy(
 ) []rule.CheckResult {
 	const option = "featureGates.AllAlpha"
 	var (
-		checkResults            []rule.CheckResult
-		additionalLabels        = map[string]string{pod.LabelInstanceID: r.InstanceID}
-		podName                 = fmt.Sprintf("diki-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
-		execPodTarget           = rule.NewTarget("cluster", "shoot", "name", podName, "namespace", "kube-system", "kind", "pod")
-		kubeProxyContainerNames = "kube-proxy"
+		checkResults           []rule.CheckResult
+		additionalLabels       = map[string]string{pod.LabelInstanceID: r.InstanceID}
+		podName                = fmt.Sprintf("diki-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
+		execPodTarget          = rule.NewTarget("cluster", "shoot", "name", podName, "namespace", "kube-system", "kind", "pod")
+		kubeProxyContainerName = "kube-proxy"
 	)
 
 	defer func() {
@@ -229,7 +229,7 @@ func (r *Rule242400) checkKubeProxy(
 	for _, pod := range pods {
 		podTarget := rule.NewTarget("cluster", "shoot", "name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 
-		rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames)
+		rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerName)
 		if err != nil {
 			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 			continue
@@ -249,7 +249,7 @@ func (r *Rule242400) checkKubeProxy(
 
 		var allAlpha *bool
 		if len(configPath) != 0 {
-			kubeProxyContainerID, err := intutils.GetContainerID(pod, kubeProxyContainerNames)
+			kubeProxyContainerID, err := intutils.GetContainerID(pod, kubeProxyContainerName)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -191,7 +191,7 @@ func (r *Rule242400) checkKubeProxy(
 		additionalLabels        = map[string]string{pod.LabelInstanceID: r.InstanceID}
 		podName                 = fmt.Sprintf("diki-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
 		execPodTarget           = rule.NewTarget("cluster", "shoot", "name", podName, "namespace", "kube-system", "kind", "pod")
-		kubeProxyContainerNames = []string{"kube-proxy", "proxy"}
+		kubeProxyContainerNames = []string{"kube-proxy"}
 	)
 
 	defer func() {

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -217,28 +217,12 @@ var _ = Describe("#242400", func() {
 		pod6.Spec.NodeName = "node1"
 		pod6.Spec.Containers[0].Command = []string{"--flag1=value1", "--feature-gates=AllAlpha=true", "--config=/var/lib/config"}
 
-		pod7 := plainPod.DeepCopy()
-		pod7.Name = "pod7"
-		pod7.OwnerReferences[0].UID = "7"
-		pod7.Spec.NodeName = "node1"
-		pod7.Spec.Containers[0].Name = "proxy"
-		pod7.Spec.Containers[0].Command = []string{"--flag=value1", "--flag=value2"}
-
-		pod8 := plainPod.DeepCopy()
-		pod8.Name = "pod8"
-		pod8.OwnerReferences[0].UID = "8"
-		pod8.Spec.NodeName = "node1"
-		pod8.Spec.Containers[0].Name = "proxy"
-		pod8.Spec.Containers[0].Command = []string{"--flag1=value1", "--feature-gates=AllAlpha=true"}
-
 		Expect(fakeClusterClient.Create(ctx, pod1)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod2)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod3)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod4)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod5)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod6)).To(Succeed())
-		Expect(fakeClusterClient.Create(ctx, pod7)).To(Succeed())
-		Expect(fakeClusterClient.Create(ctx, pod8)).To(Succeed())
 
 		fakeRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -279,8 +263,6 @@ var _ = Describe("#242400", func() {
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod4", "namespace", "kube-system")),
 			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod5", "namespace", "kube-system")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod6", "namespace", "kube-system")),
-			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod7", "namespace", "kube-system")),
-			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod8", "namespace", "kube-system")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node1")),
 			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node2")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -147,10 +147,6 @@ var _ = Describe("#242400", func() {
 			},
 		}
 
-		plainProxyPod := plainPod.DeepCopy()
-		plainProxyPod.Status.ContainerStatuses[0].Name = "proxy"
-		plainProxyPod.Status.ContainerStatuses[0].ContainerID = "containerd://foo"
-
 		dikiPod = plainPod.DeepCopy()
 		dikiPod.Name = fmt.Sprintf("diki-%s-%s", sharedrules.ID242400, "aaaaaaaaaa")
 		dikiPod.Labels = map[string]string{}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -217,12 +217,28 @@ var _ = Describe("#242400", func() {
 		pod6.Spec.NodeName = "node1"
 		pod6.Spec.Containers[0].Command = []string{"--flag1=value1", "--feature-gates=AllAlpha=true", "--config=/var/lib/config"}
 
+		pod7 := plainPod.DeepCopy()
+		pod7.Name = "pod7"
+		pod7.OwnerReferences[0].UID = "7"
+		pod7.Spec.NodeName = "node1"
+		pod7.Spec.Containers[0].Name = "proxy"
+		pod7.Spec.Containers[0].Command = []string{"--flag=value1", "--flag=value2"}
+
+		pod8 := plainPod.DeepCopy()
+		pod8.Name = "pod8"
+		pod8.OwnerReferences[0].UID = "8"
+		pod8.Spec.NodeName = "node1"
+		pod8.Spec.Containers[0].Name = "proxy"
+		pod8.Spec.Containers[0].Command = []string{"--flag1=value1", "--feature-gates=AllAlpha=true"}
+
 		Expect(fakeClusterClient.Create(ctx, pod1)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod2)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod3)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod4)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod5)).To(Succeed())
 		Expect(fakeClusterClient.Create(ctx, pod6)).To(Succeed())
+		Expect(fakeClusterClient.Create(ctx, pod7)).To(Succeed())
+		Expect(fakeClusterClient.Create(ctx, pod8)).To(Succeed())
 
 		fakeRESTClient = &manualfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
@@ -263,6 +279,8 @@ var _ = Describe("#242400", func() {
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod4", "namespace", "kube-system")),
 			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod5", "namespace", "kube-system")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod6", "namespace", "kube-system")),
+			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod7", "namespace", "kube-system")),
+			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("cluster", "shoot", "kind", "pod", "name", "pod8", "namespace", "kube-system")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node1")),
 			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node2")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("cluster", "shoot", "kind", "node", "name", "node3")),

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -205,7 +205,7 @@ func (r *Rule242400) checkKubeProxy(
 
 		rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 		if err != nil {
-			checkResults = append(checkResults, rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", podTarget.With("details", err.Error())))
+			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 			continue
 		}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -205,7 +205,7 @@ func (r *Rule242400) checkKubeProxy(
 
 		rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 		if err != nil {
-			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
+			checkResults = append(checkResults, rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", podTarget.With("details", err.Error())))
 			continue
 		}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -161,10 +161,11 @@ func (r *Rule242400) checkKubeProxy(
 ) []rule.CheckResult {
 	const option = "featureGates.AllAlpha"
 	var (
-		checkResults     []rule.CheckResult
-		additionalLabels = map[string]string{pod.LabelInstanceID: r.InstanceID}
-		podName          = fmt.Sprintf("diki-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
-		execPodTarget    = rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
+		checkResults            []rule.CheckResult
+		additionalLabels        = map[string]string{pod.LabelInstanceID: r.InstanceID}
+		podName                 = fmt.Sprintf("diki-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
+		execPodTarget           = rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
+		kubeProxyContainerNames = []string{"kube-proxy", "proxy"}
 	)
 
 	defer func() {
@@ -202,7 +203,7 @@ func (r *Rule242400) checkKubeProxy(
 	for _, pod := range pods {
 		podTarget := rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 
-		rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, "kube-proxy")
+		rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 		if err != nil {
 			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 			continue
@@ -222,7 +223,7 @@ func (r *Rule242400) checkKubeProxy(
 
 		var allAlpha *bool
 		if len(configPath) != 0 {
-			kubeProxyContainerID, err := intutils.GetContainerID(pod, "kube-proxy")
+			kubeProxyContainerID, err := intutils.GetContainerID(pod, kubeProxyContainerNames...)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -292,7 +292,7 @@ var _ = Describe("#242400", func() {
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 	})
 
-	It("should correctly check if container names are in the valid specifications", func() {
+	It("should correctly look up for a proxy container if the kube-proxy container is absent", func() {
 		node1 := plainNode.DeepCopy()
 		node1.ObjectMeta.Name = "node1"
 		Expect(fakeClient.Create(ctx, node1)).To(Succeed())

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -349,7 +349,7 @@ var _ = Describe("#242400", func() {
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("kind", "node", "name", "node1")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod")),
 			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod")),
-			rule.ErroredCheckResult("Pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -349,7 +349,7 @@ var _ = Describe("#242400", func() {
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("kind", "node", "name", "node1")),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod")),
 			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod")),
-			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("Pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -298,14 +298,14 @@ var _ = Describe("#242400", func() {
 		Expect(fakeClient.Create(ctx, node1)).To(Succeed())
 
 		kubeProxyContainerPod := plainPod.DeepCopy()
-		kubeProxyContainerPod.Name = "kube-proxy-container-pod"
+		kubeProxyContainerPod.Name = "pod1"
 		kubeProxyContainerPod.Spec.NodeName = "node1"
 		kubeProxyContainerPod.Spec.Containers[0].Command = []string{"--flag1=value1", "--flag2=value2"}
 		kubeProxyContainerPod.OwnerReferences[0].UID = "1"
 		Expect(fakeClient.Create(ctx, kubeProxyContainerPod)).To(Succeed())
 
 		proxyContainerPod := plainPod.DeepCopy()
-		proxyContainerPod.Name = "proxy-container-pod"
+		proxyContainerPod.Name = "pod2"
 		proxyContainerPod.Spec.NodeName = "node1"
 		proxyContainerPod.Spec.Containers[0].Name = "proxy"
 		proxyContainerPod.Spec.Containers[0].Command = []string{"--flag1=value1", "--feature-gates=AllAlpha=true"}
@@ -313,7 +313,7 @@ var _ = Describe("#242400", func() {
 		Expect(fakeClient.Create(ctx, proxyContainerPod)).To(Succeed())
 
 		nonValidContainerPod := plainPod.DeepCopy()
-		nonValidContainerPod.Name = "non-valid-container-pod"
+		nonValidContainerPod.Name = "pod3"
 		nonValidContainerPod.Spec.NodeName = "node1"
 		nonValidContainerPod.Spec.Containers[0].Name = "foo"
 		nonValidContainerPod.Spec.Containers[0].Command = []string{"--flag1=value1", "--config=/var/lib/config"}
@@ -347,9 +347,9 @@ var _ = Describe("#242400", func() {
 
 		expectedResults := []rule.CheckResult{
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("kind", "node", "name", "node1")),
-			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod")),
-			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "non-valid-container-pod", "namespace", "kube-system", "kind", "pod")),
-			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod")),
+			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod")),
+			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -292,7 +292,7 @@ var _ = Describe("#242400", func() {
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 	})
 
-	It("should correctly look up for a proxy container if the kube-proxy container is absent", func() {
+	It("should correctly find the kube-proxy container", func() {
 		node1 := plainNode.DeepCopy()
 		node1.ObjectMeta.Name = "node1"
 		Expect(fakeClient.Create(ctx, node1)).To(Succeed())
@@ -347,9 +347,9 @@ var _ = Describe("#242400", func() {
 
 		expectedResults := []rule.CheckResult{
 			rule.PassedCheckResult("Option featureGates.AllAlpha set to allowed value.", rule.NewTarget("kind", "node", "name", "node1")),
-			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod")),
-			rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", rule.NewTarget("name", nonValidContainerPod.Name, "namespace", nonValidContainerPod.Namespace, "kind", "pod", "details", "pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]")),
-			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod")),
+			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "non-valid-container-pod", "namespace", "kube-system", "kind", "pod")),
+			rule.FailedCheckResult("Option featureGates.AllAlpha set to not allowed value.", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
@@ -46,6 +46,6 @@ var _ = Describe("retryerrors", func() {
 		},
 		Entry("Should match diki pod not found", `pods "diki-111111-asdasdasda" not found`, true),
 		Entry("Should not match when pod is not diki", `pods "foo" not found`, false),
-		Entry("Should not match when pod does not fit diki pod regex", `pods "diki-1111-asdasdasda" not found`, false),
+		Entry("Should not match when Pod does not fit diki pod regex", `pods "diki-1111-asdasdasda" not found`, false),
 	)
 })

--- a/pkg/shared/ruleset/disak8sstig/rules/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447.go
@@ -140,7 +140,7 @@ func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 
 			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 			if err != nil {
-				checkResults = append(checkResults, rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", podTarget.With("details", err.Error())))
+				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue
 			}
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447.go
@@ -60,6 +60,7 @@ func (r *Rule242447) Name() string {
 func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
 	kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
+	kubeProxyContainerNames := []string{"kube-proxy", "proxy"}
 
 	if r.Options != nil && len(r.Options.KubeProxyMatchLabels) > 0 {
 		kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
@@ -137,7 +138,7 @@ func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 			expectedFilePermissionsMax := "644"
 			podTarget := target.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 
-			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, "kube-proxy")
+			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue
@@ -155,7 +156,7 @@ func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 				continue
 			}
 
-			kubeProxyContainerID, err := intutils.GetContainerID(pod, "kube-proxy")
+			kubeProxyContainerID, err := intutils.GetContainerID(pod, kubeProxyContainerNames...)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue

--- a/pkg/shared/ruleset/disak8sstig/rules/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447.go
@@ -140,7 +140,7 @@ func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 
 			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 			if err != nil {
-				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
+				checkResults = append(checkResults, rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", podTarget.With("details", err.Error())))
 				continue
 			}
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -166,6 +166,56 @@ var _ = Describe("#242447", func() {
 		}))
 	})
 
+	It("should correctly check if container names are in the valid specifications", func() {
+		Expect(fakeClient.Create(ctx, Node)).To(Succeed())
+		Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
+
+		kubeProxyContainerPod := plainPod.DeepCopy()
+		kubeProxyContainerPod.Name = "kube-proxy-container-pod"
+		kubeProxyContainerPod.Labels["role"] = "proxy"
+		kubeProxyContainerPod.Spec.Containers[0].Command = []string{"--config=/var/lib/config", "--kubeconfig=/var/lib/kubeconfig"}
+		kubeProxyContainerPod.OwnerReferences[0].UID = "0"
+		Expect(fakeClient.Create(ctx, kubeProxyContainerPod)).To(Succeed())
+
+		proxyContainerPod := plainPod.DeepCopy()
+		proxyContainerPod.Name = "proxy-container-pod"
+		proxyContainerPod.Labels["role"] = "proxy"
+		proxyContainerPod.Spec.Containers[0].Name = "proxy"
+		proxyContainerPod.Spec.Containers[0].Command = []string{"--config=/var/lib/config"}
+		proxyContainerPod.OwnerReferences[0].UID = "1"
+		Expect(fakeClient.Create(ctx, proxyContainerPod)).To(Succeed())
+
+		nonValidContainerPod := plainPod.DeepCopy()
+		nonValidContainerPod.Name = "non-valid-container-pod"
+		nonValidContainerPod.Labels["role"] = "proxy"
+		nonValidContainerPod.Spec.Containers[0].Name = "foo"
+		nonValidContainerPod.Spec.Containers[0].Command = []string{"--kubeconfig=/var/lib/kubeconfig"}
+		nonValidContainerPod.OwnerReferences[0].UID = "2"
+		Expect(fakeClient.Create(ctx, nonValidContainerPod)).To(Succeed())
+
+		fakePodContext = fakepod.NewFakeSimplePodContext([][]string{{mounts, compliantConfigStats, compliantKubeconfigStats, mounts, nonCompliantConfigStats, kubeProxyConfig, nonCompliantKubeconfigStats2}},
+			[][]error{{nil, nil, nil, nil, nil, nil, nil}})
+		r := &rules.Rule242447{
+			Logger:     testLogger,
+			InstanceID: instanceID,
+			Client:     fakeClient,
+			PodContext: fakePodContext,
+		}
+
+		ruleResult, err := r.Run(ctx)
+		Expect(err).To(BeNil())
+
+		expectedResults := []rule.CheckResult{
+			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, permissions: 644")),
+			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
+			rule.ErroredCheckResult("pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", nonValidContainerPod.Name, "namespace", nonValidContainerPod.Namespace, "kind", "pod")),
+			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
+			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
+		}
+
+		Expect(ruleResult.CheckResults).To(Equal(expectedResults))
+	})
+
 	DescribeTable("Run cases",
 		func(options rules.Options242447, executeReturnString [][]string, executeReturnError [][]error, expectedCheckResults []rule.CheckResult) {
 			Expect(fakeClient.Create(ctx, Node)).To(Succeed())

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -210,7 +210,7 @@ var _ = Describe("#242447", func() {
 			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
 			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
 			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
-			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("Pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -166,7 +166,7 @@ var _ = Describe("#242447", func() {
 		}))
 	})
 
-	It("should correctly check if container names are in the valid specifications", func() {
+	It("should correctly look up for a proxy container if the kube-proxy container is absent", func() {
 		Expect(fakeClient.Create(ctx, Node)).To(Succeed())
 		Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -166,7 +166,7 @@ var _ = Describe("#242447", func() {
 		}))
 	})
 
-	It("should correctly look up for a proxy container if the kube-proxy container is absent", func() {
+	It("should correctly find the kube-proxy container", func() {
 		Expect(fakeClient.Create(ctx, Node)).To(Succeed())
 		Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
 
@@ -206,11 +206,11 @@ var _ = Describe("#242447", func() {
 		Expect(err).To(BeNil())
 
 		expectedResults := []rule.CheckResult{
-			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, permissions: 644")),
-			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
-			rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", rule.NewTarget("name", nonValidContainerPod.Name, "namespace", nonValidContainerPod.Namespace, "kind", "pod", "details", "pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]")),
-			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
-			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
+			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 644")),
+			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
+			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "non-valid-container-pod", "namespace", "kube-system", "kind", "pod")),
+			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
+			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -171,14 +171,14 @@ var _ = Describe("#242447", func() {
 		Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
 
 		kubeProxyContainerPod := plainPod.DeepCopy()
-		kubeProxyContainerPod.Name = "kube-proxy-container-pod"
+		kubeProxyContainerPod.Name = "pod1"
 		kubeProxyContainerPod.Labels["role"] = "proxy"
 		kubeProxyContainerPod.Spec.Containers[0].Command = []string{"--config=/var/lib/config", "--kubeconfig=/var/lib/kubeconfig"}
 		kubeProxyContainerPod.OwnerReferences[0].UID = "0"
 		Expect(fakeClient.Create(ctx, kubeProxyContainerPod)).To(Succeed())
 
 		proxyContainerPod := plainPod.DeepCopy()
-		proxyContainerPod.Name = "proxy-container-pod"
+		proxyContainerPod.Name = "pod2"
 		proxyContainerPod.Labels["role"] = "proxy"
 		proxyContainerPod.Spec.Containers[0].Name = "proxy"
 		proxyContainerPod.Spec.Containers[0].Command = []string{"--config=/var/lib/config"}
@@ -186,7 +186,7 @@ var _ = Describe("#242447", func() {
 		Expect(fakeClient.Create(ctx, proxyContainerPod)).To(Succeed())
 
 		nonValidContainerPod := plainPod.DeepCopy()
-		nonValidContainerPod.Name = "non-valid-container-pod"
+		nonValidContainerPod.Name = "pod3"
 		nonValidContainerPod.Labels["role"] = "proxy"
 		nonValidContainerPod.Spec.Containers[0].Name = "foo"
 		nonValidContainerPod.Spec.Containers[0].Command = []string{"--kubeconfig=/var/lib/kubeconfig"}
@@ -206,11 +206,11 @@ var _ = Describe("#242447", func() {
 		Expect(err).To(BeNil())
 
 		expectedResults := []rule.CheckResult{
-			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 644")),
-			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
-			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "non-valid-container-pod", "namespace", "kube-system", "kind", "pod")),
-			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
-			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
+			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 644")),
+			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
+			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
+			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
+			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -210,7 +210,7 @@ var _ = Describe("#242447", func() {
 			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
 			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
 			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
-			rule.ErroredCheckResult("Pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -208,7 +208,7 @@ var _ = Describe("#242447", func() {
 		expectedResults := []rule.CheckResult{
 			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, permissions: 644")),
 			rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig, permissions: 600")),
-			rule.ErroredCheckResult("pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", nonValidContainerPod.Name, "namespace", nonValidContainerPod.Namespace, "kind", "pod")),
+			rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", rule.NewTarget("name", nonValidContainerPod.Name, "namespace", nonValidContainerPod.Namespace, "kind", "pod", "details", "pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]")),
 			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, permissions: 664, expectedPermissionsMax: 644")),
 			rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, permissions: 606, expectedPermissionsMax: 644")),
 		}

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -66,6 +66,7 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 	checkResults := []rule.CheckResult{}
 	options := option.FileOwnerOptions{}
 	kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
+	kubeProxyContainerNames := []string{"kube-proxy", "proxy"}
 
 	if r.Options != nil {
 		if r.Options.FileOwnerOptions != nil {
@@ -153,7 +154,7 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 			selectedFileStats := []intutils.FileStats{}
 			podTarget := target.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 
-			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, "kube-proxy")
+			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue
@@ -171,7 +172,7 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 				continue
 			}
 
-			kubeProxyContainerID, err := intutils.GetContainerID(pod, "kube-proxy")
+			kubeProxyContainerID, err := intutils.GetContainerID(pod, kubeProxyContainerNames...)
 			if err != nil {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -156,7 +156,7 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 
 			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 			if err != nil {
-				checkResults = append(checkResults, rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", podTarget.With("details", err.Error())))
+				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
 				continue
 			}
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -156,7 +156,7 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 
 			rawKubeProxyCommand, err := kubeutils.GetContainerCommand(pod, kubeProxyContainerNames...)
 			if err != nil {
-				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), podTarget))
+				checkResults = append(checkResults, rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", podTarget.With("details", err.Error())))
 				continue
 			}
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
@@ -211,7 +211,7 @@ var _ = Describe("#242448", func() {
 			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, ownerUser: 0, ownerGroup: 0")),
 			rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 1000, expectedOwnerUsers: [0]")),
 			rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, ownerGroup: 1000, expectedOwnerGroups: [0]")),
-			rule.ErroredCheckResult("Pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
@@ -172,14 +172,14 @@ var _ = Describe("#242448", func() {
 		Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
 
 		kubeProxyContainerPod := plainPod.DeepCopy()
-		kubeProxyContainerPod.Name = "kube-proxy-container-pod"
+		kubeProxyContainerPod.Name = "pod1"
 		kubeProxyContainerPod.Labels["role"] = "proxy"
 		kubeProxyContainerPod.Spec.Containers[0].Command = []string{"--config=/var/lib/config", "--kubeconfig=/var/lib/kubeconfig"}
 		kubeProxyContainerPod.OwnerReferences[0].UID = "0"
 		Expect(fakeClient.Create(ctx, kubeProxyContainerPod)).To(Succeed())
 
 		proxyContainerPod := plainPod.DeepCopy()
-		proxyContainerPod.Name = "proxy-container-pod"
+		proxyContainerPod.Name = "pod2"
 		proxyContainerPod.Labels["role"] = "proxy"
 		proxyContainerPod.Spec.Containers[0].Name = "proxy"
 		proxyContainerPod.Spec.Containers[0].Command = []string{"--config=/var/lib/config"}
@@ -187,7 +187,7 @@ var _ = Describe("#242448", func() {
 		Expect(fakeClient.Create(ctx, proxyContainerPod)).To(Succeed())
 
 		nonValidContainerPod := plainPod.DeepCopy()
-		nonValidContainerPod.Name = "non-valid-container-pod"
+		nonValidContainerPod.Name = "pod3"
 		nonValidContainerPod.Labels["role"] = "proxy"
 		nonValidContainerPod.Spec.Containers[0].Name = "foo"
 		nonValidContainerPod.Spec.Containers[0].Command = []string{"--kubeconfig=/var/lib/kubeconfig"}
@@ -207,11 +207,11 @@ var _ = Describe("#242448", func() {
 		Expect(err).To(BeNil())
 
 		expectedResults := []rule.CheckResult{
-			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 0, ownerGroup: 0")),
-			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, ownerUser: 0, ownerGroup: 0")),
-			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "non-valid-container-pod", "namespace", "kube-system", "kind", "pod")),
-			rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 1000, expectedOwnerUsers: [0]")),
-			rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, ownerGroup: 1000, expectedOwnerGroups: [0]")),
+			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 0, ownerGroup: 0")),
+			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, ownerUser: 0, ownerGroup: 0")),
+			rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 1000, expectedOwnerUsers: [0]")),
+			rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, ownerGroup: 1000, expectedOwnerGroups: [0]")),
+			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
@@ -167,7 +167,7 @@ var _ = Describe("#242448", func() {
 		}))
 	})
 
-	It("should correctly check if container names are in the valid specifications", func() {
+	It("should correctly look up for a proxy container if the kube-proxy container is absent", func() {
 		Expect(fakeClient.Create(ctx, Node)).To(Succeed())
 		Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
@@ -211,7 +211,7 @@ var _ = Describe("#242448", func() {
 			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "pod1", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, ownerUser: 0, ownerGroup: 0")),
 			rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 1000, expectedOwnerUsers: [0]")),
 			rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", "pod2", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, ownerGroup: 1000, expectedOwnerGroups: [0]")),
-			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
+			rule.ErroredCheckResult("Pod does not contain a container with name in [kube-proxy proxy]", rule.NewTarget("name", "pod3", "namespace", "kube-system", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))

--- a/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
@@ -167,7 +167,7 @@ var _ = Describe("#242448", func() {
 		}))
 	})
 
-	It("should correctly look up for a proxy container if the kube-proxy container is absent", func() {
+	It("should correctly find the kube-proxy container", func() {
 		Expect(fakeClient.Create(ctx, Node)).To(Succeed())
 		Expect(fakeClient.Create(ctx, dikiPod)).To(Succeed())
 
@@ -207,11 +207,11 @@ var _ = Describe("#242448", func() {
 		Expect(err).To(BeNil())
 
 		expectedResults := []rule.CheckResult{
-			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 0, ownerGroup: 0")),
-			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", kubeProxyContainerPod.Name, "namespace", kubeProxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig, ownerUser: 0, ownerGroup: 0")),
-			rule.ErroredCheckResult("Failed to find any containers appropriate for evaluation", rule.NewTarget("name", nonValidContainerPod.Name, "namespace", nonValidContainerPod.Namespace, "kind", "pod", "details", "pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]")),
-			rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 1000, expectedOwnerUsers: [0]")),
-			rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", proxyContainerPod.Name, "namespace", proxyContainerPod.Namespace, "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, ownerGroup: 1000, expectedOwnerGroups: [0]")),
+			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 0, ownerGroup: 0")),
+			rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "kube-proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig, ownerUser: 0, ownerGroup: 0")),
+			rule.ErroredCheckResult("Pod does not contain any of the containers specified in the provided list: [kube-proxy proxy]", rule.NewTarget("name", "non-valid-container-pod", "namespace", "kube-system", "kind", "pod")),
+			rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/config, ownerUser: 1000, expectedOwnerUsers: [0]")),
+			rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", "proxy-container-pod", "namespace", "kube-system", "kind", "pod", "details", "fileName: /var/lib/kubeconfig2, ownerGroup: 1000, expectedOwnerGroups: [0]")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedResults))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies the GetContainerCommand and GetContainerID util functions to be variadic and accept more than one possible container name for matching. Along with those modifications, rules that utilize the functions (242400, 242447, 242448) are also modified to search for "proxy" containers if "kube-proxy" containers are absent. Additional unit tests are added to validate the new modification.

**Which issue(s) this PR fixes**:
Fixes #314 

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing DISA Kubernetes STIG rules that check the `kube-proxy` container to fail to find the container, when the container name is `proxy`, was fixed.
```
