### PR TITLE
Add Severity to Rules

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -49,9 +49,10 @@ type Ruleset struct {
 
 // Rule contains information about a ran rule.
 type Rule struct {
-	ID     string  `json:"id"`
-	Name   string  `json:"name"`
-	Checks []Check `json:"checks"`
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Severity string  `json:"severity,omitempty"`
+	Checks   []Check `json:"checks"`
 }
 
 // Check is the result of a single Rule check.

--- a/pkg/rule/helpers.go
+++ b/pkg/rule/helpers.go
@@ -6,10 +6,18 @@ package rule
 
 // Result returns a [RuleResult] containing the passed checks.
 func Result(r Rule, checkResults ...CheckResult) RuleResult {
+	var severity Severity
+
+	measurer, ok := r.(Assessor)
+	if ok {
+		severity = measurer.Severity()
+	}
+
 	return RuleResult{
 		RuleID:       r.ID(),
 		RuleName:     r.Name(),
 		CheckResults: checkResults,
+		Severity:     severity,
 	}
 }
 

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -20,7 +20,23 @@ type Rule interface {
 // RuleResult contains a Rule identification and the results of a Rule run.
 type RuleResult struct {
 	RuleID, RuleName string
+	Severity         Severity
 	CheckResults     []CheckResult
+}
+
+// Severity defines the importance of a Rule.
+type Severity string
+
+// These constants define the three levels of severity - Low, Medium and High
+const (
+	SeverityLow    Severity = "Low"
+	SeverityMedium Severity = "Medium"
+	SeverityHigh   Severity = "High"
+)
+
+// Assessor defines the importance of a rule
+type Assessor interface {
+	Severity() Severity
 }
 
 // Target is used to describe the things that were checked during ruleset runs.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the structure of the currently implemented rules by creating an additional functional interface that returns a Severity index in the form of a string. All rules that have a severity can implement the interface in order to separate the severity from their names.

**Which issue(s) this PR fixes**:
Fixes #348 

**Special notes for your reviewer**:
The current state of the PR only has the base interfaces added. The follow-up implementations of the separate rules will be done once the proposed changes are approved.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
