### PR TITLE
Improve example diki configs and usage docs

### DIFF
--- a/docs/usage/disa-k8s-stig-shoot.md
+++ b/docs/usage/disa-k8s-stig-shoot.md
@@ -34,9 +34,9 @@ Set the following arguments:
 ``` yaml
 - id: managedk8s
   name: "Managed Kubernetes"
-  metadata:
-    # foo: bar
+  metadata: # custom user metadata
     # shootName: <shoot-name>
+    # foo: bar
   args:
     kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig
 ```
@@ -53,8 +53,8 @@ Set the following arguments:
 ``` yaml
 - id: garden
   name: "Garden"
-  metadata:
-  #  foo: bar
+  metadata: # custom user metadata
+    # foo: bar
   args:
     kubeconfigPath: <garden-kubeconfig-path>  # path to garden cluster kubeconfig
   rulesets:

--- a/docs/usage/disa-k8s-stig-shoot.md
+++ b/docs/usage/disa-k8s-stig-shoot.md
@@ -29,6 +29,17 @@ We will be using the sample [DISA K8s STIG for Shoots configuration file](../../
 
 Set the following arguments:
 - `providers[id=="managedk8s"].args.kubeconfigPath` pointing to a shoot admin kubeconfig.
+- (optional) `providers[id=="managedk8s"].metadata.shootName` should be set to the name of the shoot cluster. The `metadata` field contains custom metadata from the user that will be present in the generated report.
+
+``` yaml
+- id: managedk8s
+  name: "Managed Kubernetes"
+  metadata:
+    # foo: bar
+    # shootName: <shoot-name>
+  args:
+    kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig
+```
 
 In case you need instructions on how to generate such a kubeconfig, please read [Accessing Shoot Clusters](https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md).
 
@@ -38,6 +49,22 @@ Set the following arguments:
 - `providers[id=="garden"].args.kubeconfigPath` pointing to the Garden cluster kubeconfig.
 - `providers[id=="garden"].rulesets.args.projectNamespace` should be set to the namespace in which the shoot cluster is created.
 - `providers[id=="garden"].rulesets.args.shootName` should be set to the name of the shoot cluster.
+
+``` yaml
+- id: garden
+  name: "Garden"
+  metadata:
+  #  foo: bar
+  args:
+    kubeconfigPath: <garden-kubeconfig-path>  # path to garden cluster kubeconfig
+  rulesets:
+  - id: security-hardened-shoot-cluster
+    name: Security Hardened Shoot Cluster
+    version: v0.2.1
+    args:
+      projectNamespace: garden-<project-name> # name of project namespace containing the shoot resource to be tested
+      shootName: <shoot-name>                 # name of shoot resource to be tested
+```
 
 #### Additional configurations
 

--- a/docs/usage/security-hardened-k8s-shoot.md
+++ b/docs/usage/security-hardened-k8s-shoot.md
@@ -25,7 +25,7 @@ Set the following arguments:
 ``` yaml
 - id: managedk8s
   name: "Managed Kubernetes"
-  metadata:
+  metadata: # custom user metadata
     # shootName: <shoot-name>
   args:
     kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig

--- a/docs/usage/security-hardened-k8s-shoot.md
+++ b/docs/usage/security-hardened-k8s-shoot.md
@@ -20,6 +20,16 @@ We will be using the sample [Security Hardened Kubernetes Guide for Shoots confi
 
 Set the following arguments:
 - `providers[id=="managedk8s"].args.kubeconfigPath` pointing to a shoot admin kubeconfig.
+- (optional) `providers[id=="managedk8s"].metadata.shootName` should be set to the name of the shoot cluster. The `metadata` field contains custom metadata from the user that will be present in the generated report.
+
+``` yaml
+- id: managedk8s
+  name: "Managed Kubernetes"
+  metadata:
+    # shootName: <shoot-name>
+  args:
+    kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig
+```
 
 In case you need instructions on how to generate such a kubeconfig, please read [Accessing Shoot Clusters](https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md).
 

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -33,7 +33,7 @@ providers:             # contains information about known providers
             k8s-app: node-local-dns
           namespaceMatchLabels:
             kubernetes.io/metadata.name: kube-system
-          justification: "node local dns is allowed because of special handling!"
+          justification: "Node local dns requires port 53 in order to operate properly."
           ports:
           - 53
         - podMatchLabels:

--- a/example/guides/disa-k8s-stig-shoot.yaml
+++ b/example/guides/disa-k8s-stig-shoot.yaml
@@ -1,9 +1,9 @@
 providers:
 - id: managedk8s
   name: "Managed Kubernetes"
-  metadata:
-    # foo: bar
+  metadata: # custom user metadata
     # shootName: <shoot-name>
+    # foo: bar
   args:
     kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig
   rulesets:
@@ -90,8 +90,8 @@ providers:
         - worker.gardener.cloud/pool
 - id: garden
   name: "Garden"
-  metadata:
-  #  foo: bar
+  metadata: # custom user metadata
+    # foo: bar
   args:
     kubeconfigPath: <garden-kubeconfig-path>  # path to garden cluster kubeconfig
   rulesets:

--- a/example/guides/disa-k8s-stig-shoot.yaml
+++ b/example/guides/disa-k8s-stig-shoot.yaml
@@ -3,9 +3,9 @@ providers:
   name: "Managed Kubernetes"
   metadata:
     # foo: bar
-    shootName: shoot-abcd
+    # shootName: <shoot-name>
   args:
-    kubeconfigPath: /shoot-abcd-access/kubeconfig  # path to shoot admin kubeconfig
+    kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
@@ -49,7 +49,7 @@ providers:
             k8s-app: node-local-dns
           namespaceMatchLabels:
             kubernetes.io/metadata.name: kube-system
-          justification: "node local dns requires port 53 in order to operate properly"
+          justification: "Node local dns requires port 53 in order to operate properly."
           ports:
           - 53
     - ruleID: "242417"
@@ -59,7 +59,7 @@ providers:
             resources.gardener.cloud/managed-by: gardener
           namespaceMatchLabels:
             kubernetes.io/metadata.name: kube-system
-          justification: "Pods managed by Gardener are not considered as user pods"
+          justification: "Pods managed by Gardener are not considered as user pods."
     - ruleID: "242449"
       args:
         nodeGroupByLabels:
@@ -93,14 +93,14 @@ providers:
   metadata:
   #  foo: bar
   args:
-    kubeconfigPath: /garden/config  # path to garden cluster kubeconfig
+    kubeconfigPath: <garden-kubeconfig-path>  # path to garden cluster kubeconfig
   rulesets:
   - id: security-hardened-shoot-cluster
     name: Security Hardened Shoot Cluster
     version: v0.2.1
     args:
-      projectNamespace: garden-project-name # name of project namespace containing the shoot resource to be tested
-      shootName: shoot-abcd                 # name of shoot resource to be tested
+      projectNamespace: garden-<project-name> # name of project namespace containing the shoot resource to be tested
+      shootName: <shoot-name>                 # name of shoot resource to be tested
     ruleOptions:
     - ruleID: "2007"
       args:

--- a/example/guides/security-hardened-k8s-shoot.yaml
+++ b/example/guides/security-hardened-k8s-shoot.yaml
@@ -2,9 +2,9 @@ providers:
 - id: managedk8s
   name: "Managed Kubernetes"
   metadata:
-    shootName: shoot-abcd
+    # shootName: <shoot-name>
   args:
-    kubeconfigPath: /shoot-abcd-access/kubeconfig  # path to shoot admin kubeconfig
+    kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig
   rulesets:
   - id: security-hardened-k8s
     name: Security Hardened Kubernetes Cluster
@@ -15,7 +15,7 @@ providers:
         acceptedNamespaces:
         - matchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Gardener managed namespaces are accepted to allow traffic by default"
+          justification: "Gardener managed namespaces are accepted to allow traffic by default."
           acceptedTraffic:
             ingress: true
             egress: true
@@ -26,7 +26,7 @@ providers:
             resources.gardener.cloud/managed-by: gardener
           namespaceMatchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Gardener managed resources are accepted to allow privilege escalation"
+          justification: "Gardener managed resources are accepted to allow privilege escalation."
     - ruleID: "2003"
       args:
         acceptedPods:
@@ -34,7 +34,7 @@ providers:
             resources.gardener.cloud/managed-by: gardener
           namespaceMatchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Gardener managed resources are accepted to use a wider range of volume types"
+          justification: "Gardener managed resources are accepted to use a wider range of volume types."
           volumeNames:
           - "*"
     - ruleID: "2006"
@@ -44,14 +44,14 @@ providers:
             resources.gardener.cloud/managed-by: gardener
           namespaceMatchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Roles managed by Gardener are accepted to use wildcards in RBAC resources"
+          justification: "Roles managed by Gardener are accepted to use wildcards in RBAC resources."
         acceptedClusterRoles:
         - matchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Kubernetes default ClusterRoles are accepted to use wildcards in RBAC resources"
+          justification: "ClusterRoles managed by Gardener are accepted to use wildcards in RBAC resources."
         - matchLabels:
              kubernetes.io/bootstrapping: rbac-defaults
-          justification: "Kubernetes default ClusterRoles are accepted to use wildcards in RBAC verbs"
+          justification: "Kubernetes default ClusterRoles are accepted to use wildcards in RBAC resources."
     - ruleID: "2007"
       args:
         acceptedRoles:
@@ -59,14 +59,14 @@ providers:
             resources.gardener.cloud/managed-by: gardener
           namespaceMatchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "ClusterRoles managed by Gardener are accepted to use wildcards in RBAC verbs"
+          justification: "Roles managed by Gardener are accepted to use wildcards in RBAC verbs."
         acceptedClusterRoles:
         - matchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Kubernetes default ClusterRoles are accepted to use wildcards in RBAC verbs"
+          justification: "ClusterRoles managed by Gardener are accepted to use wildcards in RBAC verbs."
         - matchLabels:
              kubernetes.io/bootstrapping: rbac-defaults
-          justification: "Kubernetes default ClusterRoles are accepted to use wildcards in RBAC verbs"
+          justification: "Kubernetes default ClusterRoles are accepted to use wildcards in RBAC verbs."
     - ruleID: "2008"
       args:
         acceptedPods:
@@ -74,7 +74,7 @@ providers:
             resources.gardener.cloud/managed-by: gardener
           namespaceMatchLabels:
             resources.gardener.cloud/managed-by: gardener
-          justification: "Gardener managed resources are accepted to use a wider range of volume types"
+          justification: "Gardener managed resources are accepted to use a wider range of volume types."
           volumeNames:
           - "*"
 output:

--- a/example/guides/security-hardened-k8s-shoot.yaml
+++ b/example/guides/security-hardened-k8s-shoot.yaml
@@ -1,8 +1,9 @@
 providers:
 - id: managedk8s
   name: "Managed Kubernetes"
-  metadata:
+  metadata: # custom user metadata
     # shootName: <shoot-name>
+    # foo: bar
   args:
     kubeconfigPath: <shoot-kubeconfig-path>  # path to shoot admin kubeconfig
   rulesets:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves example diki configs by updating justifications messages and using `< >` to note places the user needs to configure.

This PR also adds code snippets to the usage docs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @n-boshnakov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
