### PR TITLE
[Security Hardened Shoot Cluster] Rule 1000 check Shoot labels

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
@@ -78,25 +78,23 @@ func (r *Rule1000) Run(ctx context.Context) (rule.RuleResult, error) {
 	var checkResults []rule.CheckResult
 
 	for _, extension := range r.Options.Extensions {
-		extensionTypeIndex := slices.IndexFunc(shoot.Spec.Extensions, func(shootSpecExtension gardencorev1beta1.Extension) bool {
-			return shootSpecExtension.Type == extension.Type
-		})
-
 		var (
-			extensionTypeDisabled       = extensionTypeIndex >= 0 && shoot.Spec.Extensions[extensionTypeIndex].Disabled != nil && *shoot.Spec.Extensions[extensionTypeIndex].Disabled
-			extensionTypeLabelKey       = fmt.Sprintf("extensions.extensions.gardener.cloud/%s", extension.Type)
-			extensionTypeLabelValue, ok = shoot.Labels[extensionTypeLabelKey]
+			extensionIndex = slices.IndexFunc(shoot.Spec.Extensions, func(shootSpecExtension gardencorev1beta1.Extension) bool {
+				return shootSpecExtension.Type == extension.Type
+			})
+			extensionDisabled                         = extensionIndex >= 0 && shoot.Spec.Extensions[extensionIndex].Disabled != nil && *shoot.Spec.Extensions[extensionIndex].Disabled
+			extensionLabelValue, extensionLabelExists = shoot.Labels["extensions.extensions.gardener.cloud/"+extension.Type]
 		)
 
 		switch {
-		case !ok:
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Extension type %s is not configured for the shoot cluster.", extension.Type), rule.NewTarget()))
-		case extensionTypeLabelValue == "true" && !extensionTypeDisabled:
-			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Extension type %s is enabled for the shoot cluster.", extension.Type), rule.NewTarget()))
-		case extensionTypeLabelValue == "true" && extensionTypeDisabled:
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Extension type %s is disabled is the shoot spec and enabled in labels.", extension.Type), rule.NewTarget()))
+		case !extensionLabelExists:
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Extension %s is not configured for the shoot cluster.", extension.Type), rule.NewTarget()))
+		case extensionLabelValue == "true" && !extensionDisabled:
+			checkResults = append(checkResults, rule.PassedCheckResult(fmt.Sprintf("Extension %s is enabled for the shoot cluster.", extension.Type), rule.NewTarget()))
+		case extensionLabelValue == "true" && extensionDisabled:
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Extension %s is disabled in the shoot spec and enabled in labels.", extension.Type), rule.NewTarget()))
 		default:
-			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Extension type %s has unexpected label value: %s.", extension.Type, extensionTypeLabelValue), rule.NewTarget()))
+			checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Extension %s has unexpected label value: %s.", extension.Type, extensionLabelValue), rule.NewTarget()))
 		}
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
@@ -96,7 +96,7 @@ var _ = Describe("#1000", func() {
 			},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Extension type foo is not configured for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "Extension foo is not configured for the shoot cluster.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should pass when a listed extension is enabled by default",
@@ -112,7 +112,7 @@ var _ = Describe("#1000", func() {
 			},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "Extension type foo is enabled for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "Extension foo is enabled for the shoot cluster.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should pass when a listed extension is added to the extension list in the shoot spec",
@@ -133,7 +133,7 @@ var _ = Describe("#1000", func() {
 			},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "Extension type foo is enabled for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "Extension foo is enabled for the shoot cluster.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should pass when a listed extension is added to the extension list in the shoot spec and explicitly enabled",
@@ -155,7 +155,7 @@ var _ = Describe("#1000", func() {
 			},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "Extension type foo is enabled for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "Extension foo is enabled for the shoot cluster.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should fail when a listed extension is enabled in the shoot labels and disabled in the shoot spec",
@@ -177,7 +177,7 @@ var _ = Describe("#1000", func() {
 			},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Extension type foo is disabled is the shoot spec and enabled in labels.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "Extension foo is disabled in the shoot spec and enabled in labels.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should fail when a listed extension has unecpected value in the shoot labels",
@@ -198,7 +198,7 @@ var _ = Describe("#1000", func() {
 			},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Extension type foo has unexpected label value: false.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "Extension foo has unexpected label value: false.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should create a check result for each provided extension in the configuration",
@@ -237,10 +237,10 @@ var _ = Describe("#1000", func() {
 			},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Passed, Message: "Extension type one is enabled for the shoot cluster.", Target: rule.NewTarget()},
-				{Status: rule.Passed, Message: "Extension type two is enabled for the shoot cluster.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "Extension type three is not configured for the shoot cluster.", Target: rule.NewTarget()},
-				{Status: rule.Failed, Message: "Extension type four is not configured for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "Extension one is enabled for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "Extension two is enabled for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "Extension three is not configured for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Failed, Message: "Extension four is not configured for the shoot cluster.", Target: rule.NewTarget()},
 			},
 		),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the implementation of rule 1000 by also checking the shoot labels if the extension type is enabled there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
