### PR TITLE
[Security Hardened Kubernetes Cluster] Rule 2000 add rule options

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -184,8 +184,8 @@ providers:                   # contains information about known providers
     #         foo: bar
     #       justification: "justification"
     #       acceptedTraffic:
-    #         Ingress: true
-    #         Egress: true
+    #         ingress: true
+    #         egress: true
     # - ruleID: "2001"
     #   args:
     #     acceptedPods:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -178,6 +178,14 @@ providers:                   # contains information about known providers
     #   skip:
     #     enabled: true
     #     justification: "the whole rule is accepted for ... reasons"
+    #   args:
+    #     acceptedNamespaces:
+    #     - matchLabels:
+    #         foo: bar
+    #       justification: "justification"
+    #       acceptedTraffic:
+    #         Ingress: true
+    #         Egress: true
     # - ruleID: "2001"
     #   args:
     #     acceptedPods:

--- a/example/guides/security-hardened-k8s-shoot.yaml
+++ b/example/guides/security-hardened-k8s-shoot.yaml
@@ -15,10 +15,10 @@ providers:
         acceptedNamespaces:
         - matchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Gardener managed namespaces are accpeted to allow traffic by default"
-          accpetedTraffic:
-            Ingress: true
-            Egress: true
+          justification: "Gardener managed namespaces are accepted to allow traffic by default"
+          acceptedTraffic:
+            ingress: true
+            egress: true
     - ruleID: "2001"
       args:
         acceptedPods:

--- a/example/guides/security-hardened-k8s-shoot.yaml
+++ b/example/guides/security-hardened-k8s-shoot.yaml
@@ -10,6 +10,23 @@ providers:
     name: Security Hardened Kubernetes Cluster
     version: v0.1.0
     ruleOptions:
+    - ruleID: "2000"
+      args:
+        acceptedNamespaces:
+        - matchLabels:
+            resources.gardener.cloud/managed-by: gardener
+          justification: "Gardener managed namespaces are accpeted to allow traffic by default"
+          accpetedTraffic:
+            Ingress: true
+            Egress: true
+    - ruleID: "2001"
+      args:
+        acceptedPods:
+        - matchLabels:
+            resources.gardener.cloud/managed-by: gardener
+          namespaceMatchLabels:
+            resources.gardener.cloud/managed-by: gardener
+          justification: "Gardener managed resources are accepted to allow privilege escalation"
     - ruleID: "2003"
       args:
         acceptedPods:

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -110,13 +110,18 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 		} else {
 			accepted, justification := r.acceptedIngress(namespace)
 
+			acceptedTarget := target
 			msg := "Namespace is accepted to allow Ingress traffic by default."
 			if len(justification) > 0 {
 				msg = justification
+				// We cannot guarantee that the user has specified in his justification the
+				// accepted traffic type. To avoid confusion and duplication of checkResults
+				// we specify the traffic type in the target details only for this case.
+				acceptedTarget = target.With("details", "traffic: ingress")
 			}
 
 			if accepted {
-				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, deniesIngressTarget))
+				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, acceptedTarget))
 			} else {
 				checkResults = append(checkResults, rule.FailedCheckResult("Ingress traffic is not denied by default.", target))
 			}
@@ -127,15 +132,18 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 		} else {
 			accepted, justification := r.acceptedEgress(namespace)
 
+			acceptedTarget := target
 			msg := "Namespace is accepted to allow Egress traffic by default."
 			if len(justification) > 0 {
 				msg = justification
+				// We cannot guarantee that the user has specified in his justification the
+				// accepted traffic type. To avoid confusion and duplication of checkResults
+				// we specify the traffic type in the target details only for this case.
+				acceptedTarget = target.With("details", "traffic: egress")
 			}
 
 			if accepted {
-				if len(checkResults) == 0 || checkResults[len(checkResults)-1].Message != msg {
-					checkResults = append(checkResults, rule.AcceptedCheckResult(msg, deniesEgressTarget))
-				}
+				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, acceptedTarget))
 			} else {
 				checkResults = append(checkResults, rule.FailedCheckResult("Egress traffic is not denied by default.", target))
 			}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -217,7 +217,12 @@ var _ = Describe("#2000", func() {
 			{
 				Status:  rule.Accepted,
 				Message: "justification foo",
-				Target:  rule.NewTarget("namespace", "kube-foo"),
+				Target:  rule.NewTarget("namespace", "kube-foo", "details", "traffic: egress"),
+			},
+			{
+				Status:  rule.Accepted,
+				Message: "justification foo",
+				Target:  rule.NewTarget("namespace", "kube-foo", "details", "traffic: ingress"),
 			},
 		}
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
@@ -5,7 +5,8 @@
 package rules
 
 type RuleOption interface {
-	Options2001 |
+	Options2000 |
+		Options2001 |
 		Options2003 |
 		Options2004 |
 		Options2005 |

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
@@ -22,6 +22,10 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 		return err
 	}
 
+	opts2000, err := getV01OptionOrNil[rules.Options2000](ruleOptions["2000"].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 2000 error: %s", err.Error())
+	}
 	opts2001, err := getV01OptionOrNil[rules.Options2001](ruleOptions["2001"].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 2001 error: %s", err.Error())
@@ -53,7 +57,8 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 
 	rules := []rule.Rule{
 		&rules.Rule2000{
-			Client: c,
+			Client:  c,
+			Options: opts2000,
 		},
 		&rules.Rule2001{
 			Client:  c,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds rule options to Rule `2000` from the `security-hardened-k8s`. The rule options allow specific namespaces to be accepted to have `Ingress` and/or `Egress` traffic allowed by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Rule options have been added to Rule `2000` from the `security-hardened-k8s`.
```
