### PR TITLE
Fix `GetDeploymentPods` utils function when pod does not have `OwnerReference`

### DIFF
--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -262,7 +262,7 @@ func GetDeploymentPods(ctx context.Context, c client.Client, name, namespace str
 		ownerRef := replicaSet.OwnerReferences[0]
 		if ownerRef.UID == deployment.UID && ownerRef.Kind == "Deployment" && (replicaSet.Spec.Replicas == nil || *replicaSet.Spec.Replicas > 0) {
 			for _, pod := range allPods {
-				if pod.OwnerReferences[0].UID == replicaSet.UID {
+				if len(pod.OwnerReferences) > 0 && pod.OwnerReferences[0].UID == replicaSet.UID {
 					pods = append(pods, pod)
 				}
 			}

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -987,12 +987,15 @@ var _ = Describe("utils", func() {
 					Kind: "ReplicaSet",
 				},
 			}
+			pod4 := basicPod.DeepCopy()
+			pod4.Name = "foo4"
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 			Expect(fakeClient.Create(ctx, replicaSet1)).To(Succeed())
 			Expect(fakeClient.Create(ctx, replicaSet2)).To(Succeed())
 			Expect(fakeClient.Create(ctx, pod1)).To(Succeed())
 			Expect(fakeClient.Create(ctx, pod2)).To(Succeed())
 			Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
+			Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
 			pods, err := utils.GetDeploymentPods(ctx, fakeClient, "foo", namespace)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing some rules to error when they encounter a `Pod` without an `OwnerReference` has been fixed.
```
