### PR TITLE
[Security Hardened Kubernetes Cluster] Rule 2005 return errored checkResult when imageID is empty

### DIFF
--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -104,6 +104,11 @@ func (r *Rule2005) Run(ctx context.Context) (rule.RuleResult, error) {
 				continue
 			}
 
+			if len(containerStatuses[containerStatusIdx].ImageID) == 0 {
+				checkResults = append(checkResults, rule.ErroredCheckResult("ImageID is empty in container status.", containerTarget))
+				continue
+			}
+
 			imageRefTarget := containerTarget.With("imageRef", containerStatuses[containerStatusIdx].ImageID)
 
 			if slices.ContainsFunc(r.Options.AllowedImages, func(allowedImage AllowedImage) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #442 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
