### PR TITLE
Do not report empty targets

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -213,14 +213,13 @@ func getChecks(checkResults []rule.CheckResult, opts *ReportOptions) []Check {
 			check := &Check{
 				Status:  checkResult.Status,
 				Message: checkResult.Message,
-				Targets: []rule.Target{},
 			}
 
-			if checkResult.Target != nil {
+			if len(checkResult.Target) > 0 {
 				check.Targets = append(check.Targets, checkResult.Target)
 			}
 			groupedChecks[key] = check
-		} else if checkResult.Target != nil {
+		} else if len(checkResult.Target) > 0 {
 			check.Targets = append(check.Targets, checkResult.Target)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Empty targets can be seen in reports.

```json
{
  "targets": [
    {}
  ]
}
```

With this change this should no longer be the case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug that was causing reports to sometimes include empty targets was fixed.
```
