### PR TITLE
[Security Hardened Kubernetes Cluster] Rule 2000 implementation

### DIFF
--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+	"slices"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var (
+	_ rule.Rule     = &Rule2000{}
+	_ rule.Severity = &Rule2000{}
+)
+
+type Rule2000 struct {
+	Client client.Client
+}
+
+func (r *Rule2000) ID() string {
+	return "2000"
+}
+
+func (r *Rule2000) Name() string {
+	return "Ingress and egress traffic must be restricted by default."
+}
+
+func (r *Rule2000) Severity() rule.SeverityLevel {
+	return rule.SeverityHigh
+}
+
+func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
+	var checkResults []rule.CheckResult
+
+	networkPolicies, err := kubeutils.GetNetworkPolicies(ctx, r.Client, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "serviceList"))), nil
+	}
+
+	namespaces, err := kubeutils.GetNamespaces(ctx, r.Client)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "namespaceList"))), nil
+	}
+
+	groupedNetworkPolicies := map[string][]networkingv1.NetworkPolicy{}
+
+	for _, np := range networkPolicies {
+		groupedNetworkPolicies[np.Namespace] = append(groupedNetworkPolicies[np.Namespace], np)
+	}
+
+	for _, namespace := range namespaces {
+		var (
+			deniesIngress bool
+			deniesEgress  bool
+			target        = rule.NewTarget("namespace", namespace.Name)
+		)
+
+		for _, networkPolicy := range groupedNetworkPolicies[namespace.Name] {
+			if len(networkPolicy.Spec.PodSelector.MatchLabels) > 0 ||
+				len(networkPolicy.Spec.PodSelector.MatchExpressions) > 0 {
+				continue
+			}
+
+			if len(networkPolicy.Spec.Ingress) == 0 &&
+				slices.Contains(networkPolicy.Spec.PolicyTypes, networkingv1.PolicyTypeIngress) {
+				deniesIngress = true
+			}
+
+			if len(networkPolicy.Spec.Egress) == 0 &&
+				slices.Contains(networkPolicy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress) {
+				deniesEgress = true
+			}
+		}
+
+		switch {
+		case deniesIngress && deniesEgress:
+			checkResults = append(checkResults, rule.PassedCheckResult("Ingress and egress traffic denied by default.", target))
+		case !deniesIngress && !deniesEgress:
+			checkResults = append(checkResults, rule.FailedCheckResult("Ingress and egress traffic not denied by default.", target))
+		case deniesIngress:
+			checkResults = append(checkResults, rule.PassedCheckResult("Ingress traffic denied by default.", target),
+				rule.FailedCheckResult("Egress traffic not denied by default.", target))
+		default:
+			checkResults = append(checkResults, rule.PassedCheckResult("Egress traffic denied by default.", target),
+				rule.FailedCheckResult("Ingress traffic not denied by default.", target))
+		}
+	}
+
+	return rule.Result(r, checkResults...), nil
+}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -87,18 +87,16 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 		}
 
-		switch {
-		case deniesIngress && deniesEgress:
-			checkResults = append(checkResults, rule.PassedCheckResult("Ingress traffic is denied by default.", deniesIngressTarget),
-				rule.PassedCheckResult("Egress traffic is denied by default.", deniesEgressTarget))
-		case !deniesIngress && !deniesEgress:
-			checkResults = append(checkResults, rule.FailedCheckResult("Ingress and egress traffic is not denied by default.", target))
-		case deniesIngress:
-			checkResults = append(checkResults, rule.PassedCheckResult("Ingress traffic is denied by default.", deniesIngressTarget),
-				rule.FailedCheckResult("Egress traffic is not denied by default.", target))
-		default:
-			checkResults = append(checkResults, rule.PassedCheckResult("Egress traffic is denied by default.", deniesEgressTarget),
-				rule.FailedCheckResult("Ingress traffic is not denied by default.", target))
+		if deniesIngress {
+			checkResults = append(checkResults, rule.PassedCheckResult("Ingress traffic is denied by default.", deniesIngressTarget))
+		} else {
+			checkResults = append(checkResults, rule.FailedCheckResult("Ingress traffic is not denied by default.", target))
+		}
+
+		if deniesEgress {
+			checkResults = append(checkResults, rule.PassedCheckResult("Egress traffic is denied by default.", deniesEgressTarget))
+		} else {
+			checkResults = append(checkResults, rule.FailedCheckResult("Egress traffic is not denied by default.", target))
 		}
 	}
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -160,7 +160,12 @@ var _ = Describe("#2000", func() {
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Ingress and egress traffic is not denied by default.",
+				Message: "Ingress traffic is not denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-node-lease"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "Egress traffic is not denied by default.",
 				Target:  rule.NewTarget("namespace", "kube-node-lease"),
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -130,32 +130,37 @@ var _ = Describe("#2000", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Ingress and egress traffic denied by default.",
-				Target:  rule.NewTarget("namespace", "default"),
+				Message: "Ingress traffic is denied by default.",
+				Target:  rule.NewTarget("namespace", "default", "kind", "networkPolicy", "name", "deny-all"),
 			},
 			{
 				Status:  rule.Passed,
-				Message: "Ingress traffic denied by default.",
-				Target:  rule.NewTarget("namespace", "kube-system"),
+				Message: "Egress traffic is denied by default.",
+				Target:  rule.NewTarget("namespace", "default", "kind", "networkPolicy", "name", "deny-all"),
+			},
+			{
+				Status:  rule.Passed,
+				Message: "Ingress traffic is denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-system", "kind", "networkPolicy", "name", "deny-ingress"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Egress traffic not denied by default.",
+				Message: "Egress traffic is not denied by default.",
 				Target:  rule.NewTarget("namespace", "kube-system"),
 			},
 			{
 				Status:  rule.Passed,
-				Message: "Egress traffic denied by default.",
+				Message: "Egress traffic is denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-public", "kind", "networkPolicy", "name", "deny-egress"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "Ingress traffic is not denied by default.",
 				Target:  rule.NewTarget("namespace", "kube-public"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Ingress traffic not denied by default.",
-				Target:  rule.NewTarget("namespace", "kube-public"),
-			},
-			{
-				Status:  rule.Failed,
-				Message: "Ingress and egress traffic not denied by default.",
+				Message: "Ingress and egress traffic is not denied by default.",
 				Target:  rule.NewTarget("namespace", "kube-node-lease"),
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#2000", func() {
+	var (
+		client client.Client
+		ctx    = context.TODO()
+	)
+
+	BeforeEach(func() {
+		client = fakeclient.NewClientBuilder().Build()
+	})
+
+	It("should return correct results", func() {
+		r := &rules.Rule2000{Client: client}
+
+		nsDefault := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		npDefault := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deny-all",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					"Ingress",
+					"Egress",
+				},
+			},
+		}
+		Expect(client.Create(ctx, nsDefault)).To(Succeed())
+		Expect(client.Create(ctx, npDefault)).To(Succeed())
+
+		nsSystem := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-system",
+			},
+		}
+
+		npSystem := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deny-ingress",
+				Namespace: "kube-system",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					"Ingress",
+					"Egress",
+				},
+			},
+		}
+		Expect(client.Create(ctx, nsSystem)).To(Succeed())
+		Expect(client.Create(ctx, npSystem)).To(Succeed())
+
+		nsPublic := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-public",
+			},
+		}
+
+		npPublic1 := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deny-egress",
+				Namespace: "kube-public",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					"Egress",
+				},
+			},
+		}
+		npPublic2 := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-deny-ingress",
+				Namespace: "kube-public",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					"Ingress",
+				},
+			},
+		}
+		Expect(client.Create(ctx, nsPublic)).To(Succeed())
+		Expect(client.Create(ctx, npPublic1)).To(Succeed())
+		Expect(client.Create(ctx, npPublic2)).To(Succeed())
+
+		nsLease := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-node-lease",
+			},
+		}
+
+		Expect(client.Create(ctx, nsLease)).To(Succeed())
+
+		ruleResult, err := r.Run(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedCheckResults := []rule.CheckResult{
+			{
+				Status:  rule.Passed,
+				Message: "Ingress and egress traffic denied by default.",
+				Target:  rule.NewTarget("namespace", "default"),
+			},
+			{
+				Status:  rule.Passed,
+				Message: "Ingress traffic denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-system"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "Egress traffic not denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-system"),
+			},
+			{
+				Status:  rule.Passed,
+				Message: "Egress traffic denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-public"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "Ingress traffic not denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-public"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "Ingress and egress traffic not denied by default.",
+				Target:  rule.NewTarget("namespace", "kube-node-lease"),
+			},
+		}
+
+		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
+	})
+})

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
@@ -40,13 +40,9 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 	}
 
 	rules := []rule.Rule{
-		rule.NewSkipRule(
-			"2000",
-			"Ingress and egress traffic must be restricted by default.",
-			"Not implemented.",
-			rule.NotImplemented,
-			rule.SkipRuleWithSeverity(rule.SeverityHigh),
-		),
+		&rules.Rule2000{
+			Client: c,
+		},
 		&rules.Rule2001{
 			Client:  c,
 			Options: opts2001,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/356

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `2000` from the `security-hardened-k8s` ruleset for provider `managedk8s`.
```
