### PR TITLE
Enable gosec for SAST scans

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -84,7 +84,7 @@ diki:
             - gosec
             comment: |
               We use gosec (linter) for SAST scans, see: https://github.com/securego/gosec.
-              Enabled by https://github.com/gardener/diki/issues/331
+              Enabled by https://github.com/gardener/diki/pull/333
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,6 +4,13 @@
 
 diki:
   base_definition:
+    repo:
+      source_labels:
+      - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+        value:
+          policy: skip
+          comment: |
+            We use gosec for sast scanning, see attached log.
     traits:
       version:
         preprocess: 'inject-commit-hash'
@@ -68,6 +75,16 @@ diki:
           nextversion: 'bump_minor'
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+          assets:
+          - type: build-step-log
+            step_name: verify
+            purposes:
+            - lint
+            - sast
+            - gosec
+            comment: |
+              We use gosec (linter) for SAST scans, see: https://github.com/securego/gosec.
+              Enabled by https://github.com/gardener/diki/issues/331
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ testbin
 .kube
 
 /hack/tools/bin
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT)
 tidy:
 	@GO111MODULE=on go mod tidy
 	@mkdir -p $(REPO_ROOT)/.ci/hack && cp $(GARDENER_HACK_DIR)/.ci/* $(REPO_ROOT)/.ci/hack/ && chmod +xw $(REPO_ROOT)/.ci/hack/*
+	@cp $(GARDENER_HACK_DIR)/sast.sh $(HACK_DIR)/sast.sh && chmod +xw $(HACK_DIR)/sast.sh
 
 .PHONY: gen-styles
 gen-styles: $(TAILWINDCSS)
@@ -53,6 +54,14 @@ generate:
 check-generate:
 	@bash $(GARDENER_HACK_DIR)/check-generate.sh $(REPO_ROOT)
 
+.PHONY: sast
+sast: tidy $(GOSEC)
+	@$(HACK_DIR)/sast.sh
+
+.PHONY: sast-report
+sast-report: tidy $(GOSEC)
+	@$(HACK_DIR)/sast.sh --gosec-report true
+
 .PHONY: test-cov
 test-cov:
 	@bash $(GARDENER_HACK_DIR)/test-cover.sh ./cmd/... ./pkg/...
@@ -62,10 +71,10 @@ test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
 .PHONY: verify
-verify: format check test
+verify: format check test sast
 
 .PHONY: verify-extended
-verify-extended: check-generate check format test test-cov test-clean
+verify-extended: check-generate check format test test-cov test-clean sast-report
 
 #### BUILD ####
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...

--- a/pkg/internal/stringgen/generator.go
+++ b/pkg/internal/stringgen/generator.go
@@ -30,7 +30,7 @@ type RandString struct {
 // NewRand returns a not secure random string generator.
 func NewRand(source rand.Source, chars []rune) *RandString {
 	return &RandString{
-		random: rand.New(source), //nolint:gosec
+		random: rand.New(source), // #nosec G404
 		chars:  chars,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable gosec for SAST scans

**Which issue(s) this PR fixes**:
Fixes #331 

**Special notes for your reviewer**:
gosec changes are influenced from https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/248

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gosec` is made available for SAST(static application security testing), it can be run with `make sast` or `make sast-report`, but is also incorporated in the `verify` and `verify-extended` makefile targets. 
```
