### PR TITLE
Add `Security Hardened Kubernetes Cluster` ruleset version `v0.1.0`

### DIFF
--- a/docs/rulesets/security-hardened-k8s-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-k8s-cluster/ruleset.md
@@ -4,14 +4,14 @@
 
 The Security Hardened Kubernetes Cluster Guide is created as an extension to the [DISA Kubernetes Security Technical Implementation Guide](../disa-k8s-stig/ruleset.md).
 It aims to additionally increase the security posture of a Kubernetes cluster.
-The ruleset is inspired and follows some of the policies from [Kyverno](https://release-1-12-0.kyverno.io/policies/).
+The ruleset is inspired and follows some of the policies from [Kyverno](https://github.com/kyverno/policies/tree/release-1.12).
 
 ## Rules
 
 ### 2000 - Ingress and egress traffic must be restricted by default.
 
 #### Description
-This rule follows the requirements from Kyverno best practices policy [Add Network Policy](https://release-1-12-0.kyverno.io/policies/best-practices/add-network-policy/add-network-policy/).
+This rule follows the requirements from Kyverno best practices policy [Add Network Policy](https://github.com/kyverno/policies/tree/release-1.12/best-practices/add-network-policy/add-network-policy.yaml).
 
 #### Fix
 Configure a default `NetworkPolicy` for each `Namespace` to default deny all ingress and egress traffic to the `Pods` in the `Namespace`.
@@ -34,7 +34,7 @@ spec:
 ### 2001 - Containers must be forbidden to escalate privileges.
 
 #### Description
-This rule follows the requirements from Kyverno pod security policy [Disallow Privilege Escalation](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation/).
+This rule follows the requirements from Kyverno pod security policy [Disallow Privilege Escalation](https://github.com/kyverno/policies/tree/release-1.12/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml).
 
 #### Fix
 Do not set `Pod` container fields `securityContext.allowPrivilegeEscalation` as it defaults to `false` or set it explicitly to `false`.
@@ -58,7 +58,7 @@ spec:
 ### 2002 - Storage Classes should have a "Delete" reclaim policy.
 
 #### Description
-This rule follows the requirements from Kyverno policy [Restrict StorageClass](https://release-1-12-0.kyverno.io/policies/other/restrict-storageclass/restrict-storageclass/).
+This rule follows the requirements from Kyverno policy [Restrict StorageClass](https://github.com/kyverno/policies/tree/release-1.12/other/restrict-storageclass/restrict-storageclass.yaml).
 
 #### Fix
 Do not set `StorageClass` field `reclaimPolicy` as it defaults to `Delete` or set it explicitly to `Delete`.
@@ -73,17 +73,17 @@ reclaimPolicy: Delete
 ### 2003 - Pods should use only allowed volume types.
 
 #### Description
-This rule follows the requirements from Kyverno pod security policy [Restrict Volume Type](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/restrict-volume-types/restrict-volume-types/).
+This rule follows the requirements from Kyverno pod security policy [Restrict Volume Type](https://github.com/kyverno/policies/tree/release-1.12/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml).
 
 #### Fix
-`Pod` `Volume` types are restricted to `configMap`, `csi`, `downwardAPI`, `emptyDir`, `ephemeral`, `persistentVolumeClaim`, `projected` and `secret`.
+Restrict `Pod` volume types to `configMap`, `csi`, `downwardAPI`, `emptyDir`, `ephemeral`, `persistentVolumeClaim`, `projected` and `secret`.
 
 ---
 
 ### 2004 - Limit the Services of type NodePort.
 
 #### Description
-This rule follows the requirements from Kyverno best practices policy [Disallow NodePort](https://release-1-12-0.kyverno.io/policies/best-practices/restrict-node-port/restrict-node-port/).
+This rule follows the requirements from Kyverno best practices policy [Disallow NodePort](https://github.com/kyverno/policies/tree/release-1.12/best-practices/restrict-node-port/restrict-node-port.yaml).
 
 #### Fix
 Remove `Services` of type `NodePort`.
@@ -93,7 +93,7 @@ Remove `Services` of type `NodePort`.
 ### 2005 - Container images must come from trusted repositories.
 
 #### Description
-This rule follows the requirements from Kyverno policy [Allowed Image Repositories](https://release-1-12-0.kyverno.io/policies/other/allowed-image-repos/allowed-image-repos/).
+This rule follows the requirements from Kyverno policy [Allowed Image Repositories](https://github.com/kyverno/policies/tree/release-1.12/other/allowed-image-repos/allowed-image-repos.yaml).
 
 #### Fix
 Maintain an allowed list of image repositories and only use images for `Pods` from the allowed repositories.
@@ -103,7 +103,7 @@ Maintain an allowed list of image repositories and only use images for `Pods` fr
 ### 2006 - Limit the use of wildcards in RBAC resources.
 
 #### Description
-This rule follows the requirements from Kyverno policy [Restrict Wildcards in Resources](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-resources/restrict-wildcard-resources/).
+This rule follows the requirements from Kyverno policy [Restrict Wildcards in Resources](https://github.com/kyverno/policies/tree/release-1.12/other/restrict-wildcard-resources/restrict-wildcard-resources.yaml).
 
 #### Fix
 Remove the use of wildcards `*` in `RBAC` resources.
@@ -113,7 +113,7 @@ Remove the use of wildcards `*` in `RBAC` resources.
 ### 2007 - Limit the use of wildcards in RBAC verbs.
 
 #### Description
-This rule follows the requirements from Kyverno policy [Restrict Wildcard in Verbs](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-verbs/restrict-wildcard-verbs/).
+This rule follows the requirements from Kyverno policy [Restrict Wildcard in Verbs](https://github.com/kyverno/policies/tree/release-1.12/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml).
 
 #### Fix
 Remove the use of wildcards `*` in `RBAC` verbs.
@@ -123,7 +123,7 @@ Remove the use of wildcards `*` in `RBAC` verbs.
 ### 2008 - Pods must not be allowed to mount host directories.
 
 #### Description
-This rule follows the requirements from Kyverno pod security policy [Disallow hostPath](https://release-1-12-0.kyverno.io/policies/pod-security/baseline/disallow-host-path/disallow-host-path/).
+This rule follows the requirements from Kyverno pod security policy [Disallow hostPath](https://github.com/kyverno/policies/tree/release-1.12/pod-security/baseline/disallow-host-path/disallow-host-path.yaml).
 
 #### Fix
 Remove `Volumes` of type `hostPath` in `Pod` spec. 

--- a/docs/rulesets/security-hardened-k8s-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-k8s-cluster/ruleset.md
@@ -1,0 +1,129 @@
+# Security Hardened Kubernetes Cluster Guide
+
+## Introduction
+
+The Security Hardened Kubernetes Cluster Guide is created as an extension to the [DISA Kubernetes Security Technical Implementation Guide](../disa-k8s-stig/ruleset.md).
+It aims to additionally increase the security posture of a Kubernetes cluster.
+The ruleset is inspired and follows some of the policies from [Kyverno](https://release-1-12-0.kyverno.io/policies/).
+
+## Rules
+
+### 2000 - Ingress and egress traffic must be restricted by default.
+
+#### Description
+This rule follows the requirements from Kyverno best practices policy [Add Network Policy](https://release-1-12-0.kyverno.io/policies/best-practices/add-network-policy/add-network-policy/).
+
+#### Fix
+Configure a default `NetworkPolicy` for each `Namespace` to default deny all ingress and egress traffic to the `Pods` in the `Namespace`.
+
+``` yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  # select all pods in the namespace
+  podSelector: {}
+  # deny all traffic
+  policyTypes:
+  - Ingress
+  - Egress
+```
+---
+
+### 2001 - Containers must be forbidden to escalate privileges.
+
+#### Description
+This rule follows the requirements from Kyverno pod security policy [Disallow Privilege Escalation](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation/).
+
+#### Fix
+Do not set `Pod` container fields `securityContext.allowPrivilegeEscalation` as it defaults to `false` or set it explicitly to `false`.
+
+> [!WARNING]  
+> `securityContext.allowPrivilegeEscalation` is set to `true` in the following exceptions:
+> - container is running as `privileged`
+> - `CAP_SYS_ADMIN` is added to the container
+
+``` yaml
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: ...
+    securityContext:
+      allowPrivilegeEscalation: false
+```
+---
+
+### 2002 - Storage Classes should have a "Delete" reclaim policy.
+
+#### Description
+This rule follows the requirements from Kyverno policy [Restrict StorageClass](https://release-1-12-0.kyverno.io/policies/other/restrict-storageclass/restrict-storageclass/).
+
+#### Fix
+Do not set `StorageClass` field `reclaimPolicy` as it defaults to `Delete` or set it explicitly to `Delete`.
+
+``` yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+reclaimPolicy: Delete
+```
+---
+
+### 2003 - Pods should use only allowed volume types.
+
+#### Description
+This rule follows the requirements from Kyverno pod security policy [Restrict Volume Type](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/restrict-volume-types/restrict-volume-types/).
+
+#### Fix
+`Pod` `Volume` types are restricted to `configMap`, `csi`, `downwardAPI`, `emptyDir`, `ephemeral`, `persistentVolumeClaim`, `projected` and `secret`.
+
+---
+
+### 2004 - Limit the Services of type NodePort.
+
+#### Description
+This rule follows the requirements from Kyverno best practices policy [Disallow NodePort](https://release-1-12-0.kyverno.io/policies/best-practices/restrict-node-port/restrict-node-port/).
+
+#### Fix
+Remove `Services` of type `NodePort`.
+
+---
+
+### 2005 - Container images must come from trusted repositories.
+
+#### Description
+This rule follows the requirements from Kyverno policy [Allowed Image Repositories](https://release-1-12-0.kyverno.io/policies/other/allowed-image-repos/allowed-image-repos/).
+
+#### Fix
+Maintain an allowed list of image repositories and only use images for `Pods` from the allowed repositories.
+
+---
+
+### 2006 - Limit the use of wildcards in RBAC resources.
+
+#### Description
+This rule follows the requirements from Kyverno policy [Restrict Wildcards in Resources](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-resources/restrict-wildcard-resources/).
+
+#### Fix
+Remove the use of wildcards `*` in `RBAC` resources.
+
+---
+
+### 2007 - Limit the use of wildcards in RBAC verbs.
+
+#### Description
+This rule follows the requirements from Kyverno policy [Restrict Wildcard in Verbs](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-verbs/restrict-wildcard-verbs/).
+
+#### Fix
+Remove the use of wildcards `*` in `RBAC` verbs.
+
+---
+
+### 2008 - Pods must not be allowed to mount host directories.
+
+#### Description
+This rule follows the requirements from Kyverno pod security policy [Disallow hostPath](https://release-1-12-0.kyverno.io/policies/pod-security/baseline/disallow-host-path/disallow-host-path/).
+
+#### Fix
+Remove `Volumes` of type `hostPath` in `Pod` spec. 

--- a/docs/rulesets/security-hardened-k8s-cluster/security-hardened-k8s-cluster-v0.1.0.yaml
+++ b/docs/rulesets/security-hardened-k8s-cluster/security-hardened-k8s-cluster-v0.1.0.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ruleset:
+  id: security-hardened-kubernetes-cluster
+  name: "Security Hardened Kubernetes Cluster"
+  version: "v0.1.0"
+rules:
+- id: 2000
+  name: "Ingress and egress traffic must be restricted by default."
+  description: "This rule follows the requirements from Kyverno best practices policy [Add Network Policy](https://release-1-12-0.kyverno.io/policies/best-practices/add-network-policy/add-network-policy/)."
+  severity: "HIGH"
+- id: 2001
+  name: "Containers must be forbidden to escalate privileges."
+  description: "This rule follows the requirements from Kyverno pod security policy [Disallow Privilege Escalation](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation/)."
+  severity: "HIGH"
+- id: 2002
+  name: "Storage Classes should have a \"Delete\" reclaim policy."
+  description: "This rule follows the requirements from Kyverno policy [Restrict StorageClass](https://release-1-12-0.kyverno.io/policies/other/restrict-storageclass/restrict-storageclass/)."
+  severity: "MEDIUM"
+- id: 2003
+  name: "Pods should use only allowed volume types."
+  description: "This rule follows the requirements from Kyverno pod security policy [Restrict Volume Type](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/restrict-volume-types/restrict-volume-types/)."
+  severity: "MEDIUM"
+- id: 2004
+  name: "Limit the Services of type NodePort."
+  description: "This rule follows the requirements from Kyverno best practices policy [Disallow NodePort](https://release-1-12-0.kyverno.io/policies/best-practices/restrict-node-port/restrict-node-port/)."
+  severity: "MEDIUM"
+- id: 2005
+  name: "Container images must come from trusted repositories."
+  description: "This rule follows the requirements from Kyverno policy [Allowed Image Repositories](https://release-1-12-0.kyverno.io/policies/other/allowed-image-repos/allowed-image-repos/)."
+  severity: "HIGH"
+- id: 2006
+  name: "Limit the use of wildcards in RBAC resources."
+  description: "This rule follows the requirements from Kyverno policy [Restrict Wildcards in Resources](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-resources/restrict-wildcard-resources/)."
+  severity: "MEDIUM"
+- id: 2007
+  name: "Limit the use of wildcards in RBAC verbs."
+  description: "This rule follows the requirements from Kyverno policy [Restrict Wildcard in Verbs](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-verbs/restrict-wildcard-verbs/)."
+  severity: "MEDIUM"
+- id: 2008
+  name: "Pods must not be allowed to mount host directories."
+  description: "This rule follows the requirements from Kyverno pod security policy [Disallow hostPath](https://release-1-12-0.kyverno.io/policies/pod-security/baseline/disallow-host-path/disallow-host-path/)."
+  severity: "HIGH"

--- a/docs/rulesets/security-hardened-k8s-cluster/security-hardened-k8s-cluster-v0.1.0.yaml
+++ b/docs/rulesets/security-hardened-k8s-cluster/security-hardened-k8s-cluster-v0.1.0.yaml
@@ -9,37 +9,37 @@ ruleset:
 rules:
 - id: 2000
   name: "Ingress and egress traffic must be restricted by default."
-  description: "This rule follows the requirements from Kyverno best practices policy [Add Network Policy](https://release-1-12-0.kyverno.io/policies/best-practices/add-network-policy/add-network-policy/)."
+  description: "This rule follows the requirements from Kyverno best practices policy [Add Network Policy](https://github.com/kyverno/policies/tree/release-1.12/best-practices/add-network-policy/add-network-policy.yaml)."
   severity: "HIGH"
 - id: 2001
   name: "Containers must be forbidden to escalate privileges."
-  description: "This rule follows the requirements from Kyverno pod security policy [Disallow Privilege Escalation](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation/)."
+  description: "This rule follows the requirements from Kyverno pod security policy [Disallow Privilege Escalation](https://github.com/kyverno/policies/tree/release-1.12/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml)."
   severity: "HIGH"
 - id: 2002
   name: "Storage Classes should have a \"Delete\" reclaim policy."
-  description: "This rule follows the requirements from Kyverno policy [Restrict StorageClass](https://release-1-12-0.kyverno.io/policies/other/restrict-storageclass/restrict-storageclass/)."
+  description: "This rule follows the requirements from Kyverno policy [Restrict StorageClass](https://github.com/kyverno/policies/tree/release-1.12/other/restrict-storageclass/restrict-storageclass.yaml)."
   severity: "MEDIUM"
 - id: 2003
   name: "Pods should use only allowed volume types."
-  description: "This rule follows the requirements from Kyverno pod security policy [Restrict Volume Type](https://release-1-12-0.kyverno.io/policies/pod-security/restricted/restrict-volume-types/restrict-volume-types/)."
+  description: "This rule follows the requirements from Kyverno pod security policy [Restrict Volume Type](https://github.com/kyverno/policies/tree/release-1.12/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml)."
   severity: "MEDIUM"
 - id: 2004
   name: "Limit the Services of type NodePort."
-  description: "This rule follows the requirements from Kyverno best practices policy [Disallow NodePort](https://release-1-12-0.kyverno.io/policies/best-practices/restrict-node-port/restrict-node-port/)."
+  description: "This rule follows the requirements from Kyverno best practices policy [Disallow NodePort](https://github.com/kyverno/policies/tree/release-1.12/best-practices/restrict-node-port/restrict-node-port.yaml)."
   severity: "MEDIUM"
 - id: 2005
   name: "Container images must come from trusted repositories."
-  description: "This rule follows the requirements from Kyverno policy [Allowed Image Repositories](https://release-1-12-0.kyverno.io/policies/other/allowed-image-repos/allowed-image-repos/)."
+  description: "This rule follows the requirements from Kyverno policy [Allowed Image Repositories](https://github.com/kyverno/policies/tree/release-1.12/other/allowed-image-repos/allowed-image-repos.yaml)."
   severity: "HIGH"
 - id: 2006
   name: "Limit the use of wildcards in RBAC resources."
-  description: "This rule follows the requirements from Kyverno policy [Restrict Wildcards in Resources](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-resources/restrict-wildcard-resources/)."
+  description: "This rule follows the requirements from Kyverno policy [Restrict Wildcards in Resources](https://github.com/kyverno/policies/tree/release-1.12/other/restrict-wildcard-resources/restrict-wildcard-resources.yaml)."
   severity: "MEDIUM"
 - id: 2007
   name: "Limit the use of wildcards in RBAC verbs."
-  description: "This rule follows the requirements from Kyverno policy [Restrict Wildcard in Verbs](https://release-1-12-0.kyverno.io/policies/other/restrict-wildcard-verbs/restrict-wildcard-verbs/)."
+  description: "This rule follows the requirements from Kyverno policy [Restrict Wildcard in Verbs](https://github.com/kyverno/policies/tree/release-1.12/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml)."
   severity: "MEDIUM"
 - id: 2008
   name: "Pods must not be allowed to mount host directories."
-  description: "This rule follows the requirements from Kyverno pod security policy [Disallow hostPath](https://release-1-12-0.kyverno.io/policies/pod-security/baseline/disallow-host-path/disallow-host-path/)."
+  description: "This rule follows the requirements from Kyverno pod security policy [Disallow hostPath](https://github.com/kyverno/policies/tree/release-1.12/pod-security/baseline/disallow-host-path/disallow-host-path.yaml)."
   severity: "HIGH"


### PR DESCRIPTION
**What this PR does / why we need it**:
 This PR adds documentation about the `Security Hardened Kubernetes Cluster` ruleset `v0.1.0`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
