### PR TITLE
Refactor rules that check `Pod` containers to also check containers in `initContainers`

### DIFF
--- a/docs/rulesets/security-hardened-k8s/ruleset.md
+++ b/docs/rulesets/security-hardened-k8s/ruleset.md
@@ -52,6 +52,10 @@ spec:
   - name: ...
     securityContext:
       allowPrivilegeEscalation: false
+  initContainers:
+  - name: ...
+    securityContext:
+      allowPrivilegeEscalation: false
 ```
 ---
 

--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -188,7 +188,7 @@ func GetContainerID(pod corev1.Pod, containerNames ...string) (string, error) {
 			if initContainerStatusIdx < 0 {
 				continue
 			}
-			containerID = pod.Status.ContainerStatuses[initContainerStatusIdx].ContainerID
+			containerID = pod.Status.InitContainerStatuses[initContainerStatusIdx].ContainerID
 		} else {
 			containerID = pod.Status.ContainerStatuses[containerStatusIdx].ContainerID
 		}

--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -137,19 +137,28 @@ func GetMountedFilesStats(
 	var err error
 
 	for _, container := range pod.Spec.Containers {
-
-		baseContainerID, err2 := GetContainerID(pod, container.Name)
-		if err2 != nil {
-			err = errors.Join(err, err2)
-			continue
-		}
-
 		containerStats, err2 := getContainerMountedFileStatResults(ctx,
 			podExecutorRootPath,
 			podExecutor,
 			pod,
-			container.Name,
-			baseContainerID,
+			container,
+			excludeSources,
+		)
+		if err2 != nil {
+			err = errors.Join(err, err2)
+		}
+
+		if len(containerStats) > 0 {
+			stats[container.Name] = containerStats
+		}
+	}
+
+	for _, container := range pod.Spec.InitContainers {
+		containerStats, err2 := getContainerMountedFileStatResults(ctx,
+			podExecutorRootPath,
+			podExecutor,
+			pod,
+			container,
 			excludeSources,
 		)
 		if err2 != nil {
@@ -171,10 +180,18 @@ func GetContainerID(pod corev1.Pod, containerNames ...string) (string, error) {
 			return containerStatus.Name == containerName
 		})
 
+		var containerID string
 		if containerStatusIdx < 0 {
-			continue
+			initContainerStatusIdx := slices.IndexFunc(pod.Status.InitContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+				return containerStatus.Name == containerName
+			})
+			if initContainerStatusIdx < 0 {
+				continue
+			}
+			containerID = pod.Status.ContainerStatuses[initContainerStatusIdx].ContainerID
+		} else {
+			containerID = pod.Status.ContainerStatuses[containerStatusIdx].ContainerID
 		}
-		containerID := pod.Status.ContainerStatuses[containerStatusIdx].ContainerID
 
 		switch {
 		case len(containerID) == 0:
@@ -214,13 +231,18 @@ func getContainerMountedFileStatResults(
 	podExecutorRootPath string,
 	podExecutor pod.PodExecutor,
 	pod corev1.Pod,
-	containerName, containerID string,
+	container corev1.Container,
 	excludedSources []string,
 ) ([]FileStats, error) {
 	var (
 		stats []FileStats
 		err   error
 	)
+
+	containerID, err := GetContainerID(pod, container.Name)
+	if err != nil {
+		return stats, err
+	}
 
 	mounts, err := GetContainerMounts(ctx, podExecutorRootPath, podExecutor, containerID)
 	if err != nil {
@@ -230,8 +252,8 @@ func getContainerMountedFileStatResults(
 
 	for _, mount := range mounts {
 		if strings.HasPrefix(mount.Source, "/") &&
-			!matchHostPathSources(excludedSourcesSet, mount.Destination, containerName, &pod) &&
-			isMountRequiredByContainer(mount.Destination, containerName, &pod) &&
+			!matchHostPathSources(excludedSourcesSet, mount.Destination, container, pod) &&
+			isMountRequiredByContainer(mount.Destination, container) &&
 			mount.Destination != "/dev/termination-log" {
 			mountFileStats, err2 := GetFileStatsByDir(ctx, podExecutor, mount.Source)
 			if err2 != nil {
@@ -244,46 +266,36 @@ func getContainerMountedFileStatResults(
 	return stats, err
 }
 
-func isMountRequiredByContainer(destination, containerName string, pod *corev1.Pod) bool {
-	for _, container := range pod.Spec.Containers {
-		if container.Name != containerName {
-			continue
-		}
-		if containsDestination := slices.ContainsFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
-			return volumeMount.MountPath == destination
-		}); containsDestination {
-			return true
-		}
+func isMountRequiredByContainer(destination string, container corev1.Container) bool {
+	if containsDestination := slices.ContainsFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+		return volumeMount.MountPath == destination
+	}); containsDestination {
+		return true
 	}
+
 	return false
 }
 
-func matchHostPathSources(sources sets.Set[string], destination, containerName string, pod *corev1.Pod) bool {
-	for _, container := range pod.Spec.Containers {
-		if container.Name != containerName {
-			continue
-		}
-		volumeMountIdx := slices.IndexFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
-			return volumeMount.MountPath == destination
-		})
+func matchHostPathSources(sources sets.Set[string], destination string, container corev1.Container, pod corev1.Pod) bool {
+	volumeMountIdx := slices.IndexFunc(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+		return volumeMount.MountPath == destination
+	})
 
-		if volumeMountIdx < 0 {
-			return false
-		}
-
-		volumeIdx := slices.IndexFunc(pod.Spec.Volumes, func(volume corev1.Volume) bool {
-			return volume.Name == container.VolumeMounts[volumeMountIdx].Name
-		})
-
-		if volumeIdx < 0 {
-			return false
-		}
-
-		volume := pod.Spec.Volumes[volumeIdx]
-
-		return volume.HostPath != nil && sources.Has(volume.HostPath.Path)
+	if volumeMountIdx < 0 {
+		return false
 	}
-	return false
+
+	volumeIdx := slices.IndexFunc(pod.Spec.Volumes, func(volume corev1.Volume) bool {
+		return volume.Name == container.VolumeMounts[volumeMountIdx].Name
+	})
+
+	if volumeIdx < 0 {
+		return false
+	}
+
+	volume := pod.Spec.Volumes[volumeIdx]
+
+	return volume.HostPath != nil && sources.Has(volume.HostPath.Path)
 }
 
 // ExceedFilePermissions returns true if any of the user, group or other permissions

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -87,19 +88,16 @@ func (r *Rule242414) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 				if port.HostPort != 0 && port.HostPort < 1024 {
 					containertTarget := target.With("container", container.Name, "details", fmt.Sprintf("port: %d", port.HostPort))
 					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, port.HostPort); accepted {
-						msg := "Pod accepted to use hostPort < 1024."
-						if justification != "" {
-							msg = justification
-						}
+						msg := cmp.Or(justification, "Pod accepted to have containers using hostPort < 1024.")
 						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, containertTarget))
 					} else {
-						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod uses hostPort < 1024.", containertTarget))
+						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod has container using hostPort < 1024.", containertTarget))
 					}
 				}
 			}
 		}
 		if len(podCheckResults) == 0 {
-			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not use hostPort < 1024.", target))
+			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not have container using hostPort < 1024.", target))
 		}
 		checkResults = append(checkResults, podCheckResults...)
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -44,9 +45,12 @@ func (r *Rule242414) Severity() rule.SeverityLevel {
 }
 
 func (r *Rule242414) Run(ctx context.Context) (rule.RuleResult, error) {
+	var (
+		seedTarget  = rule.NewTarget("cluster", "seed")
+		shootTarget = rule.NewTarget("cluster", "shoot")
+	)
+
 	seedPods, err := kubeutils.GetPods(ctx, r.ControlPlaneClient, r.ControlPlaneNamespace, labels.NewSelector(), 300)
-	seedTarget := rule.NewTarget("cluster", "seed")
-	shootTarget := rule.NewTarget("cluster", "shoot")
 	if err != nil {
 		return rule.Result(r, rule.ErroredCheckResult(err.Error(), seedTarget.With("namespace", r.ControlPlaneNamespace, "kind", "podList"))), nil
 	}
@@ -78,38 +82,27 @@ func (r *Rule242414) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 			podCheckResults []rule.CheckResult
 			target          = clusterTarget.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 		)
-		for _, container := range pod.Spec.Containers {
-			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
-		}
-		for _, container := range pod.Spec.InitContainers {
-			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
+		for _, container := range slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers) {
+			for _, port := range container.Ports {
+				if port.HostPort != 0 && port.HostPort < 1024 {
+					containertTarget := target.With("container", container.Name, "details", fmt.Sprintf("port: %d", port.HostPort))
+					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, port.HostPort); accepted {
+						msg := "Pod accepted to use hostPort < 1024."
+						if justification != "" {
+							msg = justification
+						}
+						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, containertTarget))
+					} else {
+						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod uses hostPort < 1024.", containertTarget))
+					}
+				}
+			}
 		}
 		if len(podCheckResults) == 0 {
 			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not use hostPort < 1024.", target))
 		}
 		checkResults = append(checkResults, podCheckResults...)
 	}
-	return checkResults
-}
-
-func (r *Rule242414) checkContainer(container corev1.Container, podLabels, namespaceLabels map[string]string, target rule.Target) []rule.CheckResult {
-	var checkResults []rule.CheckResult
-
-	for _, port := range container.Ports {
-		if port.HostPort != 0 && port.HostPort < 1024 {
-			target := target.With("container", container.Name, "details", fmt.Sprintf("port: %d", port.HostPort))
-			if accepted, justification := r.accepted(podLabels, namespaceLabels, port.HostPort); accepted {
-				msg := "Pod accepted to use hostPort < 1024."
-				if justification != "" {
-					msg = justification
-				}
-				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
-			} else {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pod uses hostPort < 1024.", target))
-			}
-		}
-	}
-
 	return checkResults
 }
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -110,12 +110,12 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
 			},
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "shoot", "name", "shoot-pod", "namespace", "shoot", "kind", "pod"),
 			},
 		}
@@ -135,12 +135,12 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Pod uses hostPort < 1024.",
+				Message: "Pod has container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "shoot", "name", "shoot-pod", "namespace", "shoot", "kind", "pod", "container", "test", "details", "port: 1011"),
 			},
 		}
@@ -169,12 +169,12 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Pod uses hostPort < 1024.",
+				Message: "Pod has container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "shoot", "name", "shoot-pod", "namespace", "shoot", "kind", "pod", "container", "initFoo", "details", "port: 42"),
 			},
 		}
@@ -225,7 +225,7 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
 			},
 			{
@@ -235,7 +235,7 @@ var _ = Describe("#242414", func() {
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Pod uses hostPort < 1024.",
+				Message: "Pod has container using hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "shoot", "name", "not-accepted-shoot-pod", "namespace", "shoot", "kind", "pod", "container", "test", "details", "port: 58"),
 			},
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -110,12 +110,12 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Container does not use hostPort < 1024.",
+				Message: "Pod does not use hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
 			},
 			{
 				Status:  rule.Passed,
-				Message: "Container does not use hostPort < 1024.",
+				Message: "Pod does not use hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "shoot", "name", "shoot-pod", "namespace", "shoot", "kind", "pod"),
 			},
 		}
@@ -135,13 +135,47 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Container does not use hostPort < 1024.",
+				Message: "Pod does not use hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Container may not use hostPort < 1024.",
-				Target:  rule.NewTarget("cluster", "shoot", "name", "shoot-pod", "namespace", "shoot", "kind", "pod", "details", "containerName: test, port: 1011"),
+				Message: "Pod uses hostPort < 1024.",
+				Target:  rule.NewTarget("cluster", "shoot", "name", "shoot-pod", "namespace", "shoot", "kind", "pod", "container", "test", "details", "port: 1011"),
+			},
+		}
+
+		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+	})
+
+	It("should return correct results when a pod contains an initContainer", func() {
+		r := &rules.Rule242414{ClusterClient: fakeShootClient, ControlPlaneClient: fakeSeedClient, ControlPlaneNamespace: seedNamespaceName, Options: &options}
+		shootPod.Spec.InitContainers = []corev1.Container{
+			{
+				Name: "initFoo",
+				Ports: []corev1.ContainerPort{
+					{
+						HostPort: 42,
+					},
+				},
+			},
+		}
+		Expect(fakeSeedClient.Create(ctx, seedPod)).To(Succeed())
+		Expect(fakeShootClient.Create(ctx, shootPod)).To(Succeed())
+
+		ruleResult, err := r.Run(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedCheckResults := []rule.CheckResult{
+			{
+				Status:  rule.Passed,
+				Message: "Pod does not use hostPort < 1024.",
+				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "Pod uses hostPort < 1024.",
+				Target:  rule.NewTarget("cluster", "shoot", "name", "shoot-pod", "namespace", "shoot", "kind", "pod", "container", "initFoo", "details", "port: 42"),
 			},
 		}
 
@@ -191,18 +225,18 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Container does not use hostPort < 1024.",
+				Message: "Pod does not use hostPort < 1024.",
 				Target:  rule.NewTarget("cluster", "seed", "name", "seed-pod", "namespace", "seed", "kind", "pod"),
 			},
 			{
 				Status:  rule.Accepted,
 				Message: "foo justify",
-				Target:  rule.NewTarget("cluster", "shoot", "name", "accepted-shoot-pod", "namespace", "shoot", "kind", "pod", "details", "containerName: test, port: 53"),
+				Target:  rule.NewTarget("cluster", "shoot", "name", "accepted-shoot-pod", "namespace", "shoot", "kind", "pod", "container", "test", "details", "port: 53"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Container may not use hostPort < 1024.",
-				Target:  rule.NewTarget("cluster", "shoot", "name", "not-accepted-shoot-pod", "namespace", "shoot", "kind", "pod", "details", "containerName: test, port: 58"),
+				Message: "Pod uses hostPort < 1024.",
+				Target:  rule.NewTarget("cluster", "shoot", "name", "not-accepted-shoot-pod", "namespace", "shoot", "kind", "pod", "container", "test", "details", "port: 58"),
 			},
 		}
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
@@ -75,44 +75,53 @@ func (r *Rule242415) Run(ctx context.Context) (rule.RuleResult, error) {
 func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.Namespace, clusterTarget rule.Target) []rule.CheckResult {
 	var checkResults []rule.CheckResult
 	for _, pod := range pods {
-		target := clusterTarget.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
-		passed := true
+		var (
+			podCheckResults []rule.CheckResult
+			target          = clusterTarget.With("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
+		)
 		for _, container := range pod.Spec.Containers {
-			for _, env := range container.Env {
-				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
-					target = target.With("details", fmt.Sprintf("containerName: %s, variableName: %s, keyRef: %s", container.Name, env.Name, env.ValueFrom.SecretKeyRef.Key))
-					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace], env.Name); accepted {
-						msg := "Pod accepted to use environment to inject secret."
-						if justification != "" {
-							msg = justification
-						}
-						checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
-					} else {
-						checkResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
-					}
-					passed = false
-				}
-			}
+			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
 		}
-		if passed {
-			checkResults = append(checkResults, rule.CheckResult{
-				Status:  rule.Passed,
-				Message: "Pod does not use environment to inject secret.",
-				Target:  target,
-			})
+		for _, container := range pod.Spec.InitContainers {
+			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
 		}
+		if len(podCheckResults) == 0 {
+			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not use environment to inject secret.", target))
+		}
+		checkResults = append(checkResults, podCheckResults...)
 	}
 	return checkResults
 }
 
-func (r *Rule242415) accepted(podLabels map[string]string, namespace corev1.Namespace, environmentVariable string) (bool, string) {
+func (r *Rule242415) checkContainer(container corev1.Container, podLabels, namespaceLabels map[string]string, target rule.Target) []rule.CheckResult {
+	var checkResults []rule.CheckResult
+
+	for _, env := range container.Env {
+		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+			target = target.With("container", container.Name, "details", fmt.Sprintf("variableName: %s, keyRef: %s", env.Name, env.ValueFrom.SecretKeyRef.Key))
+			if accepted, justification := r.accepted(podLabels, namespaceLabels, env.Name); accepted {
+				msg := "Pod accepted to use environment to inject secret."
+				if justification != "" {
+					msg = justification
+				}
+				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
+			} else {
+				checkResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
+			}
+		}
+	}
+
+	return checkResults
+}
+
+func (r *Rule242415) accepted(podLabels, namespaceLabels map[string]string, environmentVariable string) (bool, string) {
 	if r.Options == nil {
 		return false, ""
 	}
 
 	for _, acceptedPod := range r.Options.AcceptedPods {
 		if utils.MatchLabels(podLabels, acceptedPod.PodMatchLabels) &&
-			utils.MatchLabels(namespace.Labels, acceptedPod.NamespaceMatchLabels) {
+			utils.MatchLabels(namespaceLabels, acceptedPod.NamespaceMatchLabels) {
 			for _, acceptedEnvironmentVariable := range acceptedPod.EnvironmentVariables {
 				if acceptedEnvironmentVariable == environmentVariable {
 					return true, acceptedPod.Justification

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
@@ -89,9 +89,9 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 						if justification != "" {
 							msg = justification
 						}
-						podCheckResults = append(checkResults, rule.AcceptedCheckResult(msg, containerTarget))
+						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, containerTarget))
 					} else {
-						podCheckResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", containerTarget))
+						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod uses environment to inject secret.", containerTarget))
 					}
 				}
 			}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -85,10 +86,7 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 					containerTarget := target.With("container", container.Name, "details", fmt.Sprintf("variableName: %s, keyRef: %s", env.Name, env.ValueFrom.SecretKeyRef.Key))
 					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, env.Name); accepted {
-						msg := "Pod accepted to use environment to inject secret."
-						if justification != "" {
-							msg = justification
-						}
+						msg := cmp.Or(justification, "Pod accepted to use environment to inject secret.")
 						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, containerTarget))
 					} else {
 						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod uses environment to inject secret.", containerTarget))

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
@@ -88,51 +88,40 @@ func (r *Rule242442) checkImages(cluster string, pods []corev1.Pod) []rule.Check
 		)
 
 		for _, pod := range groupedPods {
-			for _, container := range pod.Spec.Containers {
-				checkResults = append(checkResults, r.checkContainerStatus(
-					cluster, namespace, pod.Name, container.Name, pod.Status.ContainerStatuses, reportedImages, images,
-				)...)
-			}
-			for _, container := range pod.Spec.InitContainers {
-				checkResults = append(checkResults, r.checkContainerStatus(
-					cluster, namespace, pod.Name, container.Name, pod.Status.InitContainerStatuses, reportedImages, images,
-				)...)
+			for _, container := range slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers) {
+				var (
+					containerStatuses  = slices.Concat(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses)
+					containerStatusIdx = slices.IndexFunc(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+						return containerStatus.Name == container.Name
+					})
+				)
+
+				if containerStatusIdx < 0 {
+					checkResults = append(checkResults, rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("cluster", cluster, "name", pod.Name, "container", container.Name, "kind", "pod")))
+					continue
+				}
+
+				imageRef := containerStatuses[containerStatusIdx].ImageID
+				named, err := imageref.ParseNormalizedNamed(imageRef)
+				if err != nil {
+					checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef)))
+					continue
+				}
+				imageBase := named.Name()
+
+				if _, ok := images[imageBase]; ok {
+					if images[imageBase] != imageRef {
+						if _, reported := reportedImages[imageBase]; !reported {
+							target := rule.NewTarget("cluster", cluster, "image", imageBase, "namespace", namespace)
+							reportedImages[imageBase] = struct{}{}
+							checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target))
+						}
+					}
+				} else {
+					images[imageBase] = imageRef
+				}
 			}
 		}
 	}
 	return checkResults
-}
-
-func (*Rule242442) checkContainerStatus(
-	cluster, namespaceName, podName, containerName string,
-	containerStatuses []corev1.ContainerStatus,
-	reportedImages map[string]struct{}, images map[string]string,
-) []rule.CheckResult {
-	containerStatusIdx := slices.IndexFunc(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
-		return containerStatus.Name == containerName
-	})
-
-	if containerStatusIdx < 0 {
-		return []rule.CheckResult{rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("cluster", cluster, "name", podName, "container", containerName, "kind", "pod"))}
-	}
-
-	imageRef := containerStatuses[containerStatusIdx].ImageID
-	named, err := imageref.ParseNormalizedNamed(imageRef)
-	if err != nil {
-		return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef))}
-	}
-	imageBase := named.Name()
-
-	if _, ok := images[imageBase]; ok {
-		if images[imageBase] != imageRef {
-			if _, reported := reportedImages[imageBase]; !reported {
-				target := rule.NewTarget("cluster", cluster, "image", imageBase, "namespace", namespaceName)
-				reportedImages[imageBase] = struct{}{}
-				return []rule.CheckResult{rule.FailedCheckResult("Image is used with more than one versions.", target)}
-			}
-		}
-	} else {
-		images[imageBase] = imageRef
-	}
-	return []rule.CheckResult{}
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
@@ -109,13 +109,11 @@ func (r *Rule242442) checkImages(cluster string, pods []corev1.Pod) []rule.Check
 				}
 				imageBase := named.Name()
 
-				if _, ok := images[imageBase]; ok {
-					if images[imageBase] != imageRef {
-						if _, reported := reportedImages[imageBase]; !reported {
-							target := rule.NewTarget("cluster", cluster, "image", imageBase, "namespace", namespace)
-							reportedImages[imageBase] = struct{}{}
-							checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target))
-						}
+				if ref, ok := images[imageBase]; ok && ref != imageRef {
+					if _, reported := reportedImages[imageBase]; !reported {
+						target := rule.NewTarget("cluster", cluster, "image", imageBase, "namespace", namespace)
+						reportedImages[imageBase] = struct{}{}
+						checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target))
 					}
 				} else {
 					images[imageBase] = imageRef

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
@@ -71,7 +71,7 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 	return rule.Result(r, checkResults...), nil
 }
 
-func (*Rule242442) checkImages(cluster string, pods []corev1.Pod) []rule.CheckResult {
+func (r *Rule242442) checkImages(cluster string, pods []corev1.Pod) []rule.CheckResult {
 	var (
 		checkResults    []rule.CheckResult
 		podsByNamespace = map[string][]corev1.Pod{}
@@ -89,36 +89,50 @@ func (*Rule242442) checkImages(cluster string, pods []corev1.Pod) []rule.CheckRe
 
 		for _, pod := range groupedPods {
 			for _, container := range pod.Spec.Containers {
-				containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
-					return containerStatus.Name == container.Name
-				})
-
-				if containerStatusIdx < 0 {
-					checkResults = append(checkResults, rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("cluster", cluster, "name", pod.Name, "container", container.Name, "kind", "pod")))
-					continue
-				}
-
-				imageRef := pod.Status.ContainerStatuses[containerStatusIdx].ImageID
-				named, err := imageref.ParseNormalizedNamed(imageRef)
-				if err != nil {
-					checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef)))
-					continue
-				}
-				imageBase := named.Name()
-
-				if _, ok := images[imageBase]; ok {
-					if images[imageBase] != imageRef {
-						if _, reported := reportedImages[imageBase]; !reported {
-							target := rule.NewTarget("cluster", cluster, "image", imageBase, "namespace", namespace)
-							checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target))
-							reportedImages[imageBase] = struct{}{}
-						}
-					}
-				} else {
-					images[imageBase] = imageRef
-				}
+				checkResults = append(checkResults, r.checkContainerStatus(
+					cluster, namespace, pod.Name, container.Name, pod.Status.ContainerStatuses, reportedImages, images,
+				)...)
+			}
+			for _, container := range pod.Spec.InitContainers {
+				checkResults = append(checkResults, r.checkContainerStatus(
+					cluster, namespace, pod.Name, container.Name, pod.Status.InitContainerStatuses, reportedImages, images,
+				)...)
 			}
 		}
 	}
 	return checkResults
+}
+
+func (*Rule242442) checkContainerStatus(
+	cluster, namespaceName, podName, containerName string,
+	containerStatuses []corev1.ContainerStatus,
+	reportedImages map[string]struct{}, images map[string]string,
+) []rule.CheckResult {
+	containerStatusIdx := slices.IndexFunc(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+		return containerStatus.Name == containerName
+	})
+
+	if containerStatusIdx < 0 {
+		return []rule.CheckResult{rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("cluster", cluster, "name", podName, "container", containerName, "kind", "pod"))}
+	}
+
+	imageRef := containerStatuses[containerStatusIdx].ImageID
+	named, err := imageref.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef))}
+	}
+	imageBase := named.Name()
+
+	if _, ok := images[imageBase]; ok {
+		if images[imageBase] != imageRef {
+			if _, reported := reportedImages[imageBase]; !reported {
+				target := rule.NewTarget("cluster", cluster, "image", imageBase, "namespace", namespaceName)
+				reportedImages[imageBase] = struct{}{}
+				return []rule.CheckResult{rule.FailedCheckResult("Image is used with more than one versions.", target)}
+			}
+		}
+	} else {
+		images[imageBase] = imageRef
+	}
+	return []rule.CheckResult{}
 }

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -69,19 +70,16 @@ func (r *Rule242414) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 				if port.HostPort != 0 && port.HostPort < 1024 {
 					target := target.With("container", container.Name, "details", fmt.Sprintf("port: %d", port.HostPort))
 					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, port.HostPort); accepted {
-						msg := "Pod accepted to use hostPort < 1024."
-						if justification != "" {
-							msg = justification
-						}
+						msg := cmp.Or(justification, "Pod accepted to have containers using hostPort < 1024.")
 						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, target))
 					} else {
-						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod uses hostPort < 1024.", target))
+						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod has container using hostPort < 1024.", target))
 					}
 				}
 			}
 		}
 		if len(podCheckResults) == 0 {
-			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not use hostPort < 1024.", target))
+			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not have container using hostPort < 1024.", target))
 		}
 		checkResults = append(checkResults, podCheckResults...)
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
@@ -59,40 +59,53 @@ func (r *Rule242414) Run(ctx context.Context) (rule.RuleResult, error) {
 func (r *Rule242414) checkPods(pods []corev1.Pod, namespaces map[string]corev1.Namespace) []rule.CheckResult {
 	var checkResults []rule.CheckResult
 	for _, pod := range pods {
-		target := rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
+		var (
+			podCheckResults []rule.CheckResult
+			target          = rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
+		)
 		for _, container := range pod.Spec.Containers {
-			uses := false
-			for _, port := range container.Ports {
-				if port.HostPort != 0 && port.HostPort < 1024 {
-					target = target.With("details", fmt.Sprintf("containerName: %s, port: %d", container.Name, port.HostPort))
-					if accepted, justification := r.accepted(pod, namespaces[pod.Namespace], port.HostPort); accepted {
-						msg := "Container accepted to use hostPort < 1024."
-						if justification != "" {
-							msg = justification
-						}
-						checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
-					} else {
-						checkResults = append(checkResults, rule.FailedCheckResult("Container uses hostPort < 1024.", target))
-					}
-					uses = true
-				}
-			}
-			if !uses {
-				checkResults = append(checkResults, rule.PassedCheckResult("Container does not use hostPort < 1024.", target))
-			}
+			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
 		}
+		for _, container := range pod.Spec.InitContainers {
+			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
+		}
+		if len(podCheckResults) == 0 {
+			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not use hostPort < 1024.", target))
+		}
+		checkResults = append(checkResults, podCheckResults...)
 	}
 	return checkResults
 }
 
-func (r *Rule242414) accepted(pod corev1.Pod, namespace corev1.Namespace, hostPort int32) (bool, string) {
+func (r *Rule242414) checkContainer(container corev1.Container, podLabels, namespaceLabels map[string]string, target rule.Target) []rule.CheckResult {
+	var checkResults []rule.CheckResult
+
+	for _, port := range container.Ports {
+		if port.HostPort != 0 && port.HostPort < 1024 {
+			target := target.With("container", container.Name, "details", fmt.Sprintf("port: %d", port.HostPort))
+			if accepted, justification := r.accepted(podLabels, namespaceLabels, port.HostPort); accepted {
+				msg := "Pod accepted to use hostPort < 1024."
+				if justification != "" {
+					msg = justification
+				}
+				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
+			} else {
+				checkResults = append(checkResults, rule.FailedCheckResult("Pod uses hostPort < 1024.", target))
+			}
+		}
+	}
+
+	return checkResults
+}
+
+func (r *Rule242414) accepted(podLabels, namespaceLabels map[string]string, hostPort int32) (bool, string) {
 	if r.Options == nil {
 		return false, ""
 	}
 
 	for _, acceptedPod := range r.Options.AcceptedPods {
-		if utils.MatchLabels(pod.Labels, acceptedPod.PodMatchLabels) &&
-			utils.MatchLabels(namespace.Labels, acceptedPod.NamespaceMatchLabels) {
+		if utils.MatchLabels(podLabels, acceptedPod.PodMatchLabels) &&
+			utils.MatchLabels(namespaceLabels, acceptedPod.NamespaceMatchLabels) {
 			for _, acceptedHostPort := range acceptedPod.Ports {
 				if acceptedHostPort == hostPort {
 					return true, acceptedPod.Justification

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
@@ -77,12 +77,12 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("name", "pod1", "namespace", "foo", "kind", "pod"),
 			},
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("name", "pod2", "namespace", "foo", "kind", "pod"),
 			},
 		}
@@ -107,12 +107,12 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("name", "pod1", "namespace", "foo", "kind", "pod"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Pod uses hostPort < 1024.",
+				Message: "Pod has container using hostPort < 1024.",
 				Target:  rule.NewTarget("name", "pod2", "namespace", "foo", "kind", "pod", "container", "test", "details", "port: 1011"),
 			},
 		}
@@ -146,12 +146,12 @@ var _ = Describe("#242414", func() {
 		expectedCheckResults := []rule.CheckResult{
 			{
 				Status:  rule.Passed,
-				Message: "Pod does not use hostPort < 1024.",
+				Message: "Pod does not have container using hostPort < 1024.",
 				Target:  rule.NewTarget("name", "pod1", "namespace", "foo", "kind", "pod"),
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Pod uses hostPort < 1024.",
+				Message: "Pod has container using hostPort < 1024.",
 				Target:  rule.NewTarget("name", "pod2", "namespace", "foo", "kind", "pod", "container", "initFoo", "details", "port: 42"),
 			},
 		}
@@ -205,7 +205,7 @@ var _ = Describe("#242414", func() {
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Pod uses hostPort < 1024.",
+				Message: "Pod has container using hostPort < 1024.",
 				Target:  rule.NewTarget("name", "not-accepted-shoot-pod", "namespace", "foo", "kind", "pod", "container", "test", "details", "port: 58"),
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
@@ -92,27 +92,6 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 	return checkResults
 }
 
-func (r *Rule242415) checkContainer(container corev1.Container, podLabels, namespaceLabels map[string]string, target rule.Target) []rule.CheckResult {
-	var checkResults []rule.CheckResult
-
-	for _, env := range container.Env {
-		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
-			target = target.With("container", container.Name, "details", fmt.Sprintf("variableName: %s, keyRef: %s", env.Name, env.ValueFrom.SecretKeyRef.Key))
-			if accepted, justification := r.accepted(podLabels, namespaceLabels, env.Name); accepted {
-				msg := "Pod accepted to use environment to inject secret."
-				if justification != "" {
-					msg = justification
-				}
-				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, target))
-			} else {
-				checkResults = append(checkResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
-			}
-		}
-	}
-
-	return checkResults
-}
-
 func (r *Rule242415) accepted(podLabels, namespaceLabels map[string]string, environmentVariable string) (bool, string) {
 	if r.Options == nil {
 		return false, ""

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -73,10 +74,7 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 					target = target.With("container", container.Name, "details", fmt.Sprintf("variableName: %s, keyRef: %s", env.Name, env.ValueFrom.SecretKeyRef.Key))
 					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, env.Name); accepted {
-						msg := "Pod accepted to use environment to inject secret."
-						if justification != "" {
-							msg = justification
-						}
+						msg := cmp.Or(justification, "Pod accepted to use environment to inject secret.")
 						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, target))
 					} else {
 						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -67,11 +68,21 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 			podCheckResults []rule.CheckResult
 			target          = rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod")
 		)
-		for _, container := range pod.Spec.Containers {
-			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
-		}
-		for _, container := range pod.Spec.InitContainers {
-			podCheckResults = append(podCheckResults, r.checkContainer(container, pod.Labels, namespaces[pod.Namespace].Labels, target)...)
+		for _, container := range slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers) {
+			for _, env := range container.Env {
+				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+					target = target.With("container", container.Name, "details", fmt.Sprintf("variableName: %s, keyRef: %s", env.Name, env.ValueFrom.SecretKeyRef.Key))
+					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, env.Name); accepted {
+						msg := "Pod accepted to use environment to inject secret."
+						if justification != "" {
+							msg = justification
+						}
+						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, target))
+					} else {
+						podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod uses environment to inject secret.", target))
+					}
+				}
+			}
 		}
 		if len(podCheckResults) == 0 {
 			checkResults = append(checkResults, rule.PassedCheckResult("Pod does not use environment to inject secret.", target))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -117,12 +117,10 @@ func (r *Rule242442) checkImages(pods []corev1.Pod, target rule.Target) []rule.C
 			}
 			imageBase := named.Name()
 
-			if _, ok := images[imageBase]; ok {
-				if images[imageBase] != imageRef {
-					if _, reported := reportedImages[imageBase]; !reported {
-						reportedImages[imageBase] = struct{}{}
-						checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target.With("image", imageBase)))
-					}
+			if ref, ok := images[imageBase]; ok && ref != imageRef {
+				if _, reported := reportedImages[imageBase]; !reported {
+					reportedImages[imageBase] = struct{}{}
+					checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target.With("image", imageBase)))
 				}
 			} else {
 				images[imageBase] = imageRef

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -89,7 +89,7 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 	return rule.Result(r, checkResults...), nil
 }
 
-func (*Rule242442) checkImages(pods []corev1.Pod, target rule.Target) []rule.CheckResult {
+func (r *Rule242442) checkImages(pods []corev1.Pod, target rule.Target) []rule.CheckResult {
 	var (
 		images         = map[string]string{}
 		reportedImages = map[string]struct{}{}
@@ -97,32 +97,50 @@ func (*Rule242442) checkImages(pods []corev1.Pod, target rule.Target) []rule.Che
 	)
 	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
-			containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
-				return containerStatus.Name == container.Name
-			})
-
-			if containerStatusIdx < 0 {
-				checkResults = append(checkResults, rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "container", container.Name, "kind", "pod")))
-				continue
-			}
-
-			imageRef := pod.Status.ContainerStatuses[containerStatusIdx].ImageID
-			named, err := imageref.ParseNormalizedNamed(imageRef)
-			if err != nil {
-				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), target.With("imageRef", imageRef)))
-				continue
-			}
-			imageBase := named.Name()
-
-			if _, ok := images[imageBase]; ok && images[imageBase] != imageRef {
-				if _, reported := reportedImages[imageBase]; !reported {
-					checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target.With("image", imageBase)))
-					reportedImages[imageBase] = struct{}{}
-				}
-			} else {
-				images[imageBase] = imageRef
-			}
+			checkResults = append(checkResults, r.checkContainerStatus(
+				pod.Namespace, pod.Name, container.Name, pod.Status.ContainerStatuses, reportedImages, images, target,
+			)...)
+		}
+		for _, container := range pod.Spec.InitContainers {
+			checkResults = append(checkResults, r.checkContainerStatus(
+				pod.Namespace, pod.Name, container.Name, pod.Status.InitContainerStatuses, reportedImages, images, target,
+			)...)
 		}
 	}
 	return checkResults
+}
+
+func (*Rule242442) checkContainerStatus(
+	namespaceName, podName, containerName string,
+	containerStatuses []corev1.ContainerStatus,
+	reportedImages map[string]struct{}, images map[string]string,
+	target rule.Target,
+) []rule.CheckResult {
+	containerStatusIdx := slices.IndexFunc(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+		return containerStatus.Name == containerName
+	})
+
+	if containerStatusIdx < 0 {
+		return []rule.CheckResult{rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("name", podName, "namespace", namespaceName, "container", containerName, "kind", "pod"))}
+	}
+
+	imageRef := containerStatuses[containerStatusIdx].ImageID
+	named, err := imageref.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), target.With("imageRef", imageRef))}
+	}
+	imageBase := named.Name()
+
+	if _, ok := images[imageBase]; ok {
+		if images[imageBase] != imageRef {
+			if _, reported := reportedImages[imageBase]; !reported {
+				target := target.With("image", imageBase)
+				reportedImages[imageBase] = struct{}{}
+				return []rule.CheckResult{rule.FailedCheckResult("Image is used with more than one versions.", target)}
+			}
+		}
+	} else {
+		images[imageBase] = imageRef
+	}
+	return []rule.CheckResult{}
 }

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"slices"
 	"strings"
@@ -108,10 +109,7 @@ func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
 
 			if container.SecurityContext == nil || allowsPrivilegeEscalation(*container.SecurityContext) {
 				if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels); accepted {
-					msg := "Pod accepted to escalate privileges."
-					if justification != "" {
-						msg = justification
-					}
+					msg := cmp.Or(justification, "Pod accepted to escalate privileges.")
 					podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, containerTarget))
 				} else {
 					podCheckResults = append(podCheckResults, rule.FailedCheckResult("Pod must not escalate privileges.", containerTarget))

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
@@ -22,11 +22,14 @@ import (
 
 var _ = Describe("#2001", func() {
 	var (
-		client        client.Client
-		plainPod      *corev1.Pod
-		ctx           = context.TODO()
-		namespaceName = "foo"
-		namespace     *corev1.Namespace
+		client               client.Client
+		plainPod             *corev1.Pod
+		ctx                  = context.TODO()
+		namespaceName        = "foo"
+		namespace            *corev1.Namespace
+		validSecurityContext = &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+		}
 	)
 
 	BeforeEach(func() {
@@ -54,6 +57,12 @@ var _ = Describe("#2001", func() {
 						SecurityContext: &corev1.SecurityContext{},
 					},
 				},
+				InitContainers: []corev1.Container{
+					{
+						Name:            "initTest",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
 			},
 		}
 	})
@@ -66,10 +75,11 @@ var _ = Describe("#2001", func() {
 	})
 
 	DescribeTable("Run cases",
-		func(securityContext *corev1.SecurityContext, ruleOptions rules.Options2001, expectedResult rule.CheckResult) {
+		func(securityContext *corev1.SecurityContext, initSecurityContext *corev1.SecurityContext, ruleOptions rules.Options2001, expectedResult rule.CheckResult) {
 			r := &rules.Rule2001{Client: client, Options: &ruleOptions}
 			pod := plainPod.DeepCopy()
 			pod.Spec.Containers[0].SecurityContext = securityContext
+			pod.Spec.InitContainers[0].SecurityContext = initSecurityContext
 
 			Expect(client.Create(ctx, pod)).To(Succeed())
 			Expect(client.Create(ctx, namespace)).To(Succeed())
@@ -80,35 +90,39 @@ var _ = Describe("#2001", func() {
 		},
 
 		Entry("should fail when securityContext is not set",
-			nil, rules.Options2001{},
+			nil, validSecurityContext, rules.Options2001{},
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when allowPrivilegeEscalation is not set",
-			&corev1.SecurityContext{}, rules.Options2001{},
+			&corev1.SecurityContext{}, validSecurityContext, rules.Options2001{},
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when allowPrivilegeEscalation is set to true",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, validSecurityContext, rules.Options2001{},
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
+		Entry("should fail when allowPrivilegeEscalation is set to true in initContainer",
+			validSecurityContext, &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, rules.Options2001{},
+			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "initTest")},
+		),
 		Entry("should pass when allowPrivilegeEscalation is set to false",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)}, rules.Options2001{},
+			validSecurityContext, validSecurityContext, rules.Options2001{},
 			rule.CheckResult{Status: rule.Passed, Message: "Pod does not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo")},
 		),
 		Entry("should fail when privileged is set to true",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Privileged: ptr.To(true)}, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Privileged: ptr.To(true)}, validSecurityContext, rules.Options2001{},
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when SYS_ADMIN capability is added",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}}}, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}}}, validSecurityContext, rules.Options2001{},
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when CAP_SYS_ADMIN capability is added",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_SYS_ADMIN"}}}, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_SYS_ADMIN"}}}, validSecurityContext, rules.Options2001{},
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should pass when options are set",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, validSecurityContext,
 			rules.Options2001{
 				AcceptedPods: []option.AcceptedNamespacedObject{
 					{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
@@ -79,10 +80,7 @@ func (r *Rule2004) Run(ctx context.Context) (rule.RuleResult, error) {
 
 		if service.Spec.Type == corev1.ServiceTypeNodePort {
 			if accepted, justification := r.accepted(service, namespaces[service.Namespace]); accepted {
-				msg := "Service accepted to be of type NodePort."
-				if justification != "" {
-					msg = justification
-				}
+				msg := cmp.Or(justification, "Service accepted to be of type NodePort.")
 				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, serviceTarget))
 			} else {
 				checkResults = append(checkResults, rule.FailedCheckResult("Service should not be of type NodePort.", serviceTarget))

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"strings"
 
@@ -87,10 +88,7 @@ func (r *Rule2006) Run(ctx context.Context) (rule.RuleResult, error) {
 	var (
 		checkResults []rule.CheckResult
 		checkRules   = func(policyRules []rbacv1.PolicyRule, accepted bool, justification string, target rule.Target) rule.CheckResult {
-			msg := "Role is accepted to use \"*\" in policy rule resources."
-			if len(justification) > 0 {
-				msg = justification
-			}
+			msg := cmp.Or(justification, "Role is accepted to use \"*\" in policy rule resources.")
 
 			for _, policyRule := range policyRules {
 				for _, resource := range policyRule.Resources {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"strings"
 
@@ -87,10 +88,7 @@ func (r *Rule2007) Run(ctx context.Context) (rule.RuleResult, error) {
 	var (
 		checkResults []rule.CheckResult
 		checkRules   = func(policyRules []rbacv1.PolicyRule, accepted bool, justification string, target rule.Target) rule.CheckResult {
-			msg := "Role is accepted to use \"*\" in policy rule verbs."
-			if len(justification) > 0 {
-				msg = justification
-			}
+			msg := cmp.Or(justification, "Role is accepted to use \"*\" in policy rule verbs.")
 
 			for _, policyRule := range policyRules {
 				for _, verb := range policyRule.Verbs {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -5,6 +5,7 @@
 package rules
 
 import (
+	"cmp"
 	"context"
 	"slices"
 
@@ -98,10 +99,7 @@ func (r *Rule2008) Run(ctx context.Context) (rule.RuleResult, error) {
 			if volume.HostPath != nil {
 				uses = true
 				if accepted, justification := r.accepted(pod, namespaces[pod.Namespace], volume.Name); accepted {
-					msg := "Pod accepted to use volume of type hostPath."
-					if justification != "" {
-						msg = justification
-					}
+					msg := cmp.Or(justification, "Pod accepted to use volume of type hostPath.")
 					checkResults = append(checkResults, rule.AcceptedCheckResult(msg, volumeTarget))
 				} else {
 					checkResults = append(checkResults, rule.FailedCheckResult("Pod must not use volumes of type hostPath.", volumeTarget))

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
@@ -59,50 +59,38 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 func (r *Rule242442) checkImages(pods []corev1.Pod, images map[string]string, reportedImages map[string]struct{}) []rule.CheckResult {
 	var checkResults []rule.CheckResult
 	for _, pod := range pods {
-		for _, container := range pod.Spec.Containers {
-			checkResults = append(checkResults, r.checkContainerStatus(
-				pod.Name, container.Name, pod.Status.ContainerStatuses, reportedImages, images,
-			)...)
-		}
-		for _, container := range pod.Spec.InitContainers {
-			checkResults = append(checkResults, r.checkContainerStatus(
-				pod.Name, container.Name, pod.Status.InitContainerStatuses, reportedImages, images,
-			)...)
+		for _, container := range slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers) {
+			var (
+				containerStatuses  = slices.Concat(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses)
+				containerStatusIdx = slices.IndexFunc(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+					return containerStatus.Name == container.Name
+				})
+			)
+
+			if containerStatusIdx < 0 {
+				checkResults = append(checkResults, rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("name", pod.Name, "container", container.Name, "kind", "pod")))
+				continue
+			}
+
+			imageRef := containerStatuses[containerStatusIdx].ImageID
+			named, err := imageref.ParseNormalizedNamed(imageRef)
+			if err != nil {
+				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef)))
+				continue
+			}
+			imageBase := named.Name()
+
+			if _, ok := images[imageBase]; ok {
+				if images[imageBase] != imageRef {
+					if _, reported := reportedImages[imageBase]; !reported {
+						reportedImages[imageBase] = struct{}{}
+						checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", rule.NewTarget("image", imageBase)))
+					}
+				}
+			} else {
+				images[imageBase] = imageRef
+			}
 		}
 	}
 	return checkResults
-}
-
-func (*Rule242442) checkContainerStatus(
-	podName, containerName string,
-	containerStatuses []corev1.ContainerStatus,
-	reportedImages map[string]struct{}, images map[string]string,
-) []rule.CheckResult {
-	containerStatusIdx := slices.IndexFunc(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
-		return containerStatus.Name == containerName
-	})
-
-	if containerStatusIdx < 0 {
-		return []rule.CheckResult{rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("name", podName, "container", containerName, "kind", "pod"))}
-	}
-
-	imageRef := containerStatuses[containerStatusIdx].ImageID
-	named, err := imageref.ParseNormalizedNamed(imageRef)
-	if err != nil {
-		return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef))}
-	}
-	imageBase := named.Name()
-
-	if _, ok := images[imageBase]; ok {
-		if images[imageBase] != imageRef {
-			if _, reported := reportedImages[imageBase]; !reported {
-				target := rule.NewTarget("image", imageBase)
-				reportedImages[imageBase] = struct{}{}
-				return []rule.CheckResult{rule.FailedCheckResult("Image is used with more than one versions.", target)}
-			}
-		}
-	} else {
-		images[imageBase] = imageRef
-	}
-	return []rule.CheckResult{}
 }

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
@@ -80,12 +80,10 @@ func (r *Rule242442) checkImages(pods []corev1.Pod, images map[string]string, re
 			}
 			imageBase := named.Name()
 
-			if _, ok := images[imageBase]; ok {
-				if images[imageBase] != imageRef {
-					if _, reported := reportedImages[imageBase]; !reported {
-						reportedImages[imageBase] = struct{}{}
-						checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", rule.NewTarget("image", imageBase)))
-					}
+			if ref, ok := images[imageBase]; ok && ref != imageRef {
+				if _, reported := reportedImages[imageBase]; !reported {
+					reportedImages[imageBase] = struct{}{}
+					checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", rule.NewTarget("image", imageBase)))
 				}
 			} else {
 				images[imageBase] = imageRef

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
@@ -56,39 +56,53 @@ func (r *Rule242442) Run(ctx context.Context) (rule.RuleResult, error) {
 	return rule.Result(r, checkResults...), nil
 }
 
-func (*Rule242442) checkImages(pods []corev1.Pod, images map[string]string, reportedImages map[string]struct{}) []rule.CheckResult {
+func (r *Rule242442) checkImages(pods []corev1.Pod, images map[string]string, reportedImages map[string]struct{}) []rule.CheckResult {
 	var checkResults []rule.CheckResult
 	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
-			containerStatusIdx := slices.IndexFunc(pod.Status.ContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
-				return containerStatus.Name == container.Name
-			})
-
-			if containerStatusIdx < 0 {
-				checkResults = append(checkResults, rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("name", pod.Name, "container", container.Name, "kind", "pod")))
-				continue
-			}
-
-			imageRef := pod.Status.ContainerStatuses[containerStatusIdx].ImageID
-			named, err := imageref.ParseNormalizedNamed(imageRef)
-			if err != nil {
-				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef)))
-				continue
-			}
-			imageBase := named.Name()
-
-			if _, ok := images[imageBase]; ok {
-				if images[imageBase] != imageRef {
-					if _, reported := reportedImages[imageBase]; !reported {
-						target := rule.NewTarget("image", imageBase)
-						checkResults = append(checkResults, rule.FailedCheckResult("Image is used with more than one versions.", target))
-						reportedImages[imageBase] = struct{}{}
-					}
-				}
-			} else {
-				images[imageBase] = imageRef
-			}
+			checkResults = append(checkResults, r.checkContainerStatus(
+				pod.Name, container.Name, pod.Status.ContainerStatuses, reportedImages, images,
+			)...)
+		}
+		for _, container := range pod.Spec.InitContainers {
+			checkResults = append(checkResults, r.checkContainerStatus(
+				pod.Name, container.Name, pod.Status.InitContainerStatuses, reportedImages, images,
+			)...)
 		}
 	}
 	return checkResults
+}
+
+func (*Rule242442) checkContainerStatus(
+	podName, containerName string,
+	containerStatuses []corev1.ContainerStatus,
+	reportedImages map[string]struct{}, images map[string]string,
+) []rule.CheckResult {
+	containerStatusIdx := slices.IndexFunc(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+		return containerStatus.Name == containerName
+	})
+
+	if containerStatusIdx < 0 {
+		return []rule.CheckResult{rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("name", podName, "container", containerName, "kind", "pod"))}
+	}
+
+	imageRef := containerStatuses[containerStatusIdx].ImageID
+	named, err := imageref.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), rule.NewTarget("imageRef", imageRef))}
+	}
+	imageBase := named.Name()
+
+	if _, ok := images[imageBase]; ok {
+		if images[imageBase] != imageRef {
+			if _, reported := reportedImages[imageBase]; !reported {
+				target := rule.NewTarget("image", imageBase)
+				reportedImages[imageBase] = struct{}{}
+				return []rule.CheckResult{rule.FailedCheckResult("Image is used with more than one versions.", target)}
+			}
+		}
+	} else {
+		images[imageBase] = imageRef
+	}
+	return []rule.CheckResult{}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #426

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Multiple rules that check `Pod` containers from `.spec.containers` now also check containers from `.spec.initContainers`.
```
