### PR TITLE
Add Rule 2002 to the Security Hardened Shoot Ruleset

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -60,37 +60,27 @@ var _ = Describe("#2001", func() {
 
 		Entry("should error when the shoot is not found",
 			func() { shoot.Name = "notFoo" },
-			[]rule.CheckResult{
-				{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
-			},
+			rule.CheckResult{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
 		),
 		Entry("should fail when the WorkersSettings field is not specified",
 			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} },
-			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()},
-			},
+			rule.CheckResult{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()},
 		),
 		Entry("should fail when the SSHAccess field is not specified",
 			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} },
-			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()},
-			},
+			rule.CheckResult{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()},
 		),
 		Entry("should fail when the SSH access is enabled",
 			func() {
 				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: true})})
 			},
-			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "SSH access is enabled for worker nodes.", Target: rule.NewTarget()},
-			},
+			rule.CheckResult{Status: rule.Failed, Message: "SSH access is enabled for worker nodes.", Target: rule.NewTarget()},
 		),
 		Entry("should pass when the SSH access is disabled",
 			func() {
 				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: false})})
 			},
-			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "SSH access is disabled for worker nodes.", Target: rule.NewTarget()},
-			},
+			rule.CheckResult{Status: rule.Passed, Message: "SSH access is disabled for worker nodes.", Target: rule.NewTarget()},
 		),
 	)
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -59,18 +59,38 @@ var _ = Describe("#2001", func() {
 		},
 
 		Entry("should error when the shoot is not found",
-			func() { shoot.Name = "notFoo" }, []rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}}),
+			func() { shoot.Name = "notFoo" },
+			[]rule.CheckResult{
+				{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
+			},
+		),
 		Entry("should fail when the WorkersSettings field is not specified",
-			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()}}),
+			func() { shoot.Spec.Provider = gardencorev1beta1.Provider{} },
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()},
+			},
+		),
 		Entry("should fail when the SSHAccess field is not specified",
-			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} }, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()}}),
+			func() { shoot.Spec.Provider.WorkersSettings = &gardencorev1beta1.WorkersSettings{} },
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "SSH access is not disabled for worker nodes.", Target: rule.NewTarget()},
+			},
+		),
 		Entry("should fail when the SSH access is enabled",
 			func() {
 				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: true})})
-			}, []rule.CheckResult{{Status: rule.Failed, Message: "SSH access is enabled for worker nodes.", Target: rule.NewTarget()}}),
+			},
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "SSH access is enabled for worker nodes.", Target: rule.NewTarget()},
+			},
+		),
 		Entry("should pass when the SSH access is disabled",
 			func() {
 				shoot.Spec.Provider.WorkersSettings = ptr.To(gardencorev1beta1.WorkersSettings{SSHAccess: ptr.To(gardencorev1beta1.SSHAccess{Enabled: false})})
-			}, []rule.CheckResult{{Status: rule.Passed, Message: "SSH access is disabled for worker nodes.", Target: rule.NewTarget()}}),
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "SSH access is disabled for worker nodes.", Target: rule.NewTarget()},
+			},
+		),
 	)
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -49,13 +49,13 @@ var _ = Describe("#2001", func() {
 	})
 
 	DescribeTable("Run cases",
-		func(updateFn func(), expectedResults []rule.CheckResult) {
+		func(updateFn func(), expectedResults rule.CheckResult) {
 			updateFn()
 
 			Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 			res, err := r.Run(ctx)
 			Expect(err).To(BeNil())
-			Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, CheckResults: expectedResults, Severity: rule.SeverityMedium}))
+			Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, CheckResults: []rule.CheckResult{expectedResults}, Severity: rule.SeverityMedium}))
 		},
 
 		Entry("should error when the shoot is not found",

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
@@ -84,26 +84,26 @@ func (r *Rule2002) Run(ctx context.Context) (rule.RuleResult, error) {
 	var checkResults []rule.CheckResult
 	for _, component := range components {
 		if v, ok := featureGateValues[component]; !ok {
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("AllAlpha featureGates are not enabled for the %s.", component), rule.NewTarget()))
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is not enabled for the %s.", featureGate, component), rule.NewTarget()))
 		} else if v {
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("AllAlpha featureGates are enabled for the %s.", component), rule.NewTarget()))
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("%s featureGate is enabled for the %s.", featureGate, component), rule.NewTarget()))
 		} else {
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("AllAlpha featureGates are disabled for the %s.", component), rule.NewTarget()))
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is disabled for the %s.", featureGate, component), rule.NewTarget()))
 		}
 	}
 
 	for _, worker := range shoot.Spec.Provider.Workers {
 		workerTarget := rule.NewTarget("worker", worker.Name)
 		if worker.Kubernetes == nil || worker.Kubernetes.Kubelet == nil || worker.Kubernetes.Kubelet.FeatureGates == nil {
-			checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are not enabled for the kubelet.", workerTarget))
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is not enabled for the kubelet.", featureGate), workerTarget))
 			continue
 		}
 		if v, ok := worker.Kubernetes.Kubelet.FeatureGates[featureGate]; !ok {
-			checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are not enabled for the kubelet.", workerTarget))
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is not enabled for the kubelet.", featureGate), workerTarget))
 		} else if v {
-			checkResults = append(checkResults, rule.FailedCheckResult("AllAlpha featureGates are enabled for the kubelet.", workerTarget))
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("%s featureGate is enabled for the kubelet.", featureGate), workerTarget))
 		} else {
-			checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are disabled for the kubelet.", workerTarget))
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is disabled for the kubelet.", featureGate), workerTarget))
 		}
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
@@ -84,26 +84,26 @@ func (r *Rule2002) Run(ctx context.Context) (rule.RuleResult, error) {
 	var checkResults []rule.CheckResult
 	for _, component := range components {
 		if v, ok := featureGateValues[component]; !ok {
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is not enabled for the %s.", featureGate, component), rule.NewTarget()))
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("AllAlpha featureGate is not enabled for the %s.", component), rule.NewTarget()))
 		} else if v {
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("%s featureGate is enabled for the %s.", featureGate, component), rule.NewTarget()))
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("AllAlpha featureGate is enabled for the %s.", component), rule.NewTarget()))
 		} else {
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is disabled for the %s.", featureGate, component), rule.NewTarget()))
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("AllAlpha featureGate is disabled for the %s.", component), rule.NewTarget()))
 		}
 	}
 
 	for _, worker := range shoot.Spec.Provider.Workers {
 		workerTarget := rule.NewTarget("worker", worker.Name)
 		if worker.Kubernetes == nil || worker.Kubernetes.Kubelet == nil || worker.Kubernetes.Kubelet.FeatureGates == nil {
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is not enabled for the kubelet.", featureGate), workerTarget))
+			checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGate is not enabled for the kubelet.", workerTarget))
 			continue
 		}
 		if v, ok := worker.Kubernetes.Kubelet.FeatureGates[featureGate]; !ok {
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is not enabled for the kubelet.", featureGate), workerTarget))
+			checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGate is not enabled for the kubelet.", workerTarget))
 		} else if v {
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("%s featureGate is enabled for the kubelet.", featureGate), workerTarget))
+			checkResults = append(checkResults, rule.FailedCheckResult("AllAlpha featureGate is enabled for the kubelet.", workerTarget))
 		} else {
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("%s featureGate is disabled for the kubelet.", featureGate), workerTarget))
+			checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGate is disabled for the kubelet.", workerTarget))
 		}
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var (
+	_ rule.Rule     = &Rule2002{}
+	_ rule.Severity = &Rule2002{}
+)
+
+type Rule2002 struct {
+	Client         client.Client
+	ShootName      string
+	ShootNamespace string
+}
+
+func (r *Rule2002) ID() string {
+	return "2002"
+}
+
+func (r *Rule2002) Name() string {
+	return "Shoot clusters must not have Alpha APIs enabled for any Kubernetes component."
+}
+
+func (r *Rule2002) Severity() rule.SeverityLevel {
+	return rule.SeverityMedium
+}
+
+func (r *Rule2002) Run(ctx context.Context) (rule.RuleResult, error) {
+	shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: r.ShootName, Namespace: r.ShootNamespace}}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "Shoot", "name", r.ShootName, "namespace", r.ShootNamespace))), nil
+	}
+
+	var checkResults []rule.CheckResult
+
+	switch {
+	case shoot.Spec.Kubernetes.KubeAPIServer == nil || shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates == nil:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are not enabled for the kube apiserver.", rule.NewTarget()))
+	case shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates["AllAlpha"]:
+		checkResults = append(checkResults, rule.FailedCheckResult("AllAlpha featureGates are enabled for the kube apiserver.", rule.NewTarget()))
+	default:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are disabled for the kube apiserver.", rule.NewTarget()))
+	}
+
+	switch {
+	case shoot.Spec.Kubernetes.KubeControllerManager == nil || shoot.Spec.Kubernetes.KubeControllerManager.FeatureGates == nil:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are not enabled for the kube controller manager.", rule.NewTarget()))
+	case shoot.Spec.Kubernetes.KubeControllerManager.FeatureGates["AllAlpha"]:
+		checkResults = append(checkResults, rule.FailedCheckResult("AllAlpha featureGates are enabled for the kube controller manager.", rule.NewTarget()))
+	default:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are disabled for the kube controller manager.", rule.NewTarget()))
+	}
+
+	switch {
+	case shoot.Spec.Kubernetes.KubeScheduler == nil || shoot.Spec.Kubernetes.KubeScheduler.FeatureGates == nil:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are not enabled for the kube scheduler.", rule.NewTarget()))
+	case shoot.Spec.Kubernetes.KubeScheduler.FeatureGates["AllAlpha"]:
+		checkResults = append(checkResults, rule.FailedCheckResult("AllAlpha featureGates are enabled for the kube scheduler.", rule.NewTarget()))
+	default:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are disabled for the kube scheduler.", rule.NewTarget()))
+	}
+
+	switch {
+	case shoot.Spec.Kubernetes.KubeProxy == nil || shoot.Spec.Kubernetes.KubeProxy.FeatureGates == nil:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are not enabled for the kube proxy.", rule.NewTarget()))
+	case shoot.Spec.Kubernetes.KubeProxy.FeatureGates["AllAlpha"]:
+		checkResults = append(checkResults, rule.FailedCheckResult("AllAlpha featureGates are enabled for the kube proxy.", rule.NewTarget()))
+	default:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are disabled for the kube proxy.", rule.NewTarget()))
+	}
+
+	switch {
+	case shoot.Spec.Kubernetes.Kubelet == nil || shoot.Spec.Kubernetes.Kubelet.FeatureGates == nil:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are not enabled for the kubelet.", rule.NewTarget()))
+	case shoot.Spec.Kubernetes.Kubelet.FeatureGates["AllAlpha"]:
+		checkResults = append(checkResults, rule.FailedCheckResult("AllAlpha featureGates are enabled for the kubelet.", rule.NewTarget()))
+	default:
+		checkResults = append(checkResults, rule.PassedCheckResult("AllAlpha featureGates are disabled for the kubelet.", rule.NewTarget()))
+	}
+
+	return rule.Result(r, checkResults...), nil
+}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
@@ -33,6 +33,8 @@ var _ = Describe("#2002", func() {
 		ruleName = "Shoot clusters must not have Alpha APIs enabled for any Kubernetes component."
 		ruleID   = "2002"
 		severity = rule.SeverityMedium
+
+		featureGate = "AllAlpha"
 	)
 
 	BeforeEach(func() {
@@ -70,67 +72,194 @@ var _ = Describe("#2002", func() {
 		Entry("should pass when AllAlpha featureGates are set to default for all components",
 			func() {},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube controller manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
 				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should fail when AllAlpha featureGates are enabled for all components",
 			func() {
-				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
-				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
-				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
-				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
-				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
+				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
+				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube controller manager.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-proxy.", Target: rule.NewTarget()},
 				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should pass when AllAlpha featureGates are disabled for all components",
 			func() {
-				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
-				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
-				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
-				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
-				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
+				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
+				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube controller manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-proxy.", Target: rule.NewTarget()},
 				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should pass when AllAlpha featureGates are disabled for the kube proxy component",
+		Entry("should pass when AllAlpha featureGates are disabled for the kube-proxy component",
 			func() {
-				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube controller manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-proxy.", Target: rule.NewTarget()},
 				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should fail when AllAlpha featureGates are disabled for the kubelet",
 			func() {
-				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube controller manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
 				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should pass when the AllAlpha flag is not present in the featureGates map for any of the components",
+			func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
+				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
+				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should pass when the AllAlpha featureGates are disabled for the worker node kubelet",
+			func() {
+				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+					{
+						Name: "worker1",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: ptr.To(gardencorev1beta1.KubeletConfig{
+								KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+									FeatureGates: map[string]bool{
+										featureGate: false,
+									},
+								},
+							}),
+						},
+					},
+				}
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+			},
+		),
+		Entry("should fail when the AllAlpha featureGates are enabled for the worker node kubelet",
+			func() {
+				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+					{
+						Name: "worker1",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: ptr.To(gardencorev1beta1.KubeletConfig{
+								KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+									FeatureGates: map[string]bool{
+										featureGate: true,
+									},
+								},
+							}),
+						},
+					},
+				}
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+			},
+		),
+		Entry("should pass when the AllAlpha featureGates flag is not set in the worker node kubelet",
+			func() {
+				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+					{
+						Name: "worker1",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: ptr.To(gardencorev1beta1.KubeletConfig{
+								KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+									FeatureGates: map[string]bool{},
+								},
+							}),
+						},
+					},
+				}
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+			},
+		),
+		Entry("should pass when the shoot sets a default kubernetes config",
+			func() {
+				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+					{
+						Name:       "worker1",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{},
+					},
+				}
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+			},
+		),
+		Entry("should pass when the worker doesn't set a kubernetes config",
+			func() {
+				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+					{
+						Name: "worker1",
+					},
+				}
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
 			},
 		),
 	)

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
@@ -69,17 +69,17 @@ var _ = Describe("#2002", func() {
 				{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
 			},
 		),
-		Entry("should pass when AllAlpha featureGates are set to default for all components",
+		Entry("should pass when AllAlpha featureGate is set to default for all components",
 			func() {},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should fail when AllAlpha featureGates are enabled for all components",
+		Entry("should fail when AllAlpha featureGate is enabled for all components",
 			func() {
 				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
 				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
@@ -88,14 +88,14 @@ var _ = Describe("#2002", func() {
 				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGate is enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGate is enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGate is enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGate is enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGate is enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should pass when AllAlpha featureGates are disabled for all components",
+		Entry("should pass when AllAlpha featureGate is disabled for all components",
 			func() {
 				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
 				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
@@ -104,35 +104,35 @@ var _ = Describe("#2002", func() {
 				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is disabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is disabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is disabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is disabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is disabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should pass when AllAlpha featureGates are disabled for the kube-proxy component",
+		Entry("should pass when AllAlpha featureGate is disabled for the kube-proxy component",
 			func() {
 				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: false}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is disabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should fail when AllAlpha featureGates are disabled for the kubelet",
+		Entry("should fail when AllAlpha featureGate is disabled for the kubelet",
 			func() {
 				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{featureGate: true}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGate is enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should pass when the AllAlpha flag is not present in the featureGates map for any of the components",
@@ -144,14 +144,14 @@ var _ = Describe("#2002", func() {
 				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"foo": true}}})
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should pass when the AllAlpha featureGates are disabled for the worker node kubelet",
+		Entry("should pass when the AllAlpha featureGate is disabled for the worker node kubelet",
 			func() {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
 					{
@@ -169,15 +169,15 @@ var _ = Describe("#2002", func() {
 				}
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is disabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
 			},
 		),
-		Entry("should fail when the AllAlpha featureGates are enabled for the worker node kubelet",
+		Entry("should fail when the AllAlpha featureGate is enabled for the worker node kubelet",
 			func() {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
 					{
@@ -195,15 +195,15 @@ var _ = Describe("#2002", func() {
 				}
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGate is enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
 			},
 		),
-		Entry("should pass when the AllAlpha featureGates flag is not set in the worker node kubelet",
+		Entry("should pass when the AllAlpha featureGate is not set in the worker node kubelet",
 			func() {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
 					{
@@ -219,12 +219,12 @@ var _ = Describe("#2002", func() {
 				}
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
 			},
 		),
 		Entry("should pass when the shoot sets a default kubernetes config",
@@ -237,12 +237,12 @@ var _ = Describe("#2002", func() {
 				}
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
 			},
 		),
 		Entry("should pass when the worker doesn't set a kubernetes config",
@@ -254,12 +254,12 @@ var _ = Describe("#2002", func() {
 				}
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-scheduler.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-proxy.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-controller-manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kube-proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGate is not enabled for the kubelet.", Target: rule.NewTarget("worker", "worker1")},
 			},
 		),
 	)

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
@@ -137,11 +137,11 @@ var _ = Describe("#2002", func() {
 		),
 		Entry("should pass when the AllAlpha flag is not present in the featureGates map for any of the components",
 			func() {
-				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
-				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
-				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
-				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
-				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{}}})
+				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"foo": true}}})
+				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"foo": true}}})
+				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"foo": true}}})
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"foo": true}}})
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"foo": true}}})
 			},
 			[]rule.CheckResult{
 				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube-apiserver.", Target: rule.NewTarget()},
@@ -211,7 +211,7 @@ var _ = Describe("#2002", func() {
 						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
 							Kubelet: ptr.To(gardencorev1beta1.KubeletConfig{
 								KubernetesConfig: gardencorev1beta1.KubernetesConfig{
-									FeatureGates: map[string]bool{},
+									FeatureGates: map[string]bool{"foo": true},
 								},
 							}),
 						},

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#2002", func() {
+	var (
+		fakeClient     client.Client
+		ctx            = context.TODO()
+		shootName      = "foo"
+		shootNamespace = "bar"
+
+		shoot *gardencorev1beta1.Shoot
+
+		r        rule.Rule
+		ruleName = "Shoot clusters must not have Alpha APIs enabled for any Kubernetes component."
+		ruleID   = "2002"
+		severity = rule.SeverityMedium
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+		}
+		r = &rules.Rule2002{
+			ShootName:      shootName,
+			ShootNamespace: shootNamespace,
+			Client:         fakeClient,
+		}
+	})
+
+	DescribeTable("Run cases", func(updateFn func(), expectedCheckResult []rule.CheckResult) {
+		updateFn()
+
+		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+
+		res, err := r.Run(ctx)
+		Expect(err).To(BeNil())
+
+		expectedResult := rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: expectedCheckResult}
+		Expect(res).To(Equal(expectedResult))
+	},
+		Entry("should error when the shoot is not found",
+			func() { shoot.Name = "notFoo" },
+			[]rule.CheckResult{
+				{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
+			},
+		),
+		Entry("should pass when AllAlpha featureGates are set to default for all components",
+			func() {},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube controller manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should fail when AllAlpha featureGates are enabled for all components",
+			func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+			},
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube controller manager.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should pass when AllAlpha featureGates are disabled for all components",
+			func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = ptr.To(gardencorev1beta1.KubeAPIServerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+				shoot.Spec.Kubernetes.KubeControllerManager = ptr.To(gardencorev1beta1.KubeControllerManagerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+				shoot.Spec.Kubernetes.KubeScheduler = ptr.To(gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube controller manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kubelet.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should pass when AllAlpha featureGates are disabled for the kube proxy component",
+			func() {
+				shoot.Spec.Kubernetes.KubeProxy = ptr.To(gardencorev1beta1.KubeProxyConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": false}}})
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube controller manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are disabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kubelet.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should fail when AllAlpha featureGates are disabled for the kubelet",
+			func() {
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"AllAlpha": true}}})
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube apiserver.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube controller manager.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube scheduler.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "AllAlpha featureGates are not enabled for the kube proxy.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "AllAlpha featureGates are enabled for the kubelet.", Target: rule.NewTarget()},
+			},
+		),
+	)
+})

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003_test.go
@@ -129,20 +129,6 @@ var _ = Describe("#2003", func() {
 				{Status: rule.Passed, Message: "Worker kubelet config does not disable kernel protection.", Target: rule.NewTarget("worker", "worker1")},
 			},
 		),
-		Entry("should pass when shoot worker sets default kubelet config",
-			func() {
-				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
-					{
-						Name:       "worker1",
-						Kubernetes: &gardencorev1beta1.WorkerKubernetes{},
-					},
-				}
-			},
-			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "Default kubelet config does not disable kernel protection.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "Worker kubelet config does not disable kernel protection.", Target: rule.NewTarget("worker", "worker1")},
-			},
-		),
 		Entry("should pass when shoot worker enables kernel defaults protection in kubelet config",
 			func() {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -43,13 +43,11 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 			ShootName:      r.args.ShootName,
 			ShootNamespace: r.args.ProjectNamespace,
 		},
-		rule.NewSkipRule(
-			"2002",
-			"Shoot clusters must not have Alpha APIs enabled for any Kubernetes component.",
-			"Not implemented.",
-			rule.NotImplemented,
-			rule.SkipRuleWithSeverity(rule.SeverityMedium),
-		),
+		&rules.Rule2002{
+			Client:         c,
+			ShootName:      r.args.ShootName,
+			ShootNamespace: r.args.ProjectNamespace,
+		},
 		&rules.Rule2003{
 			Client:         c,
 			ShootName:      r.args.ShootName,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an implementation of Rule 2002 of the Hardened Shoot Ruleset specification. It evaluates the following 5 kubernetes components: {kubeAPIServer,kubeControllerManager,kubeScheduler,kubeProxy,kubelet}, and checks for the featureGates.AllAlpha boolean flag in their specs.

**Which issue(s) this PR fixes**:
Part of #304

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `2002` from the `security-hardened-shoot-cluster` ruleset for provider `garden`.
```
