### PR TITLE
Change severity for rules 1001 & 1002 from shsc

### DIFF
--- a/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
+++ b/docs/rulesets/security-hardened-shoot-cluster/ruleset.md
@@ -24,10 +24,10 @@ spec:
 ```
 ---
 
-### 1001 - Shoot clusters must use a supported version of Kubernetes. <a id="1001"></a>
+### 1001 - Shoot clusters should use a supported version of Kubernetes. <a id="1001"></a>
 
 #### Description
-Shoot clusters must use a supported version of Kubernetes. This rule can be configured to accept specific version classifications.
+Shoot clusters should use a supported version of Kubernetes. This rule can be configured to accept specific version classifications.
 
 #### Fix
 Configure `supported` Kuberenetes version in the `spec.kubernetes.version` field.
@@ -41,10 +41,10 @@ spec:
 
 The supported versions can be found in the used `CloudProfile`.
 
-### 1002 - Shoot clusters must use supported versions for their Workers' images. <a id="1002"></a>
+### 1002 - Shoot clusters should use supported versions for their Workers' images. <a id="1002"></a>
 
 #### Description
-Shoot clusters must use supported versions for their Workers' images. This rule can be configured to accept specific image classifications.
+Shoot clusters should use supported versions for their Workers' images. This rule can be configured to accept specific image classifications.
 
 #### Fix
 Configure `supported` machine image versions in the `spec.provider.workers[].machine.image.version` field.

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -12,13 +12,13 @@ rules:
   description: "Shoot clusters should enable required extensions. This rule can be configured as per organisation's requirements in order to check if required extensions are enabled for the shoot cluster."
   severity: "MEDIUM"
 - id: 1001
-  name: "Shoot clusters must use a supported version of Kubernetes."
-  description: "Shoot clusters must use a supported version of Kubernetes. This rule can be configured to accept specific version classifications."
-  severity: "HIGH"
+  name: "Shoot clusters should use a supported version of Kubernetes."
+  description: "Shoot clusters should use a supported version of Kubernetes. This rule can be configured to accept specific version classifications."
+  severity: "MEDIUM"
 - id: 1002
-  name: "Shoot clusters must use supported versions for their Workers' images."
-  description: "Shoot clusters must use supported versions for their Workers' images. This rule can be configured to accept specific image classifications."
-  severity: "HIGH"
+  name: "Shoot clusters should use supported versions for their Workers' images."
+  description: "Shoot clusters should use supported versions for their Workers' images. This rule can be configured to accept specific image classifications."
+  severity: "MEDIUM"
 - id: 1003
   name: "Shoot clusters must have the Lakom extension configured."
   description: "Lakom is an admission controller which implements image signature verification. Shoot clusters should have the Lakom extension configured with trusted public keys so that only trusted images are allowed in the cluster. As a minimum requirement Lakom must verify workload managed by Gardener in the kube-system namespace."

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -61,11 +61,11 @@ func (r *Rule1001) ID() string {
 }
 
 func (r *Rule1001) Severity() rule.SeverityLevel {
-	return rule.SeverityHigh
+	return rule.SeverityMedium
 }
 
 func (r *Rule1001) Name() string {
-	return "Shoot clusters must use a supported version of Kubernetes."
+	return "Shoot clusters should use a supported version of Kubernetes."
 }
 
 func (r *Rule1001) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -39,9 +39,9 @@ var _ = Describe("#1001", func() {
 		cloudProfile   *gardencorev1beta1.CloudProfile
 		nsCloudProfile *gardencorev1beta1.NamespacedCloudProfile
 		r              rule.Rule
-		ruleName       = "Shoot clusters must use a supported version of Kubernetes."
+		ruleName       = "Shoot clusters should use a supported version of Kubernetes."
 		ruleID         = "1001"
-		severity       = rule.SeverityHigh
+		severity       = rule.SeverityMedium
 	)
 
 	BeforeEach(func() {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
@@ -71,11 +71,11 @@ func (r *Rule1002) ID() string {
 }
 
 func (r *Rule1002) Name() string {
-	return "Shoot clusters must use supported versions for their Workers' images."
+	return "Shoot clusters should use supported versions for their Workers' images."
 }
 
 func (r *Rule1002) Severity() rule.SeverityLevel {
-	return rule.SeverityHigh
+	return rule.SeverityMedium
 }
 
 func (r *Rule1002) Run(ctx context.Context) (rule.RuleResult, error) {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
@@ -39,9 +39,9 @@ var _ = Describe("#1002", func() {
 		cloudProfile   *gardencorev1beta1.CloudProfile
 		nsCloudProfile *gardencorev1beta1.NamespacedCloudProfile
 		r              rule.Rule
-		ruleName       = "Shoot clusters must use supported versions for their Workers' images."
+		ruleName       = "Shoot clusters should use supported versions for their Workers' images."
 		ruleID         = "1002"
-		severity       = rule.SeverityHigh
+		severity       = rule.SeverityMedium
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the severity of rules `1001` and `1002` from the `security-hardened-shoot-cluster` ruleset for provider `garden` from `HIGH` severity to `MEDIUM`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Rule `1001` from the `security-hardened-shoot-cluster` ruleset for provider `garden` now has it's severity downgraded from `HIGH` to `MEDIUM`, starting from version `v0.2.1`.
```
```other user
Rule `1002` from the `security-hardened-shoot-cluster` ruleset for provider `garden` now has it's severity downgraded from `HIGH` to `MEDIUM`, starting from version `v0.2.1`.
```
