### PR TITLE
Lower diki pod lifetime to 300 seconds

### DIFF
--- a/pkg/kubernetes/pod/privileged.go
+++ b/pkg/kubernetes/pod/privileged.go
@@ -43,11 +43,12 @@ func NewPrivilegedPod(name, namespace, image, nodeName string, additionalLabels 
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
+			ActiveDeadlineSeconds: ptr.To[int64](300),
 			Containers: []corev1.Container{
 				{
 					Name:    "container",
 					Image:   image,
-					Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter -m -t $(pgrep -xo systemd) sleep 600"},
+					Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter -m -t $(pgrep -xo systemd) sleep 300"},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: ptr.To(true),
 					},

--- a/pkg/kubernetes/pod/privileged_test.go
+++ b/pkg/kubernetes/pod/privileged_test.go
@@ -37,11 +37,12 @@ var _ = Describe("podutils", func() {
 					},
 				},
 				Spec: corev1.PodSpec{
+					ActiveDeadlineSeconds: ptr.To[int64](300),
 					Containers: []corev1.Container{
 						{
 							Name:    "container",
 							Image:   image,
-							Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter -m -t $(pgrep -xo systemd) sleep 600"},
+							Command: []string{"chroot", "/host", "/bin/bash", "-c", "nsenter -m -t $(pgrep -xo systemd) sleep 300"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Pods created by diki will be terminated 300 seconds after start.
```
