### PR TITLE
[Security Hardened Shoot Cluster] Rule 2006 Implementation

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var (
+	_ rule.Rule     = &Rule2006{}
+	_ rule.Severity = &Rule2006{}
+)
+
+type Rule2006 struct {
+}
+
+func (r *Rule2006) ID() string {
+	return "2006"
+}
+
+func (r *Rule2006) Name() string {
+	return "Shoot clusters must have static token kubeconfig disabled."
+}
+
+func (r *Rule2006) Severity() rule.SeverityLevel {
+	return rule.SeverityHigh
+}
+
+func (r *Rule2006) Run(ctx context.Context) (rule.RuleResult, error) {
+
+}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
@@ -51,14 +51,14 @@ func (r *Rule2006) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	if versionutils.ConstraintK8sGreaterEqual127.Check(version) {
-		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is locked to disabled for the shoot (Kubernetes version >= 1.27).", rule.NewTarget())), nil
+		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is locked to disabled (Kubernetes version >= 1.27).", rule.NewTarget())), nil
 	}
 	if shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig == nil {
-		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is not enabled for the shoot.", rule.NewTarget())), nil
+		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is not enabled.", rule.NewTarget())), nil
 	}
 	if !(*shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig) {
-		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is disabled for the shoot.", rule.NewTarget())), nil
+		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is disabled.", rule.NewTarget())), nil
 	}
 
-	return rule.Result(r, rule.FailedCheckResult("Static token kubeconfig is enabled for the shoot.", rule.NewTarget())), nil
+	return rule.Result(r, rule.FailedCheckResult("Static token kubeconfig is enabled.", rule.NewTarget())), nil
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
@@ -51,10 +51,14 @@ func (r *Rule2006) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	if versionutils.ConstraintK8sGreaterEqual127.Check(version) {
-		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is disabled for the shoot by default (Kubernetes version >= 1.27).", rule.NewTarget())), nil
+		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is locked to disabled for the shoot (Kubernetes version >= 1.27).", rule.NewTarget())), nil
 	}
 
-	if shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig == nil || !(*shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig) {
+	if shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig == nil {
+		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is disabled for the shoot by default.", rule.NewTarget())), nil
+	}
+
+	if !(*shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig) {
 		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is disabled for the shoot.", rule.NewTarget())), nil
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
@@ -53,11 +53,9 @@ func (r *Rule2006) Run(ctx context.Context) (rule.RuleResult, error) {
 	if versionutils.ConstraintK8sGreaterEqual127.Check(version) {
 		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is locked to disabled for the shoot (Kubernetes version >= 1.27).", rule.NewTarget())), nil
 	}
-
 	if shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig == nil {
-		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is disabled for the shoot by default.", rule.NewTarget())), nil
+		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is not enabled for the shoot.", rule.NewTarget())), nil
 	}
-
 	if !(*shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig) {
 		return rule.Result(r, rule.PassedCheckResult("Static token kubeconfig is disabled for the shoot.", rule.NewTarget())), nil
 	}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006.go
@@ -7,7 +7,10 @@ package rules
 import (
 	"context"
 
+	"github.com/docker/docker-credential-helpers/client"
 	"github.com/gardener/diki/pkg/rule"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -16,6 +19,9 @@ var (
 )
 
 type Rule2006 struct {
+	Client         client.Client
+	ShootName      string
+	ShootNamespace string
 }
 
 func (r *Rule2006) ID() string {
@@ -31,5 +37,13 @@ func (r *Rule2006) Severity() rule.SeverityLevel {
 }
 
 func (r *Rule2006) Run(ctx context.Context) (rule.RuleResult, error) {
+	shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: r.ShootName, Namespace: r.ShootNamespace}}
+	if err := client.Get(ctx, client.GetObjectFromKey(shoot), shoot); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", r.ShootName, "namespace", r.ShootNamespace, "kind", "Shoot"))), nil
+	}
+
+	if shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig == nil {
+
+	}
 
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
@@ -73,7 +73,7 @@ var _ = Describe("#2006", func() {
 					Version: "1.27.0",
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is locked to disabled for the shoot (Kubernetes version >= 1.27).", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is locked to disabled (Kubernetes version >= 1.27).", Target: rule.NewTarget()},
 		),
 		Entry("should pass when Static token kubeconfig is default",
 			func() {
@@ -81,7 +81,7 @@ var _ = Describe("#2006", func() {
 					Version: "1.26.0",
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is not enabled for the shoot.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is not enabled.", Target: rule.NewTarget()},
 		),
 		Entry("should pass when Static token kubeconfig is disabled",
 			func() {
@@ -90,7 +90,7 @@ var _ = Describe("#2006", func() {
 					EnableStaticTokenKubeconfig: ptr.To(false),
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled.", Target: rule.NewTarget()},
 		),
 		Entry("should fail when Static token kubeconfig is enabled",
 			func() {
@@ -99,7 +99,7 @@ var _ = Describe("#2006", func() {
 					EnableStaticTokenKubeconfig: ptr.To(true),
 				}
 			},
-			rule.CheckResult{Status: rule.Failed, Message: "Static token kubeconfig is enabled for the shoot.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Failed, Message: "Static token kubeconfig is enabled.", Target: rule.NewTarget()},
 		),
 	)
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
@@ -73,17 +73,17 @@ var _ = Describe("#2006", func() {
 					Version: "1.27.0",
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot by default (Kubernetes version >= 1.27).", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is locked to disabled for the shoot (Kubernetes version >= 1.27).", Target: rule.NewTarget()},
 		),
-		Entry("should pass when the kubernetes config is default",
+		Entry("should pass when Static token kubeconfig is default",
 			func() {
 				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
 					Version: "1.26.0",
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot by default.", Target: rule.NewTarget()},
 		),
-		Entry("should pass when the kubernetes config is disabled",
+		Entry("should pass when Static token kubeconfig is disabled",
 			func() {
 				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
 					Version:                     "1.26.0",
@@ -92,7 +92,7 @@ var _ = Describe("#2006", func() {
 			},
 			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot.", Target: rule.NewTarget()},
 		),
-		Entry("should fail when the kubernetes config is enabled",
+		Entry("should fail when Static token kubeconfig is enabled",
 			func() {
 				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
 					Version:                     "1.26.0",

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#2006", func() {
+	var (
+		fakeClient     client.Client
+		ctx            = context.TODO()
+		shootName      = "foo"
+		shootNamespace = "bar"
+
+		shoot *gardencorev1beta1.Shoot
+
+		r        rule.Rule
+		ruleName = "Shoot clusters must have static token kubeconfig disabled."
+		ruleID   = "2006"
+		severity = rule.SeverityHigh
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+		}
+		r = &rules.Rule2006{
+			Client:         fakeClient,
+			ShootName:      shootName,
+			ShootNamespace: shootNamespace,
+		}
+	})
+
+	DescribeTable("Run cases", func(updateFn func(), expectedCheckResult rule.CheckResult) {
+		updateFn()
+		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+		res, err := r.Run(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: []rule.CheckResult{expectedCheckResult}}))
+	},
+		Entry("should error when the shoot can't be found",
+			func() { shoot.Name = "notFoo" },
+			rule.CheckResult{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("name", "foo", "namespace", "bar", "kind", "Shoot")},
+		),
+		Entry("should error if the kubernetes version is not specified",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{}
+			},
+			rule.CheckResult{Status: rule.Errored, Message: "Invalid Semantic Version", Target: rule.NewTarget()},
+		),
+		Entry("should pass when the kubernetes version is above 1.26",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					Version: "1.27.0",
+				}
+			},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot by default (Kubernetes version >= 1.27).", Target: rule.NewTarget()},
+		),
+		Entry("should pass when the kubernetes config is default",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					Version: "1.26.0",
+				}
+			},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot.", Target: rule.NewTarget()},
+		),
+		Entry("should pass when the kubernetes config is disabled",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					Version:                     "1.26.0",
+					EnableStaticTokenKubeconfig: ptr.To(false),
+				}
+			},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot.", Target: rule.NewTarget()},
+		),
+		Entry("should fail when the kubernetes config is enabled",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					Version:                     "1.26.0",
+					EnableStaticTokenKubeconfig: ptr.To(true),
+				}
+			},
+			rule.CheckResult{Status: rule.Failed, Message: "Static token kubeconfig is enabled for the shoot.", Target: rule.NewTarget()},
+		),
+	)
+})

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2006_test.go
@@ -81,7 +81,7 @@ var _ = Describe("#2006", func() {
 					Version: "1.26.0",
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is disabled for the shoot by default.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Static token kubeconfig is not enabled for the shoot.", Target: rule.NewTarget()},
 		),
 		Entry("should pass when Static token kubeconfig is disabled",
 			func() {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -63,13 +63,11 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 			ShootName:      r.args.ShootName,
 			ShootNamespace: r.args.ProjectNamespace,
 		},
-		rule.NewSkipRule(
-			"2006",
-			"Shoot clusters must have static token kubeconfig disabled.",
-			"Not implemented.",
-			rule.NotImplemented,
-			rule.SkipRuleWithSeverity(rule.SeverityHigh),
-		),
+		&rules.Rule2006{
+			Client:         c,
+			ShootName:      r.args.ShootName,
+			ShootNamespace: r.args.ProjectNamespace,
+		},
 		rule.NewSkipRule(
 			"2007",
 			"Shoot clusters must have a PodSecurity admission plugin configured.",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements Rule 2006 for the Security Hardened Shoot Cluster Ruleset. It evaluates the EnableStaticTokenKubeconfig and the Kubernetes version in the Shoot Spec.

**Which issue(s) this PR fixes**:
Part of #304 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `2006` from the `security-hardened-shoot-cluster` ruleset for provider `garden`.
```
