### PR TITLE
Add Graceful Shutdown Implementation

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -26,7 +26,7 @@ import (
 )
 
 // NewDikiCommand creates a new command that is used to start Diki.
-func NewDikiCommand(ctx context.Context, providerCreateFuncs map[string]provider.ProviderFromConfigFunc) *cobra.Command {
+func NewDikiCommand(providerCreateFuncs map[string]provider.ProviderFromConfigFunc) *cobra.Command {
 	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
@@ -64,8 +64,8 @@ e.g. to check compliance of your hyperscaler accounts.`,
 		Use:   "run",
 		Short: "Run some rulesets and rules.",
 		Long:  "Run allows running rulesets and rules for the given provider(s).",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return runCmd(ctx, providerCreateFuncs, opts)
+		RunE: func(c *cobra.Command, _ []string) error {
+			return runCmd(c.Context(), providerCreateFuncs, opts)
 		},
 	}
 

--- a/cmd/diki/main.go
+++ b/cmd/diki/main.go
@@ -15,7 +15,6 @@ import (
 )
 
 func main() {
-
 	cmd := app.NewDikiCommand(map[string]provider.ProviderFromConfigFunc{
 		"garden":        builder.GardenProviderFromConfig,
 		"gardener":      builder.GardenerProviderFromConfig,

--- a/cmd/diki/main.go
+++ b/cmd/diki/main.go
@@ -5,8 +5,9 @@
 package main
 
 import (
-	"context"
 	"log"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/gardener/diki/cmd/diki/app"
 	"github.com/gardener/diki/pkg/provider"
@@ -14,14 +15,15 @@ import (
 )
 
 func main() {
-	cmd := app.NewDikiCommand(context.Background(), map[string]provider.ProviderFromConfigFunc{
+
+	cmd := app.NewDikiCommand(map[string]provider.ProviderFromConfigFunc{
 		"garden":        builder.GardenProviderFromConfig,
 		"gardener":      builder.GardenerProviderFromConfig,
 		"managedk8s":    builder.ManagedK8SProviderFromConfig,
 		"virtualgarden": builder.VirtualGardenProviderFromConfig,
 	})
 
-	if err := cmd.Execute(); err != nil {
+	if err := cmd.ExecuteContext(controllerruntime.SetupSignalHandler()); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fluent/fluent-operator/v2 v2.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gardener/etcd-druid v0.25.0 // indirect
 	github.com/gardener/hvpa-controller/api v0.17.0 // indirect
@@ -58,6 +59,7 @@ require (
 	github.com/gobuffalo/flect v1.0.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
@@ -125,6 +127,7 @@ require (
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRr
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
+github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,7 +187,10 @@ func (r *Rule242400) checkKubeProxy(
 	)
 
 	defer func() {
-		if err := r.ClusterPodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.ClusterPodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -256,7 +257,10 @@ func (r *Rule242451) checkPods(
 	)
 
 	defer func() {
-		if err := pc.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := pc.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()
@@ -355,7 +359,10 @@ func (r *Rule242451) checkKubelet(
 	)
 
 	defer func() {
-		if err := r.ClusterPodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.ClusterPodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -231,7 +232,10 @@ func (r *Rule242466) checkPods(
 	)
 
 	defer func() {
-		if err := pc.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := pc.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()
@@ -311,7 +315,10 @@ func (r *Rule242466) checkKubelet(
 	)
 
 	defer func() {
-		if err := r.ClusterPodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.ClusterPodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -231,7 +232,10 @@ func (r *Rule242467) checkPods(
 	)
 
 	defer func() {
-		if err := pc.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := pc.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()
@@ -311,7 +315,10 @@ func (r *Rule242467) checkKubelet(
 	)
 
 	defer func() {
-		if err := r.ClusterPodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.ClusterPodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -168,7 +169,10 @@ func (r *Rule242400) checkKubeProxy(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,7 +172,10 @@ func (r *Rule242451) checkPods(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()
@@ -270,7 +274,10 @@ func (r *Rule242451) checkKubelet(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,7 +158,10 @@ func (r *Rule242466) checkPods(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()
@@ -236,7 +240,10 @@ func (r *Rule242466) checkKubelet(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,7 +158,10 @@ func (r *Rule242467) checkPods(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()
@@ -236,7 +240,10 @@ func (r *Rule242467) checkKubelet(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -181,7 +182,10 @@ func (r *Rule242451) checkPods(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -169,7 +170,10 @@ func (r *Rule242466) checkPods(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -169,7 +170,10 @@ func (r *Rule242467) checkPods(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/shared/provider/provider.go
+++ b/pkg/shared/provider/provider.go
@@ -38,6 +38,8 @@ func RunAll(ctx context.Context, p provider.Provider, rulesets map[string]rulese
 	finishMsg := "finished ruleset run"
 	for _, rs := range rulesets {
 		select {
+		case <-ctx.Done():
+			return provider.ProviderResult{}, ctx.Err()
 		default:
 			log.Info("starting ruleset run", "ruleset", rs.ID(), "version", rs.Version())
 			if res, err := rs.Run(ctx); err != nil {
@@ -47,8 +49,6 @@ func RunAll(ctx context.Context, p provider.Provider, rulesets map[string]rulese
 				result.RulesetResults = append(result.RulesetResults, res)
 				log.Info(finishMsg, "ruleset", rs.ID(), "version", rs.Version())
 			}
-		case <-ctx.Done():
-			return provider.ProviderResult{}, ctx.Err()
 		}
 	}
 	log.Info("finished provider run")

--- a/pkg/shared/provider/provider.go
+++ b/pkg/shared/provider/provider.go
@@ -41,7 +41,7 @@ func RunAll(ctx context.Context, p provider.Provider, rulesets map[string]rulese
 		default:
 			log.Info("starting ruleset run", "ruleset", rs.ID(), "version", rs.Version())
 			if res, err := rs.Run(ctx); err != nil {
-				errAgg = errors.Join(errAgg, fmt.Errorf("ruleset with id %s and version %s errored: %w", res.RulesetID, res.RulesetVersion, err))
+				errAgg = errors.Join(errAgg, fmt.Errorf("ruleset with id %s and version %s errored: %w", rs.ID(), rs.Version(), err))
 				log.Error(finishMsg, "ruleset", rs.ID(), "version", rs.Version(), "error", err)
 			} else {
 				result.RulesetResults = append(result.RulesetResults, res)

--- a/pkg/shared/provider/provider.go
+++ b/pkg/shared/provider/provider.go
@@ -37,13 +37,18 @@ func RunAll(ctx context.Context, p provider.Provider, rulesets map[string]rulese
 	log.Info("starting provider run", "number_of_rulesets", len(rulesets))
 	finishMsg := "finished ruleset run"
 	for _, rs := range rulesets {
-		log.Info("starting ruleset run", "ruleset", rs.ID(), "version", rs.Version())
-		if res, err := rs.Run(ctx); err != nil {
-			errAgg = errors.Join(errAgg, fmt.Errorf("ruleset with id %s and version %s errored: %w", res.RulesetID, res.RulesetVersion, err))
-			log.Error(finishMsg, "ruleset", rs.ID(), "version", rs.Version(), "error", err)
-		} else {
-			result.RulesetResults = append(result.RulesetResults, res)
-			log.Info(finishMsg, "ruleset", rs.ID(), "version", rs.Version())
+		select {
+		default:
+			log.Info("starting ruleset run", "ruleset", rs.ID(), "version", rs.Version())
+			if res, err := rs.Run(ctx); err != nil {
+				errAgg = errors.Join(errAgg, fmt.Errorf("ruleset with id %s and version %s errored: %w", res.RulesetID, res.RulesetVersion, err))
+				log.Error(finishMsg, "ruleset", rs.ID(), "version", rs.Version(), "error", err)
+			} else {
+				result.RulesetResults = append(result.RulesetResults, res)
+				log.Info(finishMsg, "ruleset", rs.ID(), "version", rs.Version())
+			}
+		case <-ctx.Done():
+			return provider.ProviderResult{}, ctx.Err()
 		}
 	}
 	log.Info("finished provider run")

--- a/pkg/shared/ruleset/disak8sstig/rules/242393.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242393.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -103,7 +104,10 @@ func (r *Rule242393) Run(ctx context.Context) (rule.RuleResult, error) {
 		nodeTarget := rule.NewTarget("kind", "node", "name", node.Name)
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242394.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242394.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -103,7 +104,10 @@ func (r *Rule242394) Run(ctx context.Context) (rule.RuleResult, error) {
 		nodeTarget := rule.NewTarget("kind", "node", "name", node.Name)
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242396.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242396.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -128,7 +129,10 @@ func (r *Rule242396) checkKubectl(
 	)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242404.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242404.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -104,7 +105,10 @@ func (r *Rule242404) checkNode(ctx context.Context, node corev1.Node, privPodIma
 	podTarget := rule.NewTarget("kind", "pod", "namespace", "kube-system", "name", podName)
 
 	defer func() {
-		if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger.Error(err.Error())
 		}
 	}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242406.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242406.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -114,7 +115,10 @@ func (r *Rule242406) Run(ctx context.Context) (rule.RuleResult, error) {
 		podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242407.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242407.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -98,7 +99,10 @@ func (r *Rule242407) Run(ctx context.Context) (rule.RuleResult, error) {
 		podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242445.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242445.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,7 +172,10 @@ func (r *Rule242445) Run(ctx context.Context) (rule.RuleResult, error) {
 		execPodTarget := target.With("name", podName, "namespace", "kube-system", "kind", "pod")
 
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242446.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242446.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,7 +117,10 @@ func (r *Rule242446) Run(ctx context.Context) (rule.RuleResult, error) {
 		execPodTarget := target.With("name", podName, "namespace", "kube-system", "kind", "pod")
 
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,7 +109,10 @@ func (r *Rule242447) Run(ctx context.Context) (rule.RuleResult, error) {
 		execPodTarget := target.With("name", podName, "namespace", "kube-system", "kind", "pod")
 
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,7 +126,10 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 		execPodTarget := target.With("name", podName, "namespace", "kube-system", "kind", "pod")
 
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242449.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242449.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -98,7 +99,10 @@ func (r *Rule242449) Run(ctx context.Context) (rule.RuleResult, error) {
 		podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242450.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242450.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -114,7 +115,10 @@ func (r *Rule242450) Run(ctx context.Context) (rule.RuleResult, error) {
 		podName := fmt.Sprintf("diki-%s-%s", r.ID(), Generator.Generate(10))
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242452.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242452.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -99,7 +100,10 @@ func (r *Rule242452) Run(ctx context.Context) (rule.RuleResult, error) {
 		nodeTarget := rule.NewTarget("kind", "node", "name", node.Name)
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242453.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242453.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -116,7 +117,10 @@ func (r *Rule242453) Run(ctx context.Context) (rule.RuleResult, error) {
 		nodeTarget := rule.NewTarget("kind", "node", "name", node.Name)
 		execPodTarget := rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,7 +158,10 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 		execPodTarget := target.With("name", podName, "namespace", "kube-system", "kind", "pod")
 
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/disak8sstig/rules/242460.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242460.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,7 +105,10 @@ func (r *Rule242460) Run(ctx context.Context) (rule.RuleResult, error) {
 		execPodTarget := target.With("name", podName, "namespace", "kube-system", "kind", "pod")
 
 		defer func() {
-			if err := r.PodContext.Delete(ctx, podName, "kube-system"); err != nil {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 				r.Logger.Error(err.Error())
 			}
 		}()

--- a/pkg/shared/ruleset/ruleset.go
+++ b/pkg/shared/ruleset/ruleset.go
@@ -85,7 +85,6 @@ func Run(
 	}()
 
 	var err error
-
 	resultCount := 0
 	for run := range resultCh {
 		resultCount++


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a graceful shutdown when Dikl receives a SIGINT or SIGTERM signal by refactoring the tool's process management. With the new changes, a cancellable context is used for the execution of the rule check, thereby adding an additional layer for managing the terminating signals. 
If the context is cancelled during the execution of a ruleset, it terminates all goroutines after their corresponding rule's execution ends, and returns an error value. Additionally, a similar mechanism has been added when the parent process iterates through a provider's registered rulesets.
The deferred pod deletion functions in the rules that utilize them, use an independent context, which triggers a 30 second timeout after the function is called. That way, the deletion will be uninterrupted by the SIGINT/SIGTERM signal.

**Which issue(s) this PR fixes**:
Fixes #285 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Diki can now shutdown gracefully when interrupted.
```
