### PR TITLE
Update diki binaries in homebre tap and chocolatey

### DIFF
--- a/.github/workflows/upload-diki-binaries.yaml
+++ b/.github/workflows/upload-diki-binaries.yaml
@@ -5,7 +5,7 @@ on:
     types:
       - published
 jobs:
-  upload_diki_binaries_to_release:
+  upload_diki_binaries:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -25,3 +25,35 @@ jobs:
           files: 'bin/diki-darwin-amd64;bin/diki-darwin-arm64;bin/diki-linux-amd64;bin/diki-linux-arm64;bin/diki-windows-amd64'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ env.latest_release_filtered_tag }}
+      - name: Get token for gardener-github-pkg-mngr app
+        if: github.event.release.prerelease == false
+        id: gardener-github-workflows
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+        with:
+          app_id: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID }}
+          private_key: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY }}
+      - name: Send update with latest versions to ${{ github.repository_owner }}/homebrew-tap
+        if: github.event.release.prerelease == false
+        run: |
+          latest_release_filtered_tag=${{ env.latest_release_filtered_tag }}
+          darwin_sha256sum_amd64=$(sha256sum bin/diki-darwin-amd64 | awk '{print $1}')
+          darwin_sha256sum_arm64=$(sha256sum bin/diki-darwin-arm64 | awk '{print $1}')
+          linux_sha256sum_amd64=$(sha256sum bin/diki-linux-amd64 | awk '{print $1}')
+          linux_sha256sum_arm64=$(sha256sum bin/diki-linux-arm64 | awk '{print $1}')
+          data='{"event_type": "update", "client_payload": { "component": "diki", "tag": "'"$latest_release_filtered_tag"'", "darwin_sha_amd64": "'"$darwin_sha256sum_amd64"'", "darwin_sha_arm64": "'"$darwin_sha256sum_arm64"'", "linux_sha_amd64": "'"$linux_sha256sum_amd64"'", "linux_sha_arm64": "'"$linux_sha256sum_arm64"'"}}'
+          echo "${data}"
+          curl -X POST https://api.github.com/repos/${{ github.repository_owner }}/homebrew-tap/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -H "Authorization: Token ${{ steps.gardener-github-workflows.outputs.token }}" \
+          --data "${data}"
+      - name: Send update with latest versions to ${{ github.repository_owner }}/chocolatey-packages
+        if: github.event.release.prerelease == false
+        run: |
+          latest_release_filtered_tag=${{ env.latest_release_filtered_tag }}
+          windows_sha256sum=$(sha256sum bin/diki-windows-amd64 | awk '{print $1}')
+          data='{"event_type": "update", "client_payload": { "component": "diki", "tag": "'"$latest_release_filtered_tag"'", "windows_sha": "'"$windows_sha256sum"'"}}'
+          echo "${data}"
+          curl -X POST https://api.github.com/repos/${{ github.repository_owner }}/chocolatey-packages/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -H "Authorization: Token ${{ steps.gardener-github-workflows.outputs.token }}" \
+          --data "${data}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds update diki versions in homebrew tap and chocolatey repositories steps to the `upload_diki_binaries` github action.

Changes have been validated on forked repos. Generated example PRs:
https://github.com/AleksandarSavchev/homebrew-tap/pull/1
https://github.com/AleksandarSavchev/chocolatey-packages/pull/1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
