### PR TITLE
[Security Hardened Shoot Cluster] Rule 2000 Implementation

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -47,8 +47,8 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 	case shoot.Spec.Kubernetes.KubeAPIServer == nil || shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication == nil:
 		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is not enabled.", rule.NewTarget())), nil
 	case *shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication:
-		return rule.Result(r, rule.FailedCheckResult("Anonymous authentication is enabled on the kube-apiserver.", rule.NewTarget())), nil
+		return rule.Result(r, rule.FailedCheckResult("Anonymous authentication is enabled for the kube-apiserver.", rule.NewTarget())), nil
 	default:
-		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is disabled on the kube-apiserver.", rule.NewTarget())), nil
+		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is disabled for the kube-apiserver.", rule.NewTarget())), nil
 	}
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var (
+	_ rule.Rule     = &Rule2000{}
+	_ rule.Severity = &Rule2000{}
+)
+
+type Rule2000 struct {
+	Client         client.Client
+	ShootName      string
+	ShootNamespace string
+}
+
+func (r *Rule2000) ID() string {
+	return "2000"
+}
+
+func (r *Rule2000) Name() string {
+	return "Shoot clusters must have anonymous authentication disabled for the Kubernetes API server."
+}
+
+func (r *Rule2000) Severity() rule.SeverityLevel {
+	return rule.SeverityHigh
+}
+
+func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
+	shoot := &gardencorev1beta1.Shoot{ObjectMeta: v1.ObjectMeta{Name: r.ShootName, Namespace: r.ShootNamespace}}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", r.ShootName, "namespace", r.ShootNamespace, "kind", "Shoot"))), nil
+	}
+
+	switch {
+	case shoot.Spec.Kubernetes.KubeAPIServer == nil || shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication == nil:
+		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is not enabled.", rule.NewTarget())), nil
+	case *shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication:
+		return rule.Result(r, rule.FailedCheckResult("Anonymous authentication is enabled on the kube-apiserver.", rule.NewTarget())), nil
+	default:
+		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is disabled on the kube-apiserver.", rule.NewTarget())), nil
+	}
+}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -62,11 +62,11 @@ var _ = Describe("#2000", func() {
 			func() { shoot.Name = "notFoo" },
 			[]rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}},
 		),
-		Entry("should warn when kube-apiserver configuration is not set",
+		Entry("should pass when kube-apiserver configuration is not set",
 			func() {},
 			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()}},
 		),
-		Entry("should warn when anonymous authentication is not set",
+		Entry("should pass when anonymous authentication is not set",
 			func() {
 				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
 					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#2000", func() {
+	var (
+		fakeClient     client.Client
+		ctx            = context.TODO()
+		shootName      = "foo"
+		shootNamespace = "bar"
+
+		shoot    *gardencorev1beta1.Shoot
+		r        rule.Rule
+		ruleName = "Shoot clusters must have anonymous authentication disabled for the Kubernetes API server."
+		ruleID   = "2000"
+		severity = rule.SeverityHigh
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+		}
+
+		r = &rules.Rule2000{
+			Client:         fakeClient,
+			ShootName:      shootName,
+			ShootNamespace: shootNamespace,
+		}
+	})
+
+	DescribeTable("Run cases", func(updateFn func(), expectedCheckResults []rule.CheckResult) {
+		updateFn()
+		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+		res, err := r.Run(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: expectedCheckResults}))
+	},
+		Entry("should error when the shoot is not found",
+			func() { shoot.Name = "notFoo" },
+			[]rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}},
+		),
+		Entry("should warn when kube-apiserver configuration is not set",
+			func() {},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()}},
+		),
+		Entry("should warn when anonymous authentication is not set",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+							FeatureGates: map[string]bool{"foo": true},
+						},
+					},
+				}
+			},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()}},
+		),
+		Entry("should pass when anonymous authentication is disabled",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						EnableAnonymousAuthentication: ptr.To(false),
+					},
+				}
+			},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is disabled on the kube-apiserver.", Target: rule.NewTarget()}},
+		),
+		Entry("should fail when anonymous authentication is enabled",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						EnableAnonymousAuthentication: ptr.To(true),
+					},
+				}
+			},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Anonymous authentication is enabled on the kube-apiserver.", Target: rule.NewTarget()}},
+		),
+	)
+})

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -86,7 +86,7 @@ var _ = Describe("#2000", func() {
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is disabled on the kube-apiserver.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget()},
 		),
 		Entry("should fail when anonymous authentication is enabled",
 			func() {
@@ -96,7 +96,7 @@ var _ = Describe("#2000", func() {
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled on the kube-apiserver.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget()},
 		),
 	)
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -51,20 +51,20 @@ var _ = Describe("#2000", func() {
 		}
 	})
 
-	DescribeTable("Run cases", func(updateFn func(), expectedCheckResults []rule.CheckResult) {
+	DescribeTable("Run cases", func(updateFn func(), expectedCheckResult rule.CheckResult) {
 		updateFn()
 		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 		res, err := r.Run(ctx)
 		Expect(err).To(BeNil())
-		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: expectedCheckResults}))
+		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: []rule.CheckResult{expectedCheckResult}}))
 	},
 		Entry("should error when the shoot is not found",
 			func() { shoot.Name = "notFoo" },
-			[]rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}},
+			rule.CheckResult{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
 		),
 		Entry("should pass when kube-apiserver configuration is not set",
 			func() {},
-			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()}},
+			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()},
 		),
 		Entry("should pass when anonymous authentication is not set",
 			func() {
@@ -76,7 +76,7 @@ var _ = Describe("#2000", func() {
 					},
 				}
 			},
-			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()}},
+			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()},
 		),
 		Entry("should pass when anonymous authentication is disabled",
 			func() {
@@ -86,7 +86,7 @@ var _ = Describe("#2000", func() {
 					},
 				}
 			},
-			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is disabled on the kube-apiserver.", Target: rule.NewTarget()}},
+			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is disabled on the kube-apiserver.", Target: rule.NewTarget()},
 		),
 		Entry("should fail when anonymous authentication is enabled",
 			func() {
@@ -96,7 +96,7 @@ var _ = Describe("#2000", func() {
 					},
 				}
 			},
-			[]rule.CheckResult{{Status: rule.Failed, Message: "Anonymous authentication is enabled on the kube-apiserver.", Target: rule.NewTarget()}},
+			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled on the kube-apiserver.", Target: rule.NewTarget()},
 		),
 	)
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -31,13 +31,11 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 			rule.NotImplemented,
 			rule.SkipRuleWithSeverity(rule.SeverityMedium),
 		),
-		rule.NewSkipRule(
-			"2000",
-			"Shoot clusters must have anonymous authentication disabled for the Kubernetes API server.",
-			"Not implemented.",
-			rule.NotImplemented,
-			rule.SkipRuleWithSeverity(rule.SeverityHigh),
-		),
+		&rules.Rule2000{
+			Client:         c,
+			ShootName:      r.args.ShootName,
+			ShootNamespace: r.args.ProjectNamespace,
+		},
 		&rules.Rule2001{
 			Client:         c,
 			ShootName:      r.args.ShootName,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an implementation of the Rule 2000 of the Security Hardened Shoot Cluster Ruleset. It retrieves metadata about the shoot cluster and evaluates the EnableAnonymousAuthentication flag (if present) of the Kube API Server component.

**Which issue(s) this PR fixes**:
Part of #304 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `2000` from the `security-hardened-shoot-cluster` ruleset for provider `garden`.
```
