### PR TITLE
[Security Hardened Shoot Cluster] Rule 1001 Implementation

### DIFF
--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -24,6 +24,21 @@ spec:
 ```
 ---
 
+### 1001 - Shoot clusters should use a supported version of Kubernetes <a id="1001"></a>
+
+#### Description
+Shoot clusters should use supported version of Kubernetes. This rule can be configured to accept specific version classifications.
+
+#### Fix
+Configure `supported` Kuberenetes version in the `spec.kubernetes.version` field.
+``` yaml
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+spec:
+  kubernetes:
+    version: <supported-version>
+```
+
 ### 1002 - Shoot clusters should use supported versions for their Workers' images. <a id="1002"></a>
 
 #### Description

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -24,7 +24,7 @@ spec:
 ```
 ---
 
-### 1001 - Shoot clusters should use a supported version of Kubernetes <a id="1001"></a>
+### 1001 - Shoot clusters should use a supported version of Kubernetes. <a id="1001"></a>
 
 #### Description
 Shoot clusters should use a supported version of Kubernetes. This rule can be configured to accept specific version classifications.

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -27,7 +27,7 @@ spec:
 ### 1001 - Shoot clusters should use a supported version of Kubernetes <a id="1001"></a>
 
 #### Description
-Shoot clusters should use supported version of Kubernetes. This rule can be configured to accept specific version classifications.
+Shoot clusters should use a supported version of Kubernetes. This rule can be configured to accept specific version classifications.
 
 #### Fix
 Configure `supported` Kuberenetes version in the `spec.kubernetes.version` field.

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -24,10 +24,10 @@ spec:
 ```
 ---
 
-### 1001 - Shoot clusters should use a supported version of Kubernetes. <a id="1001"></a>
+### 1001 - Shoot clusters must use a supported version of Kubernetes. <a id="1001"></a>
 
 #### Description
-Shoot clusters should use a supported version of Kubernetes. This rule can be configured to accept specific version classifications.
+Shoot clusters must use a supported version of Kubernetes. This rule can be configured to accept specific version classifications.
 
 #### Fix
 Configure `supported` Kuberenetes version in the `spec.kubernetes.version` field.
@@ -39,10 +39,12 @@ spec:
     version: <supported-version>
 ```
 
-### 1002 - Shoot clusters should use supported versions for their Workers' images. <a id="1002"></a>
+The supported versions can be found in the used `CloudProfile`.
+
+### 1002 - Shoot clusters must use supported versions for their Workers' images. <a id="1002"></a>
 
 #### Description
-Shoot clusters should use supported versions for their Workers' images. This rule can be configured to accept specific image classifications.
+Shoot clusters must use supported versions for their Workers' images. This rule can be configured to accept specific image classifications.
 
 #### Fix
 Configure `supported` machine image versions in the `spec.provider.workers[].machine.image.version` field.

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.0.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.0.yaml
@@ -11,6 +11,10 @@ rules:
   name: "Shoot clusters should enable required extensions."
   description: "Shoot clusters should enable required extensions. This rule can be configured as per organisation's requirements in order to check if required extensions are enabled for the shoot cluster."
   severity: "MEDIUM"
+- id: 1001
+  name: "Shoot clusters should use a supported version of Kubernetes."
+  description: "Shoot clusters should use a supported version of Kubernetes. This rule can be configured to accept specific version classifications."
+  severity: "HIGH"
 - id: 1002
   name: "Shoot clusters should use supported versions for their Workers' images."
   description: "Shoot clusters should use supported versions for their Workers' images. This rule can be configured to accept specific image classifications."

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.0.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.0.yaml
@@ -12,12 +12,12 @@ rules:
   description: "Shoot clusters should enable required extensions. This rule can be configured as per organisation's requirements in order to check if required extensions are enabled for the shoot cluster."
   severity: "MEDIUM"
 - id: 1001
-  name: "Shoot clusters should use a supported version of Kubernetes."
-  description: "Shoot clusters should use a supported version of Kubernetes. This rule can be configured to accept specific version classifications."
+  name: "Shoot clusters must use a supported version of Kubernetes."
+  description: "Shoot clusters must use a supported version of Kubernetes. This rule can be configured to accept specific version classifications."
   severity: "HIGH"
 - id: 1002
-  name: "Shoot clusters should use supported versions for their Workers' images."
-  description: "Shoot clusters should use supported versions for their Workers' images. This rule can be configured to accept specific image classifications."
+  name: "Shoot clusters must use supported versions for their Workers' images."
+  description: "Shoot clusters must use supported versions for their Workers' images. This rule can be configured to accept specific image classifications."
   severity: "HIGH"
 - id: 2000
   name: "Shoot clusters must have anonymous authentication disabled for the Kubernetes API server."

--- a/example/config/garden.yaml
+++ b/example/config/garden.yaml
@@ -18,6 +18,11 @@ providers:       # contains information about known providers
     #     extensions:
     #     - type: extension-type-1
     #     - type: extension-type-2
+    # - ruleID: "1001"
+    #   args:
+    #     allowedClassifications:
+    #     - supported
+    #     - preview
     # - ruleID: "1002"
     #   args:
     #     machineImages:

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+)
+
+var (
+	_ rule.Rule     = &Rule1001{}
+	_ rule.Severity = &Rule1001{}
+	_ option.Option = &Options1001{}
+)
+
+type Rule1001 struct {
+	Client         client.Client
+	ShootName      string
+	ShootNamespace string
+	Options        *Options1001
+}
+
+type Options1001 struct {
+	AllowedClassifications []gardencorev1beta1.VersionClassification
+}
+
+func (o Options1001) Validate() field.ErrorList {
+	var (
+		allErrs                field.ErrorList
+		rootPath               = field.NewPath("allowedClassifications")
+		versionClassifications = []gardencorev1beta1.VersionClassification{
+			gardencorev1beta1.ClassificationPreview,
+			gardencorev1beta1.ClassificationSupported,
+			gardencorev1beta1.ClassificationDeprecated,
+		}
+	)
+
+	for _, c := range o.AllowedClassifications {
+		if !slices.Contains(versionClassifications, c) {
+			allErrs = append(allErrs, field.NotSupported(rootPath, c, versionClassifications))
+		}
+	}
+
+	return allErrs
+}
+
+func (r *Rule1001) ID() string {
+	return "1001"
+}
+
+func (r *Rule1001) Severity() rule.SeverityLevel {
+	return rule.SeverityHigh
+}
+
+func (r *Rule1001) Name() string {
+	return "Shoot clusters should use a supported Kubernetes version."
+}
+
+func (r *Rule1001) Run(ctx context.Context) (rule.RuleResult, error) {
+	shoot := &gardencorev1beta1.Shoot{ObjectMeta: v1.ObjectMeta{Name: r.ShootName, Namespace: r.ShootNamespace}}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", r.ShootName, "namespace", r.ShootNamespace, "kind", "Shoot"))), nil
+	}
+
+	var (
+		cloudProfileName       string
+		kind                   string
+		cloudProfile           *gardencorev1beta1.CloudProfile
+		namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile
+	)
+
+	if shoot.Spec.CloudProfile != nil {
+		cloudProfileName = shoot.Spec.CloudProfile.Name
+		kind = shoot.Spec.CloudProfile.Kind
+	} else {
+		cloudProfileName = *shoot.Spec.CloudProfileName
+		kind = gardencorev1beta1constants.CloudProfileReferenceKindCloudProfile
+	}
+
+	switch kind {
+	case gardencorev1beta1constants.CloudProfileReferenceKindCloudProfile:
+		cloudProfile = &gardencorev1beta1.CloudProfile{ObjectMeta: v1.ObjectMeta{Name: cloudProfileName}}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile); err != nil {
+			return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", cloudProfileName, "kind", gardencorev1beta1constants.CloudProfileReferenceKindCloudProfile))), nil
+		}
+	case gardencorev1beta1constants.CloudProfileReferenceKindNamespacedCloudProfile:
+		namespacedCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{ObjectMeta: v1.ObjectMeta{Name: cloudProfileName, Namespace: r.ShootNamespace}}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile); err != nil {
+			return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", cloudProfileName, "namespace", r.ShootNamespace, "kind", gardencorev1beta1constants.CloudProfileReferenceKindNamespacedCloudProfile))), nil
+		}
+	default:
+		return rule.Result(r, rule.ErroredCheckResult(fmt.Sprintf("cloudProfile kind %s not recognised", kind), rule.NewTarget())), nil
+	}
+
+	target := rule.NewTarget("version", shoot.Spec.Kubernetes.Version)
+
+	if kind == gardencorev1beta1constants.CloudProfileReferenceKindCloudProfile {
+		if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, cloudProfile.Spec.Kubernetes.Versions, target); found {
+			return rule.Result(r, checkResult), nil
+		}
+		return rule.Result(r, rule.ErroredCheckResult("kubernetes version not found in cloudProfile", target)), nil
+	} else {
+		if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Spec.Kubernetes.Versions, target); found {
+			return rule.Result(r, checkResult), nil
+		}
+		if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions, target); found {
+			return rule.Result(r, checkResult), nil
+		}
+		return rule.Result(r, rule.ErroredCheckResult("kubernetes version not found in namespacedCloudProfile", target)), nil
+	}
+}
+
+func (r *Rule1001) checkShootVersion(shootVersion string, kubernetesVersions []gardencorev1beta1.ExpirableVersion, target rule.Target) (rule.CheckResult, bool) {
+	for _, version := range kubernetesVersions {
+		if shootVersion == version.Version {
+			switch {
+			case version.Classification == nil:
+				return rule.FailedCheckResult("Shoot uses an unclassified Kubernetes version", target), true
+			case slices.Contains(r.acceptedClassifications(), *version.Classification):
+				return rule.PassedCheckResult("Shoot uses a Kubernetes version with an allowed classification.", target.With("classification", string(*version.Classification))), true
+			default:
+				return rule.FailedCheckResult("Shoot uses a Kubernetes version with a non-allowed classification.", target.With("classification", string(*version.Classification))), true
+			}
+		}
+	}
+	return rule.CheckResult{}, false
+}
+
+func (r *Rule1001) acceptedClassifications() []gardencorev1beta1.VersionClassification {
+	if r.Options != nil {
+		return r.Options.AllowedClassifications
+	}
+	return []gardencorev1beta1.VersionClassification{gardencorev1beta1.ClassificationSupported}
+}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -33,7 +33,7 @@ type Rule1001 struct {
 }
 
 type Options1001 struct {
-	AllowedClassifications []gardencorev1beta1.VersionClassification
+	AllowedClassifications []gardencorev1beta1.VersionClassification `json:"allowedClassifications" yaml:"allowedClassifications"`
 }
 
 func (o Options1001) Validate() field.ErrorList {
@@ -65,7 +65,7 @@ func (r *Rule1001) Severity() rule.SeverityLevel {
 }
 
 func (r *Rule1001) Name() string {
-	return "Shoot clusters should use a supported Kubernetes version."
+	return "Shoot clusters should use a supported version of Kubernetes."
 }
 
 func (r *Rule1001) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -111,15 +111,15 @@ func (r *Rule1001) Run(ctx context.Context) (rule.RuleResult, error) {
 			return rule.Result(r, checkResult), nil
 		}
 		return rule.Result(r, rule.ErroredCheckResult("kubernetes version not found in cloudProfile", target)), nil
-	} else {
-		if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Spec.Kubernetes.Versions, target); found {
-			return rule.Result(r, checkResult), nil
-		}
-		if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions, target); found {
-			return rule.Result(r, checkResult), nil
-		}
-		return rule.Result(r, rule.ErroredCheckResult("kubernetes version not found in namespacedCloudProfile", target)), nil
 	}
+
+	if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Spec.Kubernetes.Versions, target); found {
+		return rule.Result(r, checkResult), nil
+	}
+	if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions, target); found {
+		return rule.Result(r, checkResult), nil
+	}
+	return rule.Result(r, rule.ErroredCheckResult("kubernetes version not found in namespacedCloudProfile", target)), nil
 }
 
 func (r *Rule1001) checkShootVersion(shootVersion string, kubernetesVersions []gardencorev1beta1.ExpirableVersion, target rule.Target) (rule.CheckResult, bool) {
@@ -131,7 +131,7 @@ func (r *Rule1001) checkShootVersion(shootVersion string, kubernetesVersions []g
 			case slices.Contains(r.acceptedClassifications(), *version.Classification):
 				return rule.PassedCheckResult("Shoot uses a Kubernetes version with an allowed classification.", target.With("classification", string(*version.Classification))), true
 			default:
-				return rule.FailedCheckResult("Shoot uses a Kubernetes version with a non-allowed classification.", target.With("classification", string(*version.Classification))), true
+				return rule.FailedCheckResult("Shoot uses a Kubernetes version with a forbidden classification.", target.With("classification", string(*version.Classification))), true
 			}
 		}
 	}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -65,7 +65,7 @@ func (r *Rule1001) Severity() rule.SeverityLevel {
 }
 
 func (r *Rule1001) Name() string {
-	return "Shoot clusters should use a supported version of Kubernetes."
+	return "Shoot clusters must use a supported version of Kubernetes."
 }
 
 func (r *Rule1001) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gardener/diki/pkg/rule"
 )
 
-var _ = Describe("#1002", func() {
+var _ = Describe("#1001", func() {
 	var (
 		fakeClient         client.Client
 		ctx                = context.TODO()

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
+	"github.com/gardener/diki/pkg/rule"
+)
+
+var _ = Describe("#1002", func() {
+	var (
+		fakeClient         client.Client
+		ctx                = context.TODO()
+		shootName          = "foo"
+		shootNamespace     = "bar"
+		cloudProfileName   = "foo"
+		nsCloudProfileName = "foo"
+
+		deprecatedClassification                                         = gardencorev1beta1.ClassificationDeprecated
+		supportedClassification                                          = gardencorev1beta1.ClassificationSupported
+		previewClassification                                            = gardencorev1beta1.ClassificationPreview
+		fakeClassification       gardencorev1beta1.VersionClassification = "fake"
+
+		shoot          *gardencorev1beta1.Shoot
+		cloudProfile   *gardencorev1beta1.CloudProfile
+		nsCloudProfile *gardencorev1beta1.NamespacedCloudProfile
+		r              rule.Rule
+		ruleName       = "Shoot clusters should use a supported Kubernetes version."
+		ruleID         = "1001"
+		severity       = rule.SeverityHigh
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+		}
+
+		cloudProfile = &gardencorev1beta1.CloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cloudProfileName,
+			},
+			Spec: gardencorev1beta1.CloudProfileSpec{
+				Kubernetes: gardencorev1beta1.KubernetesSettings{
+					Versions: []gardencorev1beta1.ExpirableVersion{
+						{
+							Version:        "1",
+							Classification: &supportedClassification,
+						},
+						{
+							Version:        "2",
+							Classification: &deprecatedClassification,
+						},
+						{
+							Version:        "3",
+							Classification: &previewClassification,
+						},
+					},
+				},
+			},
+		}
+
+		Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+		nsCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsCloudProfileName,
+				Namespace: shootNamespace,
+			},
+			Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
+				Kubernetes: &gardencorev1beta1.KubernetesSettings{
+					Versions: []gardencorev1beta1.ExpirableVersion{
+						{
+							Version:        "4",
+							Classification: &supportedClassification,
+						},
+					},
+				},
+			},
+			Status: gardencorev1beta1.NamespacedCloudProfileStatus{
+				CloudProfileSpec: gardencorev1beta1.CloudProfileSpec{
+					Kubernetes: gardencorev1beta1.KubernetesSettings{
+						Versions: []gardencorev1beta1.ExpirableVersion{
+							{
+								Version:        "2",
+								Classification: &supportedClassification,
+							},
+							{
+								Version:        "3",
+								Classification: &previewClassification,
+							},
+							{
+								Version:        "5",
+								Classification: &deprecatedClassification,
+							},
+							{
+								Version: "6",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(fakeClient.Create(ctx, nsCloudProfile)).To(Succeed())
+	})
+
+	DescribeTable("Run cases", func(updateFn func(), options *rules.Options1001, expectedCheckResults []rule.CheckResult) {
+		updateFn()
+		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+
+		r = &rules.Rule1001{
+			Client:         fakeClient,
+			ShootName:      shootName,
+			ShootNamespace: shootNamespace,
+			Options:        options,
+		}
+
+		res, err := r.Run(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: expectedCheckResults}))
+	},
+		Entry("should error when the shoot is not found",
+			func() { shoot.Name = "notFoo" },
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
+			},
+		),
+		Entry("should error when the specified cloudProfile is not found",
+			func() { shoot.Spec.CloudProfileName = ptr.To("notFoo") },
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Errored, Message: "cloudprofiles.core.gardener.cloud \"notFoo\" not found", Target: rule.NewTarget("kind", "CloudProfile", "name", "notFoo")},
+			},
+		),
+		Entry("should error when the specified namespacedCloudProfile is not found",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "notFoo",
+					Kind: "NamespacedCloudProfile",
+				}
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Errored, Message: "namespacedcloudprofiles.core.gardener.cloud \"notFoo\" not found", Target: rule.NewTarget("kind", "NamespacedCloudProfile", "name", "notFoo", "namespace", "bar")},
+			},
+		),
+		Entry("should pass when the shoot uses a supported version of Kubernetes",
+			func() {
+				shoot.Spec.CloudProfileName = ptr.To("foo")
+				shoot.Spec.Kubernetes.Version = "1"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "Shoot uses a Kubernetes version with an allowed classification.", Target: rule.NewTarget("version", "1", "classification", "supported")},
+			},
+		),
+		Entry("should fail when the shoot uses a deprecated version of Kubernetes",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "CloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "2"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "2", "classification", "deprecated")},
+			},
+		),
+		Entry("should fail when the shoot uses a preview version of Kubernetes",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "CloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "3"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "3", "classification", "preview")},
+			},
+		),
+		Entry("should pass when the shoot uses a supported version in the namespaceCloudProfile",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "NamespacedCloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "2"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "Shoot uses a Kubernetes version with an allowed classification.", Target: rule.NewTarget("version", "2", "classification", "supported")},
+			},
+		),
+		Entry("should fail when the shoot uses a preview version in the namespaceCloudProfile",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "NamespacedCloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "3"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "3", "classification", "preview")},
+			},
+		),
+		Entry("should fail when the shoot uses a deprecated version in the namespaceCloudProfile",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "NamespacedCloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "5"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "5", "classification", "deprecated")},
+			},
+		),
+		Entry("should error when the shoot uses an unknown version in the namespaceCloudProfile",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "NamespacedCloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "1"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Errored, Message: "kubernetes version not found in namespacedCloudProfile", Target: rule.NewTarget("version", "1")},
+			},
+		),
+		Entry("should fail when the shoot uses an unclassified version in the namespaceCloudProfile",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "NamespacedCloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "6"
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Shoot uses an unclassified Kubernetes version", Target: rule.NewTarget("version", "6")},
+			},
+		),
+		Entry("should work correctly with options",
+			func() {
+				shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+					Name: "foo",
+					Kind: "CloudProfile",
+				}
+				shoot.Spec.Kubernetes.Version = "3"
+			},
+			&rules.Options1001{
+				AllowedClassifications: []gardencorev1beta1.VersionClassification{supportedClassification, previewClassification},
+			},
+			[]rule.CheckResult{
+				{Status: rule.Passed, Message: "Shoot uses a Kubernetes version with an allowed classification.", Target: rule.NewTarget("version", "3", "classification", "preview")},
+			},
+		),
+	)
+
+	Describe("#ValidateOptions", func() {
+		It("should not error when options are correct", func() {
+			options := rules.Options1001{
+				AllowedClassifications: []gardencorev1beta1.VersionClassification{
+					supportedClassification, previewClassification,
+				},
+			}
+
+			result := options.Validate()
+			Expect(result).To(BeEmpty())
+		})
+		It("should error when options are incorrect", func() {
+			options := rules.Options1001{
+				AllowedClassifications: []gardencorev1beta1.VersionClassification{
+					supportedClassification,
+					fakeClassification,
+				},
+			}
+			result := options.Validate()
+			Expect(result).To(Equal(field.ErrorList{
+				{
+					Type:     field.ErrorTypeNotSupported,
+					Field:    "allowedClassifications",
+					BadValue: fakeClassification,
+					Detail:   "supported values: \"preview\", \"supported\", \"deprecated\"",
+				},
+			}))
+		})
+	})
+})

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -39,7 +39,7 @@ var _ = Describe("#1002", func() {
 		cloudProfile   *gardencorev1beta1.CloudProfile
 		nsCloudProfile *gardencorev1beta1.NamespacedCloudProfile
 		r              rule.Rule
-		ruleName       = "Shoot clusters should use a supported Kubernetes version."
+		ruleName       = "Shoot clusters should use a supported version of Kubernetes."
 		ruleID         = "1001"
 		severity       = rule.SeverityHigh
 	)

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -184,7 +184,7 @@ var _ = Describe("#1001", func() {
 			},
 			nil,
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "2", "classification", "deprecated")},
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a forbidden classification.", Target: rule.NewTarget("version", "2", "classification", "deprecated")},
 			},
 		),
 		Entry("should fail when the shoot uses a preview version of Kubernetes",
@@ -197,7 +197,7 @@ var _ = Describe("#1001", func() {
 			},
 			nil,
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "3", "classification", "preview")},
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a forbidden classification.", Target: rule.NewTarget("version", "3", "classification", "preview")},
 			},
 		),
 		Entry("should pass when the shoot uses a supported version in the namespaceCloudProfile",
@@ -223,7 +223,7 @@ var _ = Describe("#1001", func() {
 			},
 			nil,
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "3", "classification", "preview")},
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a forbidden classification.", Target: rule.NewTarget("version", "3", "classification", "preview")},
 			},
 		),
 		Entry("should fail when the shoot uses a deprecated version in the namespaceCloudProfile",
@@ -236,7 +236,7 @@ var _ = Describe("#1001", func() {
 			},
 			nil,
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a non-allowed classification.", Target: rule.NewTarget("version", "5", "classification", "deprecated")},
+				{Status: rule.Failed, Message: "Shoot uses a Kubernetes version with a forbidden classification.", Target: rule.NewTarget("version", "5", "classification", "deprecated")},
 			},
 		),
 		Entry("should error when the shoot uses an unknown version in the namespaceCloudProfile",

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -39,7 +39,7 @@ var _ = Describe("#1001", func() {
 		cloudProfile   *gardencorev1beta1.CloudProfile
 		nsCloudProfile *gardencorev1beta1.NamespacedCloudProfile
 		r              rule.Rule
-		ruleName       = "Shoot clusters should use a supported version of Kubernetes."
+		ruleName       = "Shoot clusters must use a supported version of Kubernetes."
 		ruleID         = "1001"
 		severity       = rule.SeverityHigh
 	)

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
@@ -5,7 +5,8 @@
 package rules
 
 type RuleOption interface {
-	Options1000 | Options1001 |
+	Options1000 |
+		Options1001 |
 		Options1002 |
 		Options2007
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
@@ -5,7 +5,7 @@
 package rules
 
 type RuleOption interface {
-	Options1000 |
+	Options1000 | Options1001 |
 		Options1002 |
 		Options2007
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -29,7 +29,7 @@ var (
 	_ ruleset.Ruleset = &Ruleset{}
 	// SupportedVersions is a list of available versions for the Security Hardened Shoot Cluster Ruleset.
 	// Versions are sorted from newest to oldest.
-	SupportedVersions = []string{"v0.1.0", "v0.2.0"}
+	SupportedVersions = []string{"v0.2.0", "v0.1.0"}
 )
 
 // Ruleset implements Security Hardened Shoot Cluster.

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -115,8 +115,8 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 
 	// check that the registered rules equal
 	// the number of rules in that ruleset version
-	if len(rules) != 11 {
-		return fmt.Errorf("revision expects 11 registered rules, but got: %d", len(rules))
+	if len(rules) != 10 {
+		return fmt.Errorf("revision expects 10 registered rules, but got: %d", len(rules))
 	}
 
 	return r.AddRules(rules...)

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -29,6 +29,10 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 	if err != nil {
 		return fmt.Errorf("rule option 1000 error: %s", err.Error())
 	}
+	opts1001, err := getV02OptionOrNil[rules.Options1001](ruleOptions["1001"].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 1001 error: %s", err.Error())
+	}
 	opts1002, err := getV02OptionOrNil[rules.Options1002](ruleOptions["1002"].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 1002 error: %s", err.Error())
@@ -44,6 +48,12 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 			ShootName:      r.args.ShootName,
 			ShootNamespace: r.args.ProjectNamespace,
 			Options:        opts1000,
+		},
+		&rules.Rule1001{
+			Client:         c,
+			ShootName:      r.args.ShootName,
+			ShootNamespace: r.args.ProjectNamespace,
+			Options:        opts1001,
 		},
 		&rules.Rule1002{
 			Client:         c,
@@ -105,8 +115,8 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 
 	// check that the registered rules equal
 	// the number of rules in that ruleset version
-	if len(rules) != 9 {
-		return fmt.Errorf("revision expects 9 registered rules, but got: %d", len(rules))
+	if len(rules) != 11 {
+		return fmt.Errorf("revision expects 11 registered rules, but got: %d", len(rules))
 	}
 
 	return r.AddRules(rules...)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements and registers rule 1001 of the `Security Hardened Shoot` ruleset for the `Garden` provider. The rule checks the shoot spec for it's Kubernetes version and evaluates it's support based on the `CloudProfile/NamespacedCloudProfile` in the project

**Which issue(s) this PR fixes**:
Fixes #432 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Implementation for rule `1001` from the `security-hardened-shoot-cluster` ruleset for provider `garden`.
```
