### PR TITLE
[Security Hardened Kubernetes Cluster] Rule 2001 implementation

### DIFF
--- a/docs/rulesets/security-hardened-k8s/ruleset.md
+++ b/docs/rulesets/security-hardened-k8s/ruleset.md
@@ -37,12 +37,12 @@ spec:
 This rule follows the requirements from Kyverno pod security policy [Disallow Privilege Escalation](https://github.com/kyverno/policies/tree/release-1.12/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml).
 
 #### Fix
-Do not set `Pod` container fields `securityContext.allowPrivilegeEscalation` as it defaults to `false` or set it explicitly to `false`.
+Set the `Pod` container fields `securityContext.allowPrivilegeEscalation` explicitly to `false`. There is an [open issue in Kubernetes](https://github.com/kubernetes/kubernetes/issues/118822) about this configuration being `true` by default.
 
 > [!WARNING]  
 > `securityContext.allowPrivilegeEscalation` is set to `true` in the following exceptions:
 > - container is running as `privileged`
-> - `CAP_SYS_ADMIN` is added to the container
+> - `CAP_SYS_ADMIN/SYS_ADMIN` is added to the container. More information can be found [here](https://github.com/kubernetes/kubernetes/issues/119568).
 
 ``` yaml
 apiVersion: v1

--- a/docs/rulesets/security-hardened-k8s/ruleset.md
+++ b/docs/rulesets/security-hardened-k8s/ruleset.md
@@ -42,7 +42,7 @@ Set the `Pod` container fields `securityContext.allowPrivilegeEscalation` explic
 > [!WARNING]  
 > `securityContext.allowPrivilegeEscalation` is set to `true` in the following exceptions:
 > - container is running as `privileged`
-> - `CAP_SYS_ADMIN/SYS_ADMIN` is added to the container. More information can be found [here](https://github.com/kubernetes/kubernetes/issues/119568).
+> - `CAP_SYS_ADMIN` or `SYS_ADMIN` is added to the container. More information can be found in [this issue](https://github.com/kubernetes/kubernetes/issues/119568).
 
 ``` yaml
 apiVersion: v1

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -178,6 +178,14 @@ providers:                   # contains information about known providers
     #   skip:
     #     enabled: true
     #     justification: "the whole rule is accepted for ... reasons"
+    # - ruleID: "2001"
+    #   args:
+    #     acceptedPods:
+    #     - podMatchLabels:
+    #         foo: bar
+    #       namespaceMatchLabels:
+    #         foo: bar
+    #       justification: "justification"
     # - ruleID: "2008"
     #   args:
     #     acceptedPods:

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/diki/pkg/internal/utils"
+	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
+	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+)
+
+var (
+	_ rule.Rule     = &Rule2001{}
+	_ rule.Severity = &Rule2001{}
+	_ option.Option = &Options2001{}
+)
+
+type Rule2001 struct {
+	Client  client.Client
+	Options *Options2001
+}
+
+type Options2001 struct {
+	AcceptedPods []AcceptedPods2001 `json:"acceptedPods" yaml:"acceptedPods"`
+}
+
+type AcceptedPods2001 struct {
+	option.PodSelector
+	Justification string `json:"justification" yaml:"justification"`
+}
+
+// Validate validates that option configurations are correctly defined
+func (o Options2001) Validate() field.ErrorList {
+	var allErrs field.ErrorList
+
+	for _, p := range o.AcceptedPods {
+		allErrs = append(allErrs, p.Validate()...)
+	}
+
+	return allErrs
+}
+
+func (r *Rule2001) ID() string {
+	return "2001"
+}
+
+func (r *Rule2001) Name() string {
+	return "Containers must be forbidden to escalate privileges."
+}
+
+func (r *Rule2001) Severity() rule.SeverityLevel {
+	return rule.SeverityHigh
+}
+
+func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
+	var (
+		checkResults              []rule.CheckResult
+		allowsPrivilegeEscalation = func(securityContext corev1.SecurityContext) bool {
+			var addsCapSysAdmin = false
+
+			if securityContext.Capabilities != nil {
+				// CAP_SYS_ADMIN only works on CRI-O. ref: https://github.com/kubernetes/kubernetes/issues/119568
+				// Valiadated with `ubuntu` container, to check enabled capabilities the `capsh --print` command can be used.
+				addsCapSysAdmin = slices.ContainsFunc(securityContext.Capabilities.Add, func(cap corev1.Capability) bool {
+					return strings.ToUpper(string(cap)) == "SYS_ADMIN" || strings.ToUpper(string(cap)) == "CAP_SYS_ADMIN"
+				})
+			}
+
+			// AllowPrivilegeEscalation is defaulted to true. ref: https://github.com/kubernetes/kubernetes/issues/118822
+			// Valiadated with `ubuntu` container, to check if AllowPrivilegeEscalation is
+			// enabled the `cat /proc/self/status | grep NoNewPrivs` command can be used.
+			return securityContext.AllowPrivilegeEscalation == nil || *securityContext.AllowPrivilegeEscalation ||
+				(securityContext.Privileged != nil && *securityContext.Privileged) ||
+				addsCapSysAdmin
+		}
+	)
+
+	pods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "podList"))), nil
+	}
+
+	namespaces, err := kubeutils.GetNamespaces(ctx, r.Client)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "namespaceList"))), nil
+	}
+
+	for _, pod := range pods {
+		podTarget := rule.NewTarget("kind", "pod", "name", pod.Name, "namespace", pod.Namespace)
+		allows := false
+		for _, container := range pod.Spec.Containers {
+			var containerTarget = podTarget.With("container", container.Name)
+
+			if container.SecurityContext == nil || allowsPrivilegeEscalation(*container.SecurityContext) {
+				allows = true
+				if accepted, justification := r.accepted(pod, namespaces[pod.Namespace]); accepted {
+					msg := "Pod accepted to escalate privileges."
+					if justification != "" {
+						msg = justification
+					}
+					checkResults = append(checkResults, rule.AcceptedCheckResult(msg, containerTarget))
+				} else {
+					checkResults = append(checkResults, rule.FailedCheckResult("Pod must not escalate privileges.", containerTarget))
+				}
+			}
+		}
+		if !allows {
+			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not escalate privileges.", podTarget))
+		}
+	}
+
+	return rule.Result(r, checkResults...), nil
+}
+
+func (r *Rule2001) accepted(pod corev1.Pod, namespace corev1.Namespace) (bool, string) {
+	if r.Options == nil {
+		return false, ""
+	}
+
+	for _, acceptedPod := range r.Options.AcceptedPods {
+		if utils.MatchLabels(pod.Labels, acceptedPod.PodMatchLabels) &&
+			utils.MatchLabels(namespace.Labels, acceptedPod.NamespaceMatchLabels) {
+			return true, acceptedPod.Justification
+		}
+	}
+
+	return false, ""
+}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -67,7 +67,7 @@ func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
 	var (
 		checkResults              []rule.CheckResult
 		allowsPrivilegeEscalation = func(securityContext corev1.SecurityContext) bool {
-			var addsCapSysAdmin = false
+			addsCapSysAdmin := false
 
 			if securityContext.Capabilities != nil {
 				// CAP_SYS_ADMIN only works on CRI-O. ref: https://github.com/kubernetes/kubernetes/issues/119568
@@ -80,9 +80,11 @@ func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
 			// AllowPrivilegeEscalation is defaulted to true. ref: https://github.com/kubernetes/kubernetes/issues/118822
 			// Valiadated with `ubuntu` container, to check if AllowPrivilegeEscalation is
 			// enabled the `cat /proc/self/status | grep NoNewPrivs` command can be used.
-			return securityContext.AllowPrivilegeEscalation == nil || *securityContext.AllowPrivilegeEscalation ||
-				(securityContext.Privileged != nil && *securityContext.Privileged) ||
-				addsCapSysAdmin
+			var (
+				allowsPrivilegeEscalation = securityContext.AllowPrivilegeEscalation == nil || *securityContext.AllowPrivilegeEscalation
+				hasPrivilegedContext      = securityContext.Privileged != nil && *securityContext.Privileged
+			)
+			return allowsPrivilegeEscalation || hasPrivilegedContext || addsCapSysAdmin
 		}
 	)
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
+	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+)
+
+var _ = Describe("#2001", func() {
+	var (
+		client        client.Client
+		plainPod      *corev1.Pod
+		ctx           = context.TODO()
+		namespaceName = "foo"
+		namespace     *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		client = fakeclient.NewClientBuilder().Build()
+		namespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+		}
+		plainPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: namespaceName,
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "test",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+			},
+		}
+	})
+
+	DescribeTable("Run cases",
+		func(securityContext *corev1.SecurityContext, ruleOptions rules.Options2001, expectedResult rule.CheckResult) {
+			r := &rules.Rule2001{Client: client, Options: &ruleOptions}
+			pod := plainPod.DeepCopy()
+			pod.Spec.Containers[0].SecurityContext = securityContext
+
+			Expect(client.Create(ctx, pod)).To(Succeed())
+			Expect(client.Create(ctx, namespace)).To(Succeed())
+
+			ruleResult, err := r.Run(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{expectedResult}))
+		},
+
+		Entry("should fail when securityContext is not set",
+			nil, rules.Options2001{},
+			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
+		),
+		Entry("should fail when allowPrivilegeEscalation is not set",
+			&corev1.SecurityContext{}, rules.Options2001{},
+			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
+		),
+		Entry("should fail when allowPrivilegeEscalation is set to true",
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, rules.Options2001{},
+			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
+		),
+		Entry("should pass when allowPrivilegeEscalation is set to false",
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)}, rules.Options2001{},
+			rule.CheckResult{Status: rule.Passed, Message: "Pod does not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo")},
+		),
+		Entry("should fail when privileged is set to true",
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Privileged: ptr.To(true)}, rules.Options2001{},
+			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
+		),
+		Entry("should fail when SYS_ADMIN capability is added",
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}}}, rules.Options2001{},
+			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
+		),
+		Entry("should fail when CAP_SYS_ADMIN capability is added",
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_SYS_ADMIN"}}}, rules.Options2001{},
+			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
+		),
+		Entry("should pass when options are set",
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)},
+			rules.Options2001{
+				AcceptedPods: []rules.AcceptedPods2001{
+					{
+						PodSelector: option.PodSelector{
+							PodMatchLabels:       map[string]string{"foo": "bar"},
+							NamespaceMatchLabels: map[string]string{"foo": "bar"},
+						},
+						Justification: "foo justify",
+					},
+				},
+			},
+			rule.CheckResult{Status: rule.Accepted, Message: "foo justify", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
+		),
+	)
+})

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
@@ -5,5 +5,6 @@
 package rules
 
 type RuleOption interface {
-	Options2008
+	Options2001 |
+		Options2008
 }

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
@@ -22,6 +22,10 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 		return err
 	}
 
+	opts2001, err := getV01OptionOrNil[rules.Options2001](ruleOptions["2001"].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 2001 error: %s", err.Error())
+	}
 	opts2008, err := getV01OptionOrNil[rules.Options2008](ruleOptions["2008"].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 2008 error: %s", err.Error())
@@ -35,13 +39,10 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 			rule.NotImplemented,
 			rule.SkipRuleWithSeverity(rule.SeverityHigh),
 		),
-		rule.NewSkipRule(
-			"2001",
-			"Containers must be forbidden to escalate privileges.",
-			"Not implemented.",
-			rule.NotImplemented,
-			rule.SkipRuleWithSeverity(rule.SeverityHigh),
-		),
+		&rules.Rule2001{
+			Client:  c,
+			Options: opts2001,
+		},
 		rule.NewSkipRule(
 			"2002",
 			"Storage Classes should have a \"Delete\" reclaim policy.",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/356

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `2001` from the `security-hardened-k8s` ruleset for provider `managedk8s`.
```
