### PR TITLE
Add a wildcard option for volumes contained in AcceptedPods for Rules 2003 and 2008

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -197,6 +197,13 @@ providers:                   # contains information about known providers
     #       volumeNames:
     #       - "volume-a"
     #       - "volume-b"
+    #     - matchLabels:
+    #         foo: baz
+    #       namespaceMatchLabels:
+    #         foo: baz
+    #       justification: "justification"
+    #       volumeNames:
+    #       - "*" # a wildcard can be used to match against all volumes in an accepted pod
     # - ruleID: "2004"
     #   args:
     #     acceptedServices:
@@ -244,6 +251,13 @@ providers:                   # contains information about known providers
     #       volumeNames:
     #       - "volume-a"
     #       - "volume-b"
+    #     - matchLabels:
+    #         foo: baz
+    #       namespaceMatchLabels:
+    #         foo: baz
+    #       justification: "justification"
+    #       volumeNames:
+    #       - "*" # a wildcard can be used to match against all volumes in an accepted pod
 # metadata: # optional, additional metadata to be added to summary json report
 #   foo: bar
 #   bar:

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -120,7 +120,7 @@ func (r *Rule2003) accepted(volume corev1.Volume, pod corev1.Pod, namespace core
 
 	for _, acceptedPod := range r.Options.AcceptedPods {
 		if utils.MatchLabels(pod.Labels, acceptedPod.MatchLabels) && utils.MatchLabels(namespace.Labels, acceptedPod.NamespaceMatchLabels) {
-			if slices.Contains(acceptedPod.VolumeNames, volume.Name) {
+			if slices.Contains(acceptedPod.VolumeNames, "*") || slices.Contains(acceptedPod.VolumeNames, volume.Name) {
 				return true, acceptedPod.Justification
 			}
 		}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -120,7 +120,7 @@ func (r *Rule2008) accepted(pod corev1.Pod, namespace corev1.Namespace, volumeNa
 	for _, acceptedPod := range r.Options.AcceptedPods {
 		if utils.MatchLabels(pod.Labels, acceptedPod.MatchLabels) &&
 			utils.MatchLabels(namespace.Labels, acceptedPod.NamespaceMatchLabels) {
-			if slices.Contains(acceptedPod.VolumeNames, volumeName) {
+			if slices.Contains(acceptedPod.VolumeNames, "*") || slices.Contains(acceptedPod.VolumeNames, volumeName) {
 				return true, acceptedPod.Justification
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains a modification to the acceptedResources handling in Rules 2003 and 2008 of the Security Hardened Kubernetes Ruleset by adding the option to accept all volumes in an accepted pod by using a wildcard. 

**Which issue(s) this PR fixes**:
Fixes #407 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Accepted volume names for rules 2003 and 2008 of the Security Hardened Kubernetes Ruleset can be generalized by using a wildcard in the configuration.
```
