### PR TITLE
[Security Hardened Shoot Cluster] Improve rule 1003 

### DIFF
--- a/docs/providers/garden.md
+++ b/docs/providers/garden.md
@@ -8,6 +8,7 @@ The `Garden` provider is capable of accessing a Garden cluster environment and r
 
 The `Garden` provider implements the following `rulesets`:
 - [Security Hardened Shoot Cluster](../rulesets/security-hardened-shoot-cluster/ruleset.md)
+    - v0.2.1
     - v0.2.0
     - v0.1.0
 

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -66,9 +66,13 @@ The supported versions can be found in the used `CloudProfile`.
 ### 1003 - Shoot clusters must have the Lakom extension configured. <a id="1003"></a>
 
 #### Description
-Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster.
+Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a bare minimum Lakom should verify Gardener managed workload in the `kube-system` namespace.
 
 #### Fix
+The Lakom extension should be globally enabled by default by the Gardener admins. Please make sure you have not disabled the extension in the `spec.extensions` field.
+
+If Lakom is not enabled by default please follow the bellow guide.
+
 Add the Lakom extensions to the `spec.extensions` field.
 ``` yaml
 kind: Shoot

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -4,7 +4,7 @@
 
 The Security Hardened Shoot Cluster Guide is created by the Gardener team. It contains rules that check `Shoot` resources. The ruleset is inspired and follows some of the requirements from the [DISA Kubernetes Security Technical Implementation Guide](../disa-k8s-stig/ruleset.md).
 
-This documentation references rules from [Security Hardened Shoot Cluster Guide v0.2.0](./security-hardened-shoot-cluster-v0.2.0.yaml)
+This documentation references rules from [Security Hardened Shoot Cluster Guide v0.2.1](./security-hardened-shoot-cluster-v0.2.1.yaml)
 
 ## Rules
 
@@ -66,7 +66,7 @@ The supported versions can be found in the used `CloudProfile`.
 ### 1003 - Shoot clusters must have the Lakom extension configured. <a id="1003"></a>
 
 #### Description
-Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the `kube-system` namespace.
+Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the kube-system namespace.
 
 #### Fix
 The Lakom extension should be globally enabled by the Gardener admins so that the admission webhook verifies Gardener managed workload in the `kube-system` namespace. Please make sure you have not disabled the extension in the `spec.extensions` field.

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -69,7 +69,16 @@ The supported versions can be found in the used `CloudProfile`.
 Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster.
 
 #### Fix
-Follow the Lakom extension documentation on how to configure [TrustedKeysResourceName](https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/v0.18.1/docs/usage/shoot-extension.md#trustedkeysresourcename) with `Cluster` scope to validate all images in the cluster.
+Add the Lakom extensions to the `spec.extensions` field.
+``` yaml
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+spec:
+  extensions:
+    - type: shoot-lakom-service
+```
+If you have configured a `allowedLakomScopes` in the diki options with values different from `KubeSystemManagedByGardener` please get familiar with the different Lakom [Scopes](https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/v0.18.1/docs/usage/shoot-extension.md#scope)
+If needed follow the Lakom extension documentation on how to configure [TrustedKeysResourceName](https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/v0.18.1/docs/usage/shoot-extension.md#trustedkeysresourcename).
 
 ---
 

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -69,7 +69,7 @@ The supported versions can be found in the used `CloudProfile`.
 Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster.
 
 #### Fix
-Follow the Lakom extension documentation on how to configure [TrustedKeysResourceName](https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/v0.18.1/docs/usage/shoot-extension.md#trustedkeysresourcename).
+Follow the Lakom extension documentation on how to configure [TrustedKeysResourceName](https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/v0.18.1/docs/usage/shoot-extension.md#trustedkeysresourcename) with `Cluster` scope to validate all images in the cluster.
 
 ---
 

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -186,7 +186,7 @@ spec:
 ### 2007 - Shoot clusters must have a PodSecurity admission plugin configured. <a id="2007"></a>
 
 #### Description
-Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to `baseline` or `restricted` level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800).
+Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to 'baseline' or 'restricted' level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800).
 
 #### Fix
 Add `PodSecurity` admission plugin into `spec.kubernetes.kubeAPIServer.admissionPlugins` field with default standards set to `baseline` or `restricted`.

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -66,7 +66,7 @@ The supported versions can be found in the used `CloudProfile`.
 ### 1003 - Shoot clusters must have the Lakom extension configured. <a id="1003"></a>
 
 #### Description
-Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the kube-system namespace.
+Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the `kube-system` namespace.
 
 #### Fix
 The Lakom extension should be globally enabled by the Gardener admins so that the admission webhook verifies Gardener managed workload in the `kube-system` namespace. Please make sure you have not disabled the extension in the `spec.extensions` field.

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -186,7 +186,7 @@ spec:
 ### 2007 - Shoot clusters must have a PodSecurity admission plugin configured. <a id="2007"></a>
 
 #### Description
-Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to 'baseline' or 'restricted' level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800).
+Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to `baseline` or `restricted` level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800).
 
 #### Fix
 Add `PodSecurity` admission plugin into `spec.kubernetes.kubeAPIServer.admissionPlugins` field with default standards set to `baseline` or `restricted`.

--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -66,23 +66,12 @@ The supported versions can be found in the used `CloudProfile`.
 ### 1003 - Shoot clusters must have the Lakom extension configured. <a id="1003"></a>
 
 #### Description
-Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a bare minimum Lakom should verify Gardener managed workload in the `kube-system` namespace.
+Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the `kube-system` namespace.
 
 #### Fix
-The Lakom extension should be globally enabled by default by the Gardener admins. Please make sure you have not disabled the extension in the `spec.extensions` field.
+The Lakom extension should be globally enabled by the Gardener admins so that the admission webhook verifies Gardener managed workload in the `kube-system` namespace. Please make sure you have not disabled the extension in the `spec.extensions` field.
 
-If Lakom is not enabled by default please follow the bellow guide.
-
-Add the Lakom extensions to the `spec.extensions` field.
-``` yaml
-kind: Shoot
-apiVersion: core.gardener.cloud/v1beta1
-spec:
-  extensions:
-    - type: shoot-lakom-service
-```
-If you have configured a `allowedLakomScopes` in the diki options with values different from `KubeSystemManagedByGardener` please get familiar with the different Lakom [Scopes](https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/v0.18.1/docs/usage/shoot-extension.md#scope)
-If needed follow the Lakom extension documentation on how to configure [TrustedKeysResourceName](https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/v0.18.1/docs/usage/shoot-extension.md#trustedkeysresourcename).
+If you want to extend the scope of the verified images to include non-Gardener workload you can do so by explicitly configuring the extension. Please see [its documentation](https://gardener.cloud/docs/extensions/others/gardener-extension-shoot-lakom-service/shoot-extension/) for more details.
 
 ---
 

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -49,5 +49,5 @@ rules:
   severity: "MEDIUM"
 - id: 2007
   name: "Shoot clusters must have a PodSecurity admission plugin configured."
-  description: "Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to 'baseline' or 'restricted' level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800)."
+  description: "Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to baseline or restricted level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800)."
   severity: "HIGH"

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -49,5 +49,5 @@ rules:
   severity: "MEDIUM"
 - id: 2007
   name: "Shoot clusters must have a PodSecurity admission plugin configured."
-  description: "Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to `baseline` or `restricted` level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800)."
+  description: "Shoot clusters must have a PodSecurity admission plugin configured. It is recommended to set default pod security standards to 'baseline' or 'restricted' level. This rule follows the requirements from DISA K8s STIG rule [254800](https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-254800)."
   severity: "HIGH"

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -21,7 +21,7 @@ rules:
   severity: "HIGH"
 - id: 1003
   name: "Shoot clusters must have the Lakom extension configured."
-  description: "Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a bare minimum Lakom should verify Gardener managed workload in the `kube-system` namespace."
+  description: "Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the `kube-system` namespace."
   severity: "HIGH"
 - id: 2000
   name: "Shoot clusters must have anonymous authentication disabled for the Kubernetes API server."

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -5,7 +5,7 @@
 ruleset:
   id: security-hardened-shoot-cluster
   name: "Security Hardened Shoot Cluster"
-  version: "v0.2.0"
+  version: "v0.2.1-dev"
 rules:
 - id: 1000
   name: "Shoot clusters should enable required extensions."
@@ -21,7 +21,7 @@ rules:
   severity: "HIGH"
 - id: 1003
   name: "Shoot clusters must have the Lakom extension configured."
-  description: "Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster."
+  description: "Lakom is an admission controller which implements image signature verification. Shoot clusters must have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a bare minimum Lakom should verify Gardener managed workload in the `kube-system` namespace."
   severity: "HIGH"
 - id: 2000
   name: "Shoot clusters must have anonymous authentication disabled for the Kubernetes API server."

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -5,7 +5,7 @@
 ruleset:
   id: security-hardened-shoot-cluster
   name: "Security Hardened Shoot Cluster"
-  version: "v0.2.1-dev"
+  version: "v0.2.1"
 rules:
 - id: 1000
   name: "Shoot clusters should enable required extensions."
@@ -21,7 +21,7 @@ rules:
   severity: "HIGH"
 - id: 1003
   name: "Shoot clusters must have the Lakom extension configured."
-  description: "Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the `kube-system` namespace."
+  description: "Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the kube-system namespace."
   severity: "HIGH"
 - id: 2000
   name: "Shoot clusters must have anonymous authentication disabled for the Kubernetes API server."

--- a/example/config/garden.yaml
+++ b/example/config/garden.yaml
@@ -30,6 +30,12 @@ providers:       # contains information about known providers
     #       allowedClassifications:
     #       - supported
     #       - preview
+    # - ruleID: "1003"
+    #   args:
+    #     allowedLakomScopes: # Defaults to a full list of valid scopes
+    #     - KubeSystemManagedByGardener
+    #     - KubeSystem
+    #     - Cluster
     # - ruleID: "2000"
     #   skip:
     #     enabled: true

--- a/example/config/garden.yaml
+++ b/example/config/garden.yaml
@@ -32,7 +32,7 @@ providers:       # contains information about known providers
     #       - preview
     # - ruleID: "1003"
     #   args:
-    #     allowedLakomScopes: # Defaults to a full list of valid scopes
+    #     allowedLakomScopes: # Config can be skipped as it defaults to the full list of valid scopes
     #     - KubeSystemManagedByGardener
     #     - KubeSystem
     #     - Cluster

--- a/example/config/garden.yaml
+++ b/example/config/garden.yaml
@@ -8,7 +8,7 @@ providers:       # contains information about known providers
   rulesets:
   - id: security-hardened-shoot-cluster
     name: Security Hardened Shoot Cluster
-    version: v0.2.0
+    version: v0.2.1
     args:
       projectNamespace: garden-project-name # name of project namespace containing the shoot resource to be tested
       shootName: foo                        # name of shoot resource to be tested

--- a/example/guides/disa-k8s-stig-shoot.yaml
+++ b/example/guides/disa-k8s-stig-shoot.yaml
@@ -97,7 +97,7 @@ providers:
   rulesets:
   - id: security-hardened-shoot-cluster
     name: Security Hardened Shoot Cluster
-    version: v0.2.0
+    version: v0.2.1
     args:
       projectNamespace: garden-project-name # name of project namespace containing the shoot resource to be tested
       shootName: shoot-abcd                 # name of shoot resource to be tested

--- a/pkg/provider/builder/garden.go
+++ b/pkg/provider/builder/garden.go
@@ -31,7 +31,7 @@ func GardenProviderFromConfig(conf config.ProviderConfig) (provider.Provider, er
 	for _, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case securityhardenedshoot.RulesetID:
-			ruleset, err := securityhardenedshoot.FromGenericConfig(rulesetConfig, p.Config)
+			ruleset, err := securityhardenedshoot.FromGenericConfig(rulesetConfig, p.Config, providerLogger)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/garden/provider.go
+++ b/pkg/provider/garden/provider.go
@@ -71,6 +71,7 @@ func (p *Provider) RunAll(ctx context.Context) (provider.ProviderResult, error) 
 }
 
 func rulesetKey(rulesetID, rulesetVersion string) string {
+	// TODO: Remove this case when we no longer support security-hardened-shoot-cluster versions v0.2.x
 	if rulesetID == "security-hardened-shoot-cluster" && rulesetVersion == "v0.2.0" {
 		return rulesetID + "--v0.2.1"
 	}

--- a/pkg/provider/garden/provider.go
+++ b/pkg/provider/garden/provider.go
@@ -71,6 +71,10 @@ func (p *Provider) RunAll(ctx context.Context) (provider.ProviderResult, error) 
 }
 
 func rulesetKey(rulesetID, rulesetVersion string) string {
+	if rulesetID == "security-hardened-shoot-cluster" && rulesetVersion == "v0.2.0" {
+		return rulesetID + "--v0.2.1"
+	}
+
 	return rulesetID + "--" + rulesetVersion
 }
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
@@ -94,7 +94,7 @@ var _ = Describe("#1003", func() {
 				{Status: rule.Failed, Message: "Extension shoot-lakom-service is not configured for the shoot cluster.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should fail when Lakom extension does not have extension configuration",
+		Entry("should pass when Lakom extension does not have extension config",
 			func() {
 				shoot.Labels = map[string]string{
 					"extensions.extensions.gardener.cloud/shoot-lakom-service": "true",
@@ -102,7 +102,20 @@ var _ = Describe("#1003", func() {
 			},
 			nil,
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Extension shoot-lakom-service is not configured for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "Extension shoot-lakom-service configured correctly for the shoot cluster.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should fail when Lakom extension does not have extension config and default scope is not allowed",
+			func() {
+				shoot.Labels = map[string]string{
+					"extensions.extensions.gardener.cloud/shoot-lakom-service": "true",
+				}
+			},
+			&rules.Options1003{
+				AllowedLakomScopes: []lakomapi.ScopeType{kubeSystemScope, clusterScope},
+			},
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Extension shoot-lakom-service is not configured with allowed scope.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should warn when Lakom extension is disabled",
@@ -133,7 +146,7 @@ var _ = Describe("#1003", func() {
 				{Status: rule.Warning, Message: "Extension shoot-lakom-service has unexpected label value: false.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should fail when Lakom extension does not have provider config",
+		Entry("should pass when Lakom extension does not have provider config",
 			func() {
 				shoot.Labels = map[string]string{
 					"extensions.extensions.gardener.cloud/shoot-lakom-service": "true",
@@ -146,7 +159,25 @@ var _ = Describe("#1003", func() {
 			},
 			nil,
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Extension shoot-lakom-service is not configured for the shoot cluster.", Target: rule.NewTarget()},
+				{Status: rule.Passed, Message: "Extension shoot-lakom-service configured correctly for the shoot cluster.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should fail when Lakom extension does not have provider config and default scope is not allowed",
+			func() {
+				shoot.Labels = map[string]string{
+					"extensions.extensions.gardener.cloud/shoot-lakom-service": "true",
+				}
+				shoot.Spec.Extensions = []gardencorev1beta1.Extension{
+					{
+						Type: "shoot-lakom-service",
+					},
+				}
+			},
+			&rules.Options1003{
+				AllowedLakomScopes: []lakomapi.ScopeType{kubeSystemScope, clusterScope},
+			},
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Extension shoot-lakom-service is not configured with allowed scope.", Target: rule.NewTarget()},
 			},
 		),
 		Entry("should pass when Lakom extension is configured",

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
@@ -118,7 +118,21 @@ var _ = Describe("#1003", func() {
 				{Status: rule.Failed, Message: "Extension shoot-lakom-service is not configured with allowed scope.", Target: rule.NewTarget()},
 			},
 		),
-		Entry("should warn when Lakom extension is disabled",
+		Entry("should fail when Lakom extension is explicitly disabled but label is missing",
+			func() {
+				shoot.Spec.Extensions = []gardencorev1beta1.Extension{
+					{
+						Type:     "shoot-lakom-service",
+						Disabled: ptr.To(true),
+					},
+				}
+			},
+			nil,
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Extension shoot-lakom-service is not configured for the shoot cluster.", Target: rule.NewTarget()},
+			},
+		),
+		Entry("should warn when Lakom extension is explicitly disabled but label says extension is enabled",
 			func() {
 				shoot.Labels = map[string]string{
 					"extensions.extensions.gardener.cloud/shoot-lakom-service": "true",

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
@@ -8,5 +8,6 @@ type RuleOption interface {
 	Options1000 |
 		Options1001 |
 		Options1002 |
+		Options1003 |
 		Options2007
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
+	"github.com/gardener/diki/pkg/shared/provider"
 	sharedruleset "github.com/gardener/diki/pkg/shared/ruleset"
 )
 
@@ -29,7 +30,7 @@ var (
 	_ ruleset.Ruleset = &Ruleset{}
 	// SupportedVersions is a list of available versions for the Security Hardened Shoot Cluster Ruleset.
 	// Versions are sorted from newest to oldest.
-	SupportedVersions = []string{"v0.2.0", "v0.1.0"}
+	SupportedVersions = []string{"v0.2.1", "v0.2.0", "v0.1.0"}
 )
 
 // Ruleset implements Security Hardened Shoot Cluster.
@@ -78,7 +79,7 @@ func (r *Ruleset) Version() string {
 }
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
-func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config) (*Ruleset, error) {
+func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config, logger provider.Logger) (*Ruleset, error) {
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
 		return nil, err
@@ -113,6 +114,15 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 			return nil, err
 		}
 	case "v0.2.0":
+		logger.Info("Using version v0.2.1 as latest patch version of security-hardened-shoot-cluster v0.2")
+
+		setLatestPatchVersion := WithVersion("v0.2.1")
+		setLatestPatchVersion(ruleset)
+
+		if err := ruleset.registerV02Rules(ruleOptions); err != nil {
+			return nil, err
+		}
+	case "v0.2.1":
 		if err := ruleset.registerV02Rules(ruleOptions); err != nil {
 			return nil, err
 		}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -114,7 +114,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 			return nil, err
 		}
 	case "v0.2.0":
-		logger.Info("Using version v0.2.1 as latest patch version of security-hardened-shoot-cluster v0.2")
+		logger.Info("Using version v0.2.1 as latest patch version of security-hardened-shoot-cluster v0.2.x ruleset")
 
 		setLatestPatchVersion := WithVersion("v0.2.1")
 		setLatestPatchVersion(ruleset)

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -37,6 +37,10 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 	if err != nil {
 		return fmt.Errorf("rule option 1002 error: %s", err.Error())
 	}
+	opts1003, err := getV02OptionOrNil[rules.Options1003](ruleOptions["1003"].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 1003 error: %s", err.Error())
+	}
 	opts2007, err := getV02OptionOrNil[rules.Options2007](ruleOptions["2007"].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 2007 error: %s", err.Error())
@@ -65,6 +69,7 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 			Client:         c,
 			ShootName:      r.args.ShootName,
 			ShootNamespace: r.args.ProjectNamespace,
+			Options:        opts1003,
 		},
 		&rules.Rule2000{
 			Client:         c,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves rule 1003 for `security-hardened-shoot-cluster` ruleset by also checking if extension Lakom is configured with `Cluster` scope in order to validate all images in cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Rule `1003` from the `security-hardened-shoot-cluster` ruleset for provider `garden` now checks if the Lakom extension is enabled, starting from version `v0.2.1`.

```
```feature user
Rule `1003` from the `security-hardened-shoot-cluster` ruleset for provider `garden` now can be configured with an allowed list of Lakom scopes., starting from version `v0.2.1`.
```
