### PR TITLE
[Security Hardened Shoot Cluster] Rule 2005 Implementation

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var (
+	_ rule.Rule     = &Rule2005{}
+	_ rule.Severity = &Rule2005{}
+)
+
+type Rule2005 struct {
+	Client         client.Client
+	ShootName      string
+	ShootNamespace string
+}
+
+func (r *Rule2005) ID() string {
+	return "2005"
+}
+
+func (r *Rule2005) Name() string {
+	return "Shoot clusters must not disable timeouts for Kubelet."
+}
+
+func (r *Rule2005) Severity() rule.SeverityLevel {
+	return rule.SeverityMedium
+}
+
+func (r *Rule2005) Run(ctx context.Context) (rule.RuleResult, error) {
+	shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: r.ShootName, Namespace: r.ShootNamespace}}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), nil
+	}
+
+	var checkResults = []rule.CheckResult{}
+
+	if shoot.Spec.Kubernetes.Kubelet == nil || shoot.Spec.Kubernetes.Kubelet.StreamingConnectionIdleTimeout == nil {
+		checkResults = append(checkResults, rule.PassedCheckResult("The connection timeout is set to the reccomended value (5m).", rule.NewTarget()))
+	} else {
+		timeoutDuration := *shoot.Spec.Kubernetes.Kubelet.StreamingConnectionIdleTimeout
+		switch {
+		case timeoutDuration.Minutes() < 5:
+			checkResults = append(checkResults, rule.FailedCheckResult("The connection timeout is not set to a valid value (< 5m).", rule.NewTarget()))
+		case timeoutDuration.Minutes() == 5:
+			checkResults = append(checkResults, rule.PassedCheckResult("The connection timeout is set to the reccomended value (5m).", rule.NewTarget()))
+		case timeoutDuration.Hours() <= 4:
+			checkResults = append(checkResults, rule.PassedCheckResult("The connection timeout is set to a valid value ([5m; 4h]).", rule.NewTarget()))
+		default:
+			checkResults = append(checkResults, rule.FailedCheckResult("The connection timeout is not set to a valid value (> 4h).", rule.NewTarget()))
+		}
+	}
+
+	for _, worker := range shoot.Spec.Provider.Workers {
+		workerTarget := rule.NewTarget("worker", worker.Name)
+		if worker.Kubernetes == nil || worker.Kubernetes.Kubelet == nil || worker.Kubernetes.Kubelet.StreamingConnectionIdleTimeout == nil {
+			checkResults = append(checkResults, rule.PassedCheckResult("The connection timeout is set to the reccomended value (5m).", workerTarget))
+		} else {
+			timeoutDuration := *worker.Kubernetes.Kubelet.StreamingConnectionIdleTimeout
+			switch {
+			case timeoutDuration.Minutes() < 5:
+				checkResults = append(checkResults, rule.FailedCheckResult("The connection timeout is not set to a valid value (< 5m).", workerTarget))
+			case timeoutDuration.Minutes() == 5:
+				checkResults = append(checkResults, rule.PassedCheckResult("The connection timeout is set to the reccomended value (5m).", workerTarget))
+			case timeoutDuration.Hours() <= 4:
+				checkResults = append(checkResults, rule.PassedCheckResult("The connection timeout is set to a valid value ([5m; 4h]).", workerTarget))
+			default:
+				checkResults = append(checkResults, rule.FailedCheckResult("The connection timeout is not set to a valid value (> 4h).", workerTarget))
+			}
+		}
+	}
+
+	return rule.Result(r, checkResults...), nil
+}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005_test.go
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#2005", func() {
+	var (
+		fakeClient     client.Client
+		ctx            = context.TODO()
+		shootName      = "foo"
+		shootNamespace = "bar"
+
+		shoot *gardencorev1beta1.Shoot
+
+		r        rule.Rule
+		ruleName = "Shoot clusters must not disable timeouts for Kubelet."
+		ruleID   = "2005"
+		severity = rule.SeverityMedium
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+		}
+		r = &rules.Rule2005{
+			Client:         fakeClient,
+			ShootName:      shootName,
+			ShootNamespace: shootNamespace,
+		}
+	})
+
+	DescribeTable("Run cases", func(updateFn func(), expectedCheckResult []rule.CheckResult) {
+		updateFn()
+		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+		res, err := r.Run(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: expectedCheckResult}))
+	},
+		Entry("should error when the shoot can't be found",
+			func() { shoot.Name = "notFoo" },
+			[]rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget()}},
+		),
+		Entry("should pass when the main kubelet has a default configuration",
+			func() {},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "The connection timeout is set to the reccomended value (5m).", Target: rule.NewTarget()}},
+		),
+		Entry("should pass when the main kubelet has a default connection timeout",
+			func() {
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{})
+			},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "The connection timeout is set to the reccomended value (5m).", Target: rule.NewTarget()}},
+		),
+		Entry("should pass when the main kubelet has a connection timeout set to 5m",
+			func() {
+				duration, err := time.ParseDuration("5m")
+				Expect(err).To(BeNil())
+
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{
+					StreamingConnectionIdleTimeout: &metav1.Duration{
+						Duration: duration,
+					},
+				})
+			},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "The connection timeout is set to the reccomended value (5m).", Target: rule.NewTarget()}},
+		),
+		Entry("should pass when the main kubelet has a connection timeout set in the interval between 5m and 4h",
+			func() {
+				duration, err := time.ParseDuration("2h45m")
+				Expect(err).To(BeNil())
+
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{
+					StreamingConnectionIdleTimeout: &metav1.Duration{
+						Duration: duration,
+					},
+				})
+			},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "The connection timeout is set to a valid value ([5m; 4h]).", Target: rule.NewTarget()}},
+		),
+		Entry("should fail when the main kubelet has a connection timeout set below 5m",
+			func() {
+				duration, err := time.ParseDuration("3s")
+				Expect(err).To(BeNil())
+
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{
+					StreamingConnectionIdleTimeout: &metav1.Duration{
+						Duration: duration,
+					},
+				})
+			},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "The connection timeout is not set to a valid value (< 5m).", Target: rule.NewTarget()}},
+		),
+		Entry("should fail when the main kubelet has a connection timeout set above 4h",
+			func() {
+				duration, err := time.ParseDuration("5h12s")
+				Expect(err).To(BeNil())
+
+				shoot.Spec.Kubernetes.Kubelet = ptr.To(gardencorev1beta1.KubeletConfig{
+					StreamingConnectionIdleTimeout: &metav1.Duration{
+						Duration: duration,
+					},
+				})
+			},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "The connection timeout is not set to a valid value (> 4h).", Target: rule.NewTarget()}},
+		),
+		Entry("should return appropriate check results for varying worker node configurations",
+			func() {
+				reccomendedDuration, err := time.ParseDuration("5m")
+				Expect(err).To(BeNil())
+				belowValidDuration, err := time.ParseDuration("19s")
+				Expect(err).To(BeNil())
+				validDuration, err := time.ParseDuration("3h57m")
+				Expect(err).To(BeNil())
+				aboveValidDuration, err := time.ParseDuration("5h")
+				Expect(err).To(BeNil())
+
+				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+					{
+						Name:       "worker1",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{},
+					},
+					{
+						Name: "worker2",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: &gardencorev1beta1.KubeletConfig{},
+						},
+					},
+					{
+						Name: "worker3",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: &gardencorev1beta1.KubeletConfig{
+								StreamingConnectionIdleTimeout: &metav1.Duration{
+									Duration: reccomendedDuration,
+								},
+							},
+						},
+					},
+					{
+						Name: "worker4",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: &gardencorev1beta1.KubeletConfig{
+								StreamingConnectionIdleTimeout: &metav1.Duration{
+									Duration: belowValidDuration,
+								},
+							},
+						},
+					},
+					{
+						Name: "worker5",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: &gardencorev1beta1.KubeletConfig{
+								StreamingConnectionIdleTimeout: &metav1.Duration{
+									Duration: validDuration,
+								},
+							},
+						},
+					},
+					{
+						Name: "worker6",
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Kubelet: &gardencorev1beta1.KubeletConfig{
+								StreamingConnectionIdleTimeout: &metav1.Duration{
+									Duration: aboveValidDuration,
+								},
+							},
+						},
+					},
+				}
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "The connection timeout is set to the reccomended value (5m).", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "The connection timeout is set to the reccomended value (5m).", Target: rule.NewTarget("worker", "worker1")},
+				{Status: rule.Passed, Message: "The connection timeout is set to the reccomended value (5m).", Target: rule.NewTarget("worker", "worker2")},
+				{Status: rule.Passed, Message: "The connection timeout is set to the reccomended value (5m).", Target: rule.NewTarget("worker", "worker3")},
+				{Status: rule.Failed, Message: "The connection timeout is not set to a valid value (< 5m).", Target: rule.NewTarget("worker", "worker4")},
+				{Status: rule.Passed, Message: "The connection timeout is set to a valid value ([5m; 4h]).", Target: rule.NewTarget("worker", "worker5")},
+				{Status: rule.Failed, Message: "The connection timeout is not set to a valid value (> 4h).", Target: rule.NewTarget("worker", "worker6")},
+			},
+		),
+	)
+})

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -60,13 +60,11 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 			rule.NotImplemented,
 			rule.SkipRuleWithSeverity(rule.SeverityHigh),
 		),
-		rule.NewSkipRule(
-			"2005",
-			"Shoot clusters must not disable timeouts for Kubelet.",
-			"Not implemented.",
-			rule.NotImplemented,
-			rule.SkipRuleWithSeverity(rule.SeverityMedium),
-		),
+		&rules.Rule2005{
+			Client:         c,
+			ShootName:      r.args.ShootName,
+			ShootNamespace: r.args.ProjectNamespace,
+		},
 		rule.NewSkipRule(
 			"2006",
 			"Shoot clusters must have static token kubeconfig disabled.",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements rule 2005 of the Security Hardened Shoot Cluster Ruleset. It evaluates the kubelet configurations of the main and worker nodes by checking the value of their connection timeouts. The checkResults are in accordance with the DISA STIG guide for rule 245541 [ref](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-245541).

**Which issue(s) this PR fixes**:
Part of #304 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `2005` from the `security-hardened-shoot-cluster` ruleset for provider `garden`.
```
