### PR TITLE
Add Rule 2001 to Security Hardened Shoot Ruleset

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
@@ -43,14 +43,12 @@ func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", r.ShootName, "namespace", r.ShootNamespace, "kind", "Shoot"))), nil
 	}
 
-	var checkResults []rule.CheckResult
 	switch {
 	case shoot.Spec.Provider.WorkersSettings == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess == nil:
-		checkResults = append(checkResults, rule.FailedCheckResult("SSH access to worker nodes is not disabled.", rule.NewTarget()))
+		return rule.Result(r, rule.FailedCheckResult("SSH access to worker nodes is not disabled.", rule.NewTarget())), nil
 	case !shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled:
-		checkResults = append(checkResults, rule.PassedCheckResult("SSH access is disabled for worker nodes.", rule.NewTarget()))
+		return rule.Result(r, rule.PassedCheckResult("SSH access is disabled for worker nodes.", rule.NewTarget())), nil
 	default:
-		checkResults = append(checkResults, rule.FailedCheckResult("SSH access is enabled for worker nodes.", rule.NewTarget()))
+		return rule.Result(r, rule.FailedCheckResult("SSH access is enabled for worker nodes.", rule.NewTarget())), nil
 	}
-	return rule.Result(r, checkResults...), nil
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var (
+	_ rule.Rule     = &Rule2001{}
+	_ rule.Severity = &Rule2001{}
+)
+
+type Rule2001 struct {
+	Client         client.Client
+	ShootName      string
+	ShootNamespace string
+}
+
+func (r *Rule2001) ID() string {
+	return "2001"
+}
+
+func (r *Rule2001) Name() string {
+	return "Shoot clusters must disable ssh access to worker nodes."
+}
+
+func (r *Rule2001) Severity() rule.SeverityLevel {
+	return rule.SeverityMedium
+}
+
+func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
+	shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: r.ShootName, Namespace: r.ShootNamespace}}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", r.ShootName, "namespace", r.ShootNamespace, "kind", "Shoot"))), nil
+	}
+
+	var checkResults []rule.CheckResult
+	switch {
+	case shoot.Spec.Provider.WorkersSettings == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess == nil:
+		checkResults = append(checkResults, rule.FailedCheckResult("Provider config doesn't disable SSH access to the worker nodes.", rule.NewTarget()))
+	case !shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled:
+		checkResults = append(checkResults, rule.PassedCheckResult("Provider config disables SSH access to the worker nodes", rule.NewTarget()))
+	default:
+		checkResults = append(checkResults, rule.FailedCheckResult("Provider config explicitly enables SSH access to the worker nodes.", rule.NewTarget()))
+	}
+	return rule.Result(r, checkResults...), nil
+}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
@@ -46,11 +46,11 @@ func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
 	var checkResults []rule.CheckResult
 	switch {
 	case shoot.Spec.Provider.WorkersSettings == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess == nil:
-		checkResults = append(checkResults, rule.FailedCheckResult("Provider config doesn't disable SSH access to the worker nodes.", rule.NewTarget()))
+		checkResults = append(checkResults, rule.FailedCheckResult("SSH access to worker nodes is not disabled.", rule.NewTarget()))
 	case !shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled:
-		checkResults = append(checkResults, rule.PassedCheckResult("Provider config disables SSH access to the worker nodes", rule.NewTarget()))
+		checkResults = append(checkResults, rule.PassedCheckResult("SSH access is disabled for worker nodes.", rule.NewTarget()))
 	default:
-		checkResults = append(checkResults, rule.FailedCheckResult("Provider config explicitly enables SSH access to the worker nodes.", rule.NewTarget()))
+		checkResults = append(checkResults, rule.FailedCheckResult("SSH access is enabled for worker nodes.", rule.NewTarget()))
 	}
 	return rule.Result(r, checkResults...), nil
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
@@ -45,7 +45,7 @@ func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	switch {
 	case shoot.Spec.Provider.WorkersSettings == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess == nil:
-		return rule.Result(r, rule.FailedCheckResult("SSH access to worker nodes is not disabled.", rule.NewTarget())), nil
+		return rule.Result(r, rule.FailedCheckResult("SSH access is not disabled for worker nodes.", rule.NewTarget())), nil
 	case !shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled:
 		return rule.Result(r, rule.PassedCheckResult("SSH access is disabled for worker nodes.", rule.NewTarget())), nil
 	default:

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -61,9 +61,9 @@ var _ = Describe("#2001", func() {
 		Entry("should error when the shoot is not found",
 			func() { shoot.Name = "notFoo" }, []rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}}),
 		Entry("should fail when the WorkersSettings field is not specified",
-			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access to worker nodes is not disabled.", Target: rule.NewTarget()}}),
+			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()}}),
 		Entry("should fail when the SSHAccess field is not specified",
-			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access to worker nodes is not disabled.", Target: rule.NewTarget()}}),
+			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()}}),
 		Entry("should fail when the SSH access is enabled",
 			func() {
 				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: true})})

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -60,17 +60,17 @@ var _ = Describe("#2001", func() {
 
 		Entry("should error when the shoot is not found",
 			func() { shoot.Name = "notFoo" }, []rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}}),
-		Entry("should fail when the workers' settings field is not specified",
-			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} }, []rule.CheckResult{{Status: rule.Failed, Message: "Provider config doesn't disable SSH access to the worker nodes.", Target: rule.NewTarget()}}),
-		Entry("should fail when the SSH access field is not specified",
-			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} }, []rule.CheckResult{{Status: rule.Failed, Message: "Provider config doesn't disable SSH access to the worker nodes.", Target: rule.NewTarget()}}),
-		Entry("should fail when the SSH access field is set to true",
+		Entry("should fail when the WorkersSettings field is not specified",
+			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access to worker nodes is not disabled.", Target: rule.NewTarget()}}),
+		Entry("should fail when the SSHAccess field is not specified",
+			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access to worker nodes is not disabled.", Target: rule.NewTarget()}}),
+		Entry("should fail when the SSH access is enabled",
 			func() {
 				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: true})})
-			}, []rule.CheckResult{{Status: rule.Failed, Message: "Provider config explicitly enables SSH access to the worker nodes.", Target: rule.NewTarget()}}),
-		Entry("should pass when the SSH access field is set to false",
+			}, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access is enabled for worker nodes.", Target: rule.NewTarget()}}),
+		Entry("should pass when the SSH access is disabled",
 			func() {
 				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: false})})
-			}, []rule.CheckResult{{Status: rule.Passed, Message: "Provider config disables SSH access to the worker nodes", Target: rule.NewTarget()}}),
+			}, []rule.CheckResult{{Status: rule.Passed, Message: "SSH access is disabled for worker nodes.", Target: rule.NewTarget()}}),
 	)
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#2001", func() {
+	var (
+		fakeClient    client.Client
+		ctx           = context.TODO()
+		shootName     = "foo"
+		namespaceName = "bar"
+
+		shoot    *gardencorev1beta1.Shoot
+		r        rule.Rule
+		ruleName = "Shoot clusters must disable ssh access to worker nodes."
+		ruleID   = "2001"
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: namespaceName,
+			},
+		}
+		r = &rules.Rule2001{
+			ShootName:      shootName,
+			ShootNamespace: namespaceName,
+			Client:         fakeClient,
+		}
+	})
+
+	DescribeTable("Run cases",
+		func(updateFn func(), expectedResults []rule.CheckResult) {
+			updateFn()
+
+			Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+			res, err := r.Run(ctx)
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, CheckResults: expectedResults, Severity: rule.SeverityMedium}))
+		},
+
+		Entry("should error when the shoot is not found",
+			func() { shoot.Name = "notFoo" }, []rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}}),
+		Entry("should fail when the workers' settings field is not specified",
+			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} }, []rule.CheckResult{{Status: rule.Failed, Message: "Provider config doesn't disable SSH access to the worker nodes.", Target: rule.NewTarget()}}),
+		Entry("should fail when the SSH access field is not specified",
+			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} }, []rule.CheckResult{{Status: rule.Failed, Message: "Provider config doesn't disable SSH access to the worker nodes.", Target: rule.NewTarget()}}),
+		Entry("should fail when the SSH access field is set to true",
+			func() {
+				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: true})})
+			}, []rule.CheckResult{{Status: rule.Failed, Message: "Provider config explicitly enables SSH access to the worker nodes.", Target: rule.NewTarget()}}),
+		Entry("should pass when the SSH access field is set to false",
+			func() {
+				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: false})})
+			}, []rule.CheckResult{{Status: rule.Passed, Message: "Provider config disables SSH access to the worker nodes", Target: rule.NewTarget()}}),
+	)
+})

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -38,13 +38,11 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 			rule.NotImplemented,
 			rule.SkipRuleWithSeverity(rule.SeverityHigh),
 		),
-		rule.NewSkipRule(
-			"2001",
-			"Shoot clusters must disable ssh access to worker nodes.",
-			"Not implemented.",
-			rule.NotImplemented,
-			rule.SkipRuleWithSeverity(rule.SeverityMedium),
-		),
+		&rules.Rule2001{
+			Client:         c,
+			ShootName:      r.args.ShootName,
+			ShootNamespace: r.args.ProjectNamespace,
+		},
 		rule.NewSkipRule(
 			"2002",
 			"Shoot clusters must not have Alpha APIs enabled for any Kubernetes component.",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements rule 2001 of the Security Hardened Shoot Ruleset. It evaluates the SSH access field (based on it's value or availability) of the shoot spec.

**Which issue(s) this PR fixes**:
Part of #304 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `2001` from the `security-hardened-shoot-cluster` ruleset for provider `garden`.
```
