### PR TITLE
Improve DISA K8s STIG rule 242382 to also check `AuthorizationConfiguration`

### DIFF
--- a/pkg/internal/utils/set.go
+++ b/pkg/internal/utils/set.go
@@ -27,6 +27,20 @@ func Subset(s1, s2 []string) bool {
 	return true
 }
 
+// InitialSegment checks if all ordered elements of s1 are the initial ordered elements of s2. An empty s1 is always a initial segment of s2.
+func InitialSegment(s1, s2 []string) bool {
+	if len(s1) > len(s2) {
+		return false
+	}
+
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // MatchLabels checks if all m2 keys and values are present in m1. If m1 or m2 is nil returns false.
 func MatchLabels(m1, m2 map[string]string) bool {
 	if m1 == nil || m2 == nil {

--- a/pkg/internal/utils/set.go
+++ b/pkg/internal/utils/set.go
@@ -27,14 +27,14 @@ func Subset(s1, s2 []string) bool {
 	return true
 }
 
-// InitialSegment checks if all ordered elements of s1 are the initial ordered elements of s2. An empty s1 is always a initial segment of s2.
-func InitialSegment(s1, s2 []string) bool {
-	if len(s1) > len(s2) {
+// StartsWith checks if all ordered elements of s2 are the first elements that occur in s1. If s2 is empty, the function returns true.
+func StartsWith(s1 []string, s2 ...string) bool {
+	if len(s2) > len(s1) {
 		return false
 	}
 
-	for i := range s1 {
-		if s1[i] != s2[i] {
+	for i := range s2 {
+		if s2[i] != s1[i] {
 			return false
 		}
 	}

--- a/pkg/internal/utils/set_test.go
+++ b/pkg/internal/utils/set_test.go
@@ -42,6 +42,22 @@ var _ = Describe("utils", func() {
 			[]string{"foo", "bar", "foo-bar"}, []string{"foo", "bar"}, false),
 	)
 
+	DescribeTable("#InitialSegment",
+		func(s1, s2 []string, expectedResult bool) {
+			result := utils.InitialSegment(s1, s2)
+
+			Expect(result).To(Equal(expectedResult))
+		},
+		Entry("should return true when s1 is empty",
+			[]string{}, []string{"foo", "bar"}, true),
+		Entry("should return true when s1 is a initial segment of s2",
+			[]string{"foo", "bar"}, []string{"foo", "bar", "foo-bar"}, true),
+		Entry("should return false when s1 is not a initial segment of s2",
+			[]string{"bar", "test"}, []string{"foo", "bar", "test"}, false),
+		Entry("should return false when s1 has more elements than s2",
+			[]string{"foo", "bar", "foo-bar"}, []string{"foo", "bar"}, false),
+	)
+
 	DescribeTable("#MatchLabels",
 		func(m1, m2 map[string]string, expectedResult bool) {
 			result := utils.MatchLabels(m1, m2)

--- a/pkg/internal/utils/set_test.go
+++ b/pkg/internal/utils/set_test.go
@@ -44,18 +44,18 @@ var _ = Describe("utils", func() {
 
 	DescribeTable("#InitialSegment",
 		func(s1, s2 []string, expectedResult bool) {
-			result := utils.InitialSegment(s1, s2)
+			result := utils.StartsWith(s1, s2...)
 
 			Expect(result).To(Equal(expectedResult))
 		},
 		Entry("should return true when s1 is empty",
-			[]string{}, []string{"foo", "bar"}, true),
+			[]string{"foo", "bar"}, []string{}, true),
 		Entry("should return true when s1 is a initial segment of s2",
-			[]string{"foo", "bar"}, []string{"foo", "bar", "foo-bar"}, true),
+			[]string{"foo", "bar", "foo-bar"}, []string{"foo", "bar"}, true),
 		Entry("should return false when s1 is not a initial segment of s2",
-			[]string{"bar", "test"}, []string{"foo", "bar", "test"}, false),
+			[]string{"foo", "bar", "test"}, []string{"bar", "test"}, false),
 		Entry("should return false when s1 has more elements than s2",
-			[]string{"foo", "bar", "foo-bar"}, []string{"foo", "bar"}, false),
+			[]string{"foo", "bar"}, []string{"foo", "bar", "foo-bar"}, false),
 	)
 
 	DescribeTable("#MatchLabels",

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -104,11 +104,11 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ContainerName:  kcmContainerName,
 		},
 		&sharedrules.Rule242382{
-			Client:         runtimeClient,
-			Namespace:      ns,
-			DeploymentName: apiserverDeploymentName,
-			ContainerName:  apiserverContainerName,
-			ExpectedModes:  []string{"RBAC", "Webhook"},
+			Client:               runtimeClient,
+			Namespace:            ns,
+			DeploymentName:       apiserverDeploymentName,
+			ContainerName:        apiserverContainerName,
+			ExpectedInitialModes: []string{"RBAC", "Webhook"},
 		},
 		rule.NewSkipRule(
 			sharedrules.ID242383,

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v1r11_ruleset.go
@@ -104,11 +104,11 @@ func (r *Ruleset) registerV1R11Rules(ruleOptions map[string]config.RuleOptionsCo
 			ContainerName:  kcmContainerName,
 		},
 		&sharedrules.Rule242382{
-			Client:               runtimeClient,
-			Namespace:            ns,
-			DeploymentName:       apiserverDeploymentName,
-			ContainerName:        apiserverContainerName,
-			ExpectedInitialModes: []string{"RBAC", "Webhook"},
+			Client:             runtimeClient,
+			Namespace:          ns,
+			DeploymentName:     apiserverDeploymentName,
+			ContainerName:      apiserverContainerName,
+			ExpectedStartModes: []string{"RBAC", "Webhook"},
 		},
 		rule.NewSkipRule(
 			sharedrules.ID242383,

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r1_ruleset.go
@@ -104,11 +104,11 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			ContainerName:  kcmContainerName,
 		},
 		&sharedrules.Rule242382{
-			Client:               runtimeClient,
-			Namespace:            ns,
-			DeploymentName:       apiserverDeploymentName,
-			ContainerName:        apiserverContainerName,
-			ExpectedInitialModes: []string{"RBAC", "Webhook"},
+			Client:             runtimeClient,
+			Namespace:          ns,
+			DeploymentName:     apiserverDeploymentName,
+			ContainerName:      apiserverContainerName,
+			ExpectedStartModes: []string{"RBAC", "Webhook"},
 		},
 		rule.NewSkipRule(
 			sharedrules.ID242383,

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r1_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r1_ruleset.go
@@ -104,11 +104,11 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 			ContainerName:  kcmContainerName,
 		},
 		&sharedrules.Rule242382{
-			Client:         runtimeClient,
-			Namespace:      ns,
-			DeploymentName: apiserverDeploymentName,
-			ContainerName:  apiserverContainerName,
-			ExpectedModes:  []string{"RBAC", "Webhook"},
+			Client:               runtimeClient,
+			Namespace:            ns,
+			DeploymentName:       apiserverDeploymentName,
+			ContainerName:        apiserverContainerName,
+			ExpectedInitialModes: []string{"RBAC", "Webhook"},
 		},
 		rule.NewSkipRule(
 			sharedrules.ID242383,

--- a/pkg/shared/ruleset/disak8sstig/rules/242382.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242382.go
@@ -25,11 +25,11 @@ import (
 var _ rule.Rule = &Rule242382{}
 
 type Rule242382 struct {
-	Client               client.Client
-	Namespace            string
-	DeploymentName       string
-	ContainerName        string
-	ExpectedInitialModes []string
+	Client             client.Client
+	Namespace          string
+	DeploymentName     string
+	ContainerName      string
+	ExpectedStartModes []string
 }
 
 func (r *Rule242382) ID() string {
@@ -46,9 +46,9 @@ func (r *Rule242382) Run(ctx context.Context) (rule.RuleResult, error) {
 		authorizationConfigOpt = "authorization-config"
 	)
 	var (
-		deploymentName       = "kube-apiserver"
-		containerName        = "kube-apiserver"
-		expectedInitialModes = []string{"Node", "RBAC"}
+		deploymentName     = "kube-apiserver"
+		containerName      = "kube-apiserver"
+		expectedStartModes = []string{"Node", "RBAC"}
 	)
 
 	if r.DeploymentName != "" {
@@ -59,8 +59,8 @@ func (r *Rule242382) Run(ctx context.Context) (rule.RuleResult, error) {
 		containerName = r.ContainerName
 	}
 
-	if len(r.ExpectedInitialModes) != 0 {
-		expectedInitialModes = r.ExpectedInitialModes
+	if len(r.ExpectedStartModes) != 0 {
+		expectedStartModes = r.ExpectedStartModes
 	}
 
 	target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
@@ -76,7 +76,7 @@ func (r *Rule242382) Run(ctx context.Context) (rule.RuleResult, error) {
 	case len(authzConfigOptSlice) == 1 && strings.TrimSpace(authzConfigOptSlice[0]) == "":
 		return rule.Result(r, rule.FailedCheckResult(fmt.Sprintf("Option %s is empty.", authorizationConfigOpt), target)), nil
 	case len(authzConfigOptSlice) == 1:
-		return r.checkAuthzConfig(ctx, deploymentName, containerName, authzConfigOptSlice[0], expectedInitialModes), nil
+		return r.checkAuthzConfig(ctx, deploymentName, containerName, authzConfigOptSlice[0], expectedStartModes), nil
 	default:
 	}
 
@@ -93,7 +93,7 @@ func (r *Rule242382) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.Result(r, rule.WarningCheckResult(fmt.Sprintf("Option %s has been set more than once in container command.", authorizationModeOpt), target)), nil
 	case slices.Contains(strings.Split(authzModeOptSlice[0], ","), "AlwaysAllow"):
 		return rule.Result(r, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not allowed value.", authorizationModeOpt), target)), nil
-	case utils.InitialSegment(expectedInitialModes, strings.Split(authzModeOptSlice[0], ",")):
+	case utils.StartsWith(strings.Split(authzModeOptSlice[0], ","), expectedStartModes...):
 		return rule.Result(r, rule.PassedCheckResult(fmt.Sprintf("Option %s set to expected value.", authorizationModeOpt), target)), nil
 	default:
 		return rule.Result(r, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not expected value.", authorizationModeOpt), target)), nil
@@ -133,9 +133,9 @@ func (r *Rule242382) checkAuthzConfig(ctx context.Context, deploymentName, conta
 		modes = append(modes, authorizer.Type)
 	}
 
-	if utils.InitialSegment(expectedModes, modes) {
-		return rule.Result(r, rule.PassedCheckResult("AuthorizationConfiguration has expected initial mode types set.", authzConfigTarget))
+	if utils.StartsWith(modes, expectedModes...) {
+		return rule.Result(r, rule.PassedCheckResult("AuthorizationConfiguration has expected start mode types set.", authzConfigTarget))
 	}
 
-	return rule.Result(r, rule.FailedCheckResult("AuthorizationConfiguration has not expected initial mode type set.", authzConfigTarget))
+	return rule.Result(r, rule.FailedCheckResult("AuthorizationConfiguration does not have expected start mode types set.", authzConfigTarget))
 }

--- a/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
@@ -142,9 +142,9 @@ authorizers:
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
 
 			r := &rules.Rule242382{
-				Client:               fakeClient,
-				Namespace:            namespace,
-				ExpectedInitialModes: expectedModes,
+				Client:             fakeClient,
+				Namespace:          namespace,
+				ExpectedStartModes: expectedModes,
 			}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
@@ -204,9 +204,9 @@ authorizers:
 			Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
 
 			r := &rules.Rule242382{
-				Client:               fakeClient,
-				Namespace:            namespace,
-				ExpectedInitialModes: expectedModes,
+				Client:             fakeClient,
+				Namespace:          namespace,
+				ExpectedStartModes: expectedModes,
 			}
 			ruleResult, err := r.Run(ctx)
 			Expect(err).To(errorMatcher)
@@ -217,7 +217,7 @@ authorizers:
 		Entry("should pass when AuthorizationConfiguration contains only expected mode types Node,RBAC", []string{},
 			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
 			map[string]string{fileName: authzConfig},
-			[]rule.CheckResult{{Status: rule.Passed, Message: "AuthorizationConfiguration has expected initial mode types set.", Target: authorizationConfigTarget}},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "AuthorizationConfiguration has expected start mode types set.", Target: authorizationConfigTarget}},
 			BeNil()),
 		Entry("should fail when AuthorizationConfiguration contains not allowd mode type AlwaysAllow", []string{},
 			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
@@ -227,22 +227,22 @@ authorizers:
 		Entry("should fail when AuthorizationConfiguration contains not expected mode type", []string{},
 			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
 			map[string]string{fileName: notExpectedAuthzConfig},
-			[]rule.CheckResult{{Status: rule.Failed, Message: "AuthorizationConfiguration has not expected initial mode type set.", Target: authorizationConfigTarget}},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "AuthorizationConfiguration does not have expected start mode types set.", Target: authorizationConfigTarget}},
 			BeNil()),
 		Entry("should fail when AuthorizationConfiguration does not contain all expected mode types", []string{},
 			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
 			map[string]string{fileName: notAllExpectedAuthzConfig},
-			[]rule.CheckResult{{Status: rule.Failed, Message: "AuthorizationConfiguration has not expected initial mode type set.", Target: authorizationConfigTarget}},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "AuthorizationConfiguration does not have expected start mode types set.", Target: authorizationConfigTarget}},
 			BeNil()),
 		Entry("should fail when AuthorizationConfiguration sets expected mode types in wrong order", []string{},
 			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
 			map[string]string{fileName: wrongOrderAuthzConfig},
-			[]rule.CheckResult{{Status: rule.Failed, Message: "AuthorizationConfiguration has not expected initial mode type set.", Target: authorizationConfigTarget}},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "AuthorizationConfiguration does not have expected start mode types set.", Target: authorizationConfigTarget}},
 			BeNil()),
 		Entry("should return correct checkResults when expectedModes are set", []string{"Webhook", "Node", "RBAC"},
 			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
 			map[string]string{fileName: notExpectedAuthzConfig},
-			[]rule.CheckResult{{Status: rule.Passed, Message: "AuthorizationConfiguration has expected initial mode types set.", Target: authorizationConfigTarget}},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "AuthorizationConfiguration has expected start mode types set.", Target: authorizationConfigTarget}},
 			BeNil()),
 		Entry("should warn when authorization-config is set more than once", []string{},
 			[]string{"--authorization-config=/foo/bar"}, []string{"--authorization-config=/bar/foo"}, map[string]string{},

--- a/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
@@ -21,13 +21,45 @@ import (
 )
 
 var _ = Describe("#242382", func() {
+	const (
+		authzConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthorizationConfiguration
+authorizers:
+- type: Node
+  name: node
+- type: RBAC
+  name: rbac`
+		notAllowedAuthzConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthorizationConfiguration
+authorizers:
+- type: AlwaysAllow
+  name: AlwaysAllow`
+		notExpectedAuthzConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthorizationConfiguration
+authorizers:
+- type: Webhook
+  name: Webhook
+- type: Node
+  name: node
+- type: RBAC
+  name: rbac`
+		notAllExpectedAuthzConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthorizationConfiguration
+authorizers:
+- type: Node
+  name: node`
+	)
 	var (
-		fakeClient client.Client
-		ctx        = context.TODO()
-		namespace  = "foo"
-
-		kcmDeployment *appsv1.Deployment
-		target        = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		fakeClient                client.Client
+		ctx                       = context.TODO()
+		namespace                 = "foo"
+		fileName                  = "fileName.yaml"
+		configMapName             = "kube-apiserver-authorization-config"
+		configMapData             = "configMapData"
+		kcmDeployment             *appsv1.Deployment
+		configMap                 *corev1.ConfigMap
+		target                    = rule.NewTarget("name", "kube-apiserver", "namespace", namespace, "kind", "deployment")
+		authorizationConfigTarget = rule.NewTarget("kind", "AuthorizationConfiguration")
 	)
 
 	BeforeEach(func() {
@@ -45,10 +77,37 @@ var _ = Describe("#242382", func() {
 								Name:    "kube-apiserver",
 								Command: []string{},
 								Args:    []string{},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "authorization-config",
+										MountPath: "/foo/bar",
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "authorization-config",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: configMapName,
+										},
+									},
+								},
 							},
 						},
 					},
 				},
+			},
+		}
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				fileName: configMapData,
 			},
 		}
 	})
@@ -68,7 +127,7 @@ var _ = Describe("#242382", func() {
 		))
 	})
 
-	DescribeTable("Run cases",
+	DescribeTable("Run authorization-mode cases",
 		func(expectedModes []string, container corev1.Container, expectedCheckResults []rule.CheckResult, errorMatcher gomegatypes.GomegaMatcher) {
 			kcmDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
@@ -123,6 +182,57 @@ var _ = Describe("#242382", func() {
 		Entry("should error when deployment does not have container 'kube-apiserver'", []string{},
 			corev1.Container{Name: "not-kube-apiserver", Command: []string{"--authorization-mode=RBAC,Node"}},
 			[]rule.CheckResult{{Status: rule.Errored, Message: "deployment: kube-apiserver does not contain container: kube-apiserver", Target: target}},
+			BeNil()),
+	)
+
+	DescribeTable("Run AuthorizationConfiguration cases",
+		func(expectedModes, command, args []string, configMapData map[string]string, expectedCheckResults []rule.CheckResult, errorMatcher gomegatypes.GomegaMatcher) {
+			kcmDeployment.Spec.Template.Spec.Containers[0].Command = command
+			kcmDeployment.Spec.Template.Spec.Containers[0].Args = args
+			Expect(fakeClient.Create(ctx, kcmDeployment)).To(Succeed())
+
+			configMap.Data = configMapData
+			Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+
+			r := &rules.Rule242382{
+				Client:        fakeClient,
+				Namespace:     namespace,
+				ExpectedModes: expectedModes,
+			}
+			ruleResult, err := r.Run(ctx)
+			Expect(err).To(errorMatcher)
+
+			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+		},
+
+		Entry("should pass when AuthorizationConfiguration contains only expected mode types Node,RBAC", []string{},
+			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
+			map[string]string{fileName: authzConfig},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Expected modes set.", Target: authorizationConfigTarget}},
+			BeNil()),
+		Entry("should fail when AuthorizationConfiguration contains not allowd mode type AlwaysAllow", []string{},
+			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
+			map[string]string{fileName: notAllowedAuthzConfig},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Not allowed mode set.", Target: authorizationConfigTarget}},
+			BeNil()),
+		Entry("should fail when AuthorizationConfiguration contains not expected mode type", []string{},
+			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
+			map[string]string{fileName: notExpectedAuthzConfig},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Not expected mode set.", Target: authorizationConfigTarget}},
+			BeNil()),
+		Entry("should fail when AuthorizationConfiguration does not contain all expected mode types", []string{},
+			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
+			map[string]string{fileName: notAllExpectedAuthzConfig},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Not expected mode set.", Target: authorizationConfigTarget}},
+			BeNil()),
+		Entry("should return correct checkResults when expectedModes are set", []string{"RBAC", "Node", "Webhook"},
+			[]string{"--authorization-config=/foo/bar/fileName.yaml"}, []string{},
+			map[string]string{fileName: notExpectedAuthzConfig},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Expected modes set.", Target: authorizationConfigTarget}},
+			BeNil()),
+		Entry("should warn when authorization-config is set more than once", []string{},
+			[]string{"--authorization-config=/foo/bar"}, []string{"--authorization-config=/bar/foo"}, map[string]string{},
+			[]rule.CheckResult{{Status: rule.Warning, Message: "Option authorization-config has been set more than once in container command.", Target: target}},
 			BeNil()),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
With the introduction of [StructuredAuthorization](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#configuring-the-api-server-using-an-authorization-config-file) when `authorization-mode` cannot be set when `authorization-config` is set. This PR improves DISA K8s STIG rule 242382 by also checking the specified `AuthoricationConfiguration` file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
DISA K8s STIG rule 242382 now also checks `AuthorizationConfiguration` when it is set via `authorization-config`.
```
