### PR TITLE
Add a minimal status option to the report generating command

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -22,6 +23,7 @@ import (
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/provider"
 	"github.com/gardener/diki/pkg/report"
+	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
 )
 
@@ -144,6 +146,7 @@ func addRunFlags(cmd *cobra.Command, opts *runOptions) {
 func addReportGenerateFlags(cmd *cobra.Command, opts *generateOptions) {
 	cmd.PersistentFlags().Var(cliflag.NewMapStringString(&opts.distinctBy), "distinct-by", "If set generates a merged report. The keys are the IDs for the providers which the merged report will include and the values are distinct metadata attributes to be used as IDs for the different reports.")
 	cmd.PersistentFlags().StringVar(&opts.format, "format", "html", "Format for the output report. Format can be one of 'html' or 'json'.")
+	cmd.PersistentFlags().StringVar(&opts.minStatus, "min-status", "Passed", "If set specifies the minimal status that will be included in the generated report. Status can be one of 'Passed', 'Skipped', 'Accepted', 'Warning', 'Failed', 'Errored' or 'NotImplemented'")
 }
 
 func addReportDiffFlags(cmd *cobra.Command, opts *diffOptions) {
@@ -263,6 +266,17 @@ func generateCmd(args []string, rootOpts reportOptions, opts generateOptions, lo
 		return errors.New("generate command requires a single filepath argument when the distinct-by flag is not set")
 	}
 
+	var minStatus rule.Status
+
+	if len(opts.minStatus) == 0 {
+		minStatus = rule.Passed
+	} else {
+		minStatus = rule.Status(opts.minStatus)
+		if !slices.Contains(rule.Statuses(), minStatus) {
+			return fmt.Errorf("status %s is not defined", minStatus)
+		}
+	}
+
 	var reports []*report.Report
 	for _, arg := range args {
 		fileData, err := os.ReadFile(filepath.Clean(arg))
@@ -276,6 +290,7 @@ func generateCmd(args []string, rootOpts reportOptions, opts generateOptions, lo
 			return fmt.Errorf("failed to unmarshal data: %w", err)
 		}
 
+		rep.DiscardCheckResultsBelowMinStatus(minStatus)
 		reports = append(reports, rep)
 	}
 
@@ -455,6 +470,7 @@ type runOptions struct {
 type generateOptions struct {
 	distinctBy map[string]string
 	format     string
+	minStatus  string
 }
 
 type generateDiffOptions struct {

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -146,7 +146,7 @@ func addRunFlags(cmd *cobra.Command, opts *runOptions) {
 func addReportGenerateFlags(cmd *cobra.Command, opts *generateOptions) {
 	cmd.PersistentFlags().Var(cliflag.NewMapStringString(&opts.distinctBy), "distinct-by", "If set generates a merged report. The keys are the IDs for the providers which the merged report will include and the values are distinct metadata attributes to be used as IDs for the different reports.")
 	cmd.PersistentFlags().StringVar(&opts.format, "format", "html", "Format for the output report. Format can be one of 'html' or 'json'.")
-	cmd.PersistentFlags().StringVar(&opts.minStatus, "min-status", "Passed", "If set specifies the minimal status that will be included in the generated report. Status can be one of 'Passed', 'Skipped', 'Accepted', 'Warning', 'Failed', 'Errored' or 'NotImplemented'")
+	cmd.PersistentFlags().StringVar(&opts.minStatus, "min-status", "Passed", "If set specifies the minimal status that will be included in the generated report. Ordered from lowest to highest priority, Status can be one of 'Passed', 'Skipped', 'Accepted', 'Warning', 'Failed', 'Errored' or 'NotImplemented'")
 }
 
 func addReportDiffFlags(cmd *cobra.Command, opts *diffOptions) {

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -266,14 +266,11 @@ func generateCmd(args []string, rootOpts reportOptions, opts generateOptions, lo
 		return errors.New("generate command requires a single filepath argument when the distinct-by flag is not set")
 	}
 
-	var minStatus rule.Status
-
-	if len(opts.minStatus) == 0 {
-		minStatus = rule.Passed
-	} else {
+	minStatus := rule.Passed
+	if len(opts.minStatus) != 0 {
 		minStatus = rule.Status(opts.minStatus)
 		if !slices.Contains(rule.Statuses(), minStatus) {
-			return fmt.Errorf("status %s is not defined", minStatus)
+			return fmt.Errorf("not defined status: %s", minStatus)
 		}
 	}
 
@@ -290,7 +287,7 @@ func generateCmd(args []string, rootOpts reportOptions, opts generateOptions, lo
 			return fmt.Errorf("failed to unmarshal data: %w", err)
 		}
 
-		rep.DiscardCheckResultsBelowMinStatus(minStatus)
+		rep.SetMinStatus(minStatus)
 		reports = append(reports, rep)
 	}
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -125,6 +125,26 @@ func (r *Report) WriteToFile(filePath string) error {
 	return os.WriteFile(filePath, data, 0600)
 }
 
+// SetMinStatus sets minStatus of the report. It also removes all checks with status less than the specified one.
+// If the new minStatus is less that the original one, nothing is changed.
+func (r *Report) SetMinStatus(minStatus rule.Status) {
+	if minStatus.Less(r.MinStatus) {
+		return
+	}
+
+	r.MinStatus = minStatus
+	for _, provider := range r.Providers {
+		for _, ruleset := range provider.Rulesets {
+			for ruleIdx := range ruleset.Rules {
+				filteredChecks := slices.DeleteFunc(ruleset.Rules[ruleIdx].Checks, func(check Check) bool {
+					return check.Status.Less(minStatus)
+				})
+				ruleset.Rules[ruleIdx].Checks = filteredChecks
+			}
+		}
+	}
+}
+
 // rulesetSummaryText returns a summary string with the number of rules with results per status.
 func rulesetSummaryText(ruleset *Ruleset) string {
 	statuses := rule.Statuses()
@@ -239,24 +259,4 @@ func getChecks(checkResults []rule.CheckResult, opts *ReportOptions) []Check {
 		checks = append(checks, *check)
 	}
 	return checks
-}
-
-// SetMinStatus sets minStatus of the report. It also removes all checks with status less than the specified one.
-// If the new minStatus is less that the original one, nothing is changed.
-func (r *Report) SetMinStatus(minStatus rule.Status) {
-	if minStatus.Less(r.MinStatus) {
-		return
-	}
-
-	r.MinStatus = minStatus
-	for _, provider := range r.Providers {
-		for _, ruleset := range provider.Rulesets {
-			for ruleIdx := range ruleset.Rules {
-				filteredChecks := slices.DeleteFunc(ruleset.Rules[ruleIdx].Checks, func(check Check) bool {
-					return check.Status.Less(minStatus)
-				})
-				ruleset.Rules[ruleIdx].Checks = filteredChecks
-			}
-		}
-	}
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -241,19 +241,16 @@ func getChecks(checkResults []rule.CheckResult, opts *ReportOptions) []Check {
 	return checks
 }
 
-// DiscardCheckResultsBelowMinStatus removes all checks of the report, whose statuses are lower than the specified one.
-func (r *Report) DiscardCheckResultsBelowMinStatus(minStatus rule.Status) {
+// SetMinStatus sets minStatus of the report. It also removes all checks with status less than the specified one.
+// If the new minStatus is less that the original one, nothing is changed.
+func (r *Report) SetMinStatus(minStatus rule.Status) {
 	if minStatus.Less(r.MinStatus) {
 		return
 	}
 
 	r.MinStatus = minStatus
-	for providerIdx := range r.Providers {
-
-		var provider = r.Providers[providerIdx]
-		for rulesetIdx := range provider.Rulesets {
-
-			var ruleset = provider.Rulesets[rulesetIdx]
+	for _, provider := range r.Providers {
+		for _, ruleset := range provider.Rulesets {
 			for ruleIdx := range ruleset.Rules {
 				filteredChecks := slices.DeleteFunc(ruleset.Rules[ruleIdx].Checks, func(check Check) bool {
 					return check.Status.Less(minStatus)

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -241,7 +241,7 @@ func getChecks(checkResults []rule.CheckResult, opts *ReportOptions) []Check {
 	return checks
 }
 
-// DiscardCheckResultsBelowMinStatus removes all of the report's checks which have a lower status than the minimal one
+// DiscardCheckResultsBelowMinStatus removes all checks of the report, whose statuses are lower than the specified one.
 func (r *Report) DiscardCheckResultsBelowMinStatus(minStatus rule.Status) {
 	if minStatus.Less(r.MinStatus) {
 		return

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -126,7 +126,7 @@ func (r *Report) WriteToFile(filePath string) error {
 }
 
 // SetMinStatus sets minStatus of the report. It also removes all checks with status less than the specified one.
-// If the new minStatus is less that the original one, nothing is changed.
+// If the new minStatus is less than the original one, nothing is changed.
 func (r *Report) SetMinStatus(minStatus rule.Status) {
 	if minStatus.Less(r.MinStatus) {
 		return

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -161,13 +161,13 @@ var _ = Describe("report", func() {
 					},
 				},
 			}
-			simpleReport.DiscardCheckResultsBelowMinStatus(rule.Failed)
+			simpleReport.SetMinStatus(rule.Failed)
 			Expect(simpleReport).To(Equal(expectedReportResult))
 		})
 
 		It("should not alter the report when the passed minStatus is not lower the report's minStatus", func() {
 			expectedReport := simpleReport
-			simpleReport.DiscardCheckResultsBelowMinStatus(rule.Passed)
+			simpleReport.SetMinStatus(rule.Passed)
 			Expect(simpleReport).To(Equal(expectedReport))
 		})
 	})

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package report_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/diki/pkg/report"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("report", func() {
+	Describe("Report", func() {
+		var (
+			reportTime     time.Time
+			providerID     = "provider-foo"
+			providerName   = "Provider Foo"
+			rulesetID      = "ruleset-foo"
+			rulesetName    = "Ruleset Foo"
+			rulesetVersion = "v1"
+			simpleReport   report.Report
+		)
+		BeforeEach(func() {
+			reportTime = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.Local)
+			simpleReport = report.Report{
+				Time:        reportTime,
+				DikiVersion: "1",
+				MinStatus:   rule.Accepted,
+				Providers: []report.Provider{
+					{
+						ID:   providerID,
+						Name: providerName,
+						Rulesets: []report.Ruleset{
+							{
+								ID:      rulesetID,
+								Name:    rulesetName,
+								Version: rulesetVersion,
+								Rules: []report.Rule{
+									{
+										ID:       "1",
+										Name:     "1",
+										Severity: rule.SeverityHigh,
+										Checks: []report.Check{
+											{
+												Status:  "Accepted",
+												Message: "foo",
+												Targets: []rule.Target{},
+											},
+											{
+												Status:  "Failed",
+												Message: "bar",
+												Targets: []rule.Target{},
+											},
+											{
+												Status:  "Skipped",
+												Message: "baz",
+												Targets: []rule.Target{},
+											},
+										},
+									},
+									{
+										ID:       "2",
+										Name:     "2",
+										Severity: rule.SeverityLow,
+										Checks: []report.Check{
+											{
+												Status:  "Accepted",
+												Message: "foo",
+												Targets: []rule.Target{},
+											},
+											{
+												Status:  "Accepted",
+												Message: "bar",
+												Targets: []rule.Target{},
+											},
+										},
+									},
+									{
+										ID:       "3",
+										Name:     "3",
+										Severity: rule.SeverityLow,
+										Checks: []report.Check{
+											{
+												Status:  "Failed",
+												Message: "foo",
+												Targets: []rule.Target{},
+											},
+											{
+												Status:  "Failed",
+												Message: "bar",
+												Targets: []rule.Target{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should correctly remove ruleset checks that are below the minStatus", func() {
+			expectedReportResult := report.Report{
+				Time:        reportTime,
+				DikiVersion: "1",
+				MinStatus:   rule.Failed,
+				Providers: []report.Provider{
+					{
+						ID:   providerID,
+						Name: providerName,
+						Rulesets: []report.Ruleset{
+							{
+								ID:      rulesetID,
+								Name:    rulesetName,
+								Version: rulesetVersion,
+								Rules: []report.Rule{
+									{
+										ID:       "1",
+										Name:     "1",
+										Severity: rule.SeverityHigh,
+										Checks: []report.Check{
+											{
+												Status:  "Failed",
+												Message: "bar",
+												Targets: []rule.Target{},
+											},
+										},
+									},
+									{
+										ID:       "2",
+										Name:     "2",
+										Severity: rule.SeverityLow,
+										Checks:   []report.Check{},
+									},
+									{
+										ID:       "3",
+										Name:     "3",
+										Severity: rule.SeverityLow,
+										Checks: []report.Check{
+											{
+												Status:  "Failed",
+												Message: "foo",
+												Targets: []rule.Target{},
+											},
+											{
+												Status:  "Failed",
+												Message: "bar",
+												Targets: []rule.Target{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			simpleReport.DiscardCheckResultsBelowMinStatus(rule.Failed)
+			Expect(simpleReport).To(Equal(expectedReportResult))
+		})
+
+		It("should not alter the report when the passed minStatus is not lower the report's minStatus", func() {
+			expectedReport := simpleReport
+			simpleReport.DiscardCheckResultsBelowMinStatus(rule.Passed)
+			Expect(simpleReport).To(Equal(expectedReport))
+		})
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an additional flag to the diki report generate command that specifies the minimal status of the checks that should be included in the rendered report. This flag only discards check results that have a higher status when generating a regular or merged report.

**Which issue(s) this PR fixes**:
Fixes #378 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`diki report generate` now has a --min-status flag that discards check results with a higher status than the argument.
```
