### PR TITLE
Reduce entered namespaces by `nsenter`

### DIFF
--- a/pkg/kubernetes/pod/privileged.go
+++ b/pkg/kubernetes/pod/privileged.go
@@ -47,7 +47,7 @@ func NewPrivilegedPod(name, namespace, image, nodeName string, additionalLabels 
 				{
 					Name:    "container",
 					Image:   image,
-					Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter --all -t $(pgrep -xo systemd) sleep 600"},
+					Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter -m -t $(pgrep -xo systemd) sleep 600"},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: ptr.To(true),
 					},

--- a/pkg/kubernetes/pod/privileged_test.go
+++ b/pkg/kubernetes/pod/privileged_test.go
@@ -41,7 +41,7 @@ var _ = Describe("podutils", func() {
 						{
 							Name:    "container",
 							Image:   image,
-							Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter --all -t $(pgrep -xo systemd) sleep 600"},
+							Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter -m -t $(pgrep -xo systemd) sleep 600"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduces the entered namespaces by `nsenter` to only the required namespace for `diki-ops` pod. This is done to avoid error resulted from not having permissions to enter a specific namespace.

It has been validated that diki works with only the mount `-m` namespace, if other namespaces are required in the future we can add them when they are needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
