### PR TITLE
[DISA K8s STIG] Add support for version v2r3

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ diki run \
     --config=config.yaml \
     --provider=gardener \
     --ruleset-id=disa-kubernetes-stig \
-    --ruleset-version=v2r2
+    --ruleset-version=v2r3
 ```
 
 - Run a specific rule defined in a ruleset for a known provider
@@ -95,7 +95,7 @@ diki run \
     --config=config.yaml \
     --provider=gardener \
     --ruleset-id=disa-kubernetes-stig \
-    --ruleset-version=v2r2 \
+    --ruleset-version=v2r3 \
     --rule-id=242414
 ```
 

--- a/docs/providers/gardener.md
+++ b/docs/providers/gardener.md
@@ -8,8 +8,8 @@ The `Gardener` provider is capable of accessing a `seed/shoot` environment and r
 
 The `Gardener` provider implements the following `rulesets`:
 - [DISA Kubernetes Security Technical Implementation Guide](../rulesets/disa-k8s-stig/ruleset.md)
+    - v2r3
     - v2r2
-    - v2r1
     
 ### Configuration
 

--- a/docs/providers/managedk8s.md
+++ b/docs/providers/managedk8s.md
@@ -8,8 +8,8 @@ The `Managed Kubernetes` provider is capable of accessing a managed Kubernetes e
 
 The `Managed Kubernetes` provider implements the following `rulesets`:
 - [DISA Kubernetes Security Technical Implementation Guide](../rulesets/disa-k8s-stig/ruleset.md)
+    - v2r3
     - v2r2
-    - v2r1
     
 - [Security Hardened Kubernetes Cluster](../rulesets/security-hardened-k8s/ruleset.md)
     - v0.1.0

--- a/docs/providers/virtualgarden.md
+++ b/docs/providers/virtualgarden.md
@@ -8,8 +8,8 @@ The `Virtual Garden` provider is capable of accessing a `runtime/virtual garden`
 
 The `Gardener` provider implements the following `rulesets`:
 - [DISA Kubernetes Security Technical Implementation Guide](../rulesets/disa-k8s-stig/ruleset.md)
+    - v2r3
     - v2r2
-    - v2r1
     
 
 ### Configuration

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -15,7 +15,7 @@ providers:             # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r2
+    version: v2r3
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -10,7 +10,7 @@ providers:                   # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r2
+    version: v2r3
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -10,7 +10,7 @@ providers:               # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r2
+    version: v2r3
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:

--- a/example/guides/disa-k8s-stig-shoot.yaml
+++ b/example/guides/disa-k8s-stig-shoot.yaml
@@ -9,7 +9,7 @@ providers:
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r2
+    version: v2r3
     ruleOptions:
     - ruleID: "242393"
       args:

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -9,7 +9,7 @@ set -e
 rule_id=""
 provider="gardener"
 ruleset_id="disa-kubernetes-stig"
-ruleset_version="v2r2"
+ruleset_version="v2r3"
 run_all="false"
 
 
@@ -29,7 +29,7 @@ This command runs diki with a specified config file.
                       specified ruleset are executed.
     --provider        Ruleset provider. Defaults to "gardener".
     --ruleset-id      ID of ruleset that will be ran. Defaults to "disa-kubernetes-stig".
-    --ruleset-version Version of ruleset that will be ran. Defaults to "v2r2".
+    --ruleset-version Version of ruleset that will be ran. Defaults to "v2r3".
     
   environment variables:
     IMAGEVECTOR_OVERWRITE Overwrites diki/imagesvector/images.yaml file with specified file path.

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -31,7 +31,7 @@ var (
 	_ ruleset.Ruleset = &Ruleset{}
 	// SupportedVersions is a list of available versions for the DISA Kubernetes STIG Ruleset.
 	// Versions are sorted from newest to oldest.
-	SupportedVersions = []string{"v2r2", "v2r1"}
+	SupportedVersions = []string{"v2r3", "v2r2"}
 )
 
 // Ruleset implements DISA Kubernetes STIG.
@@ -121,12 +121,12 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 	}
 
 	switch rulesetConfig.Version {
-	case "v2r1":
-		if err := ruleset.registerV2R1Rules(ruleOptions); err != nil {
-			return nil, err
-		}
 	case "v2r2":
 		if err := ruleset.registerV2R2Rules(ruleOptions); err != nil {
+			return nil, err
+		}
+	case "v2r3":
+		if err := ruleset.registerV2R3Rules(ruleOptions); err != nil {
 			return nil, err
 		}
 	default:

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +23,7 @@ import (
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
-func parseV2R1Options[O rules.RuleOption](options any) (*O, error) {
+func parseV2R3Options[O rules.RuleOption](options any) (*O, error) {
 	optionsByte, err := json.Marshal(options)
 	if err != nil {
 		return nil, err
@@ -43,14 +43,14 @@ func parseV2R1Options[O rules.RuleOption](options any) (*O, error) {
 	return &parsedOptions, nil
 }
 
-func getV2R1OptionOrNil[O rules.RuleOption](options any) (*O, error) {
+func getV2R3OptionOrNil[O rules.RuleOption](options any) (*O, error) {
 	if options == nil {
 		return nil, nil
 	}
-	return parseV2R1Options[O](options)
+	return parseV2R3Options[O](options)
 }
 
-func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
+func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
 	shootClient, err := client.New(r.ShootConfig, client.Options{Scheme: kubernetesgardener.ShootScheme})
 	if err != nil {
 		return err
@@ -76,43 +76,43 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
-	opts242400, err := getV2R1OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
+	opts242400, err := getV2R3OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242400 error: %s", err.Error())
 	}
-	opts242414, err := getV2R1OptionOrNil[option.Options242414](ruleOptions[sharedrules.ID242414].Args)
+	opts242414, err := getV2R3OptionOrNil[option.Options242414](ruleOptions[sharedrules.ID242414].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242414 error: %s", err.Error())
 	}
-	opts242415, err := getV2R1OptionOrNil[option.Options242415](ruleOptions[sharedrules.ID242415].Args)
+	opts242415, err := getV2R3OptionOrNil[option.Options242415](ruleOptions[sharedrules.ID242415].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242415 error: %s", err.Error())
 	}
-	opts242445, err := getV2R1OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
+	opts242445, err := getV2R3OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242445 error: %s", err.Error())
 	}
-	opts242446, err := getV2R1OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242446].Args)
+	opts242446, err := getV2R3OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242446].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242446 error: %s", err.Error())
 	}
-	opts242451, err := getV2R1OptionOrNil[rules.Options242451](ruleOptions[sharedrules.ID242451].Args)
+	opts242451, err := getV2R3OptionOrNil[rules.Options242451](ruleOptions[sharedrules.ID242451].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242451 error: %s", err.Error())
 	}
-	opts242466, err := getV2R1OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242466].Args)
+	opts242466, err := getV2R3OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242466].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242466 error: %s", err.Error())
 	}
-	opts242467, err := getV2R1OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242467].Args)
+	opts242467, err := getV2R3OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242467].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242467 error: %s", err.Error())
 	}
-	opts245543, err := getV2R1OptionOrNil[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args)
+	opts245543, err := getV2R3OptionOrNil[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 245543 error: %s", err.Error())
 	}
-	opts254800, err := getV2R1OptionOrNil[sharedrules.Options254800](ruleOptions[sharedrules.ID254800].Args)
+	opts254800, err := getV2R3OptionOrNil[sharedrules.Options254800](ruleOptions[sharedrules.ID254800].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 254800 error: %s", err.Error())
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -31,7 +31,7 @@ var (
 	_ ruleset.Ruleset = &Ruleset{}
 	// SupportedVersions is a list of available versions for the DISA Kubernetes STIG Ruleset.
 	// Versions are sorted from newest to oldest.
-	SupportedVersions = []string{"v2r2", "v2r1"}
+	SupportedVersions = []string{"v2r3", "v2r2"}
 )
 
 // Ruleset implements DISA Kubernetes STIG.
@@ -116,12 +116,12 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 	}
 
 	switch rulesetConfig.Version {
-	case "v2r1":
-		if err := ruleset.registerV2R1Rules(ruleOptions); err != nil {
-			return nil, err
-		}
 	case "v2r2":
 		if err := ruleset.registerV2R2Rules(ruleOptions); err != nil {
+			return nil, err
+		}
+	case "v2r3":
+		if err := ruleset.registerV2R3Rules(ruleOptions); err != nil {
 			return nil, err
 		}
 	default:

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,7 @@ import (
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
-func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
+func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
 	client, err := client.New(r.Config, client.Options{})
 	if err != nil {
 		return err
@@ -46,87 +46,87 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 		return fmt.Errorf("failed to parse kube-apiserver CA data from config")
 	}
 
-	opts242383, err := getV2R1OptionOrNil[sharedrules.Options242383](ruleOptions[sharedrules.ID242383].Args)
+	opts242383, err := getV2R3OptionOrNil[sharedrules.Options242383](ruleOptions[sharedrules.ID242383].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242383 error: %s", err.Error())
 	}
-	opts242393, err := getV2R1OptionOrNil[sharedrules.Options242393](ruleOptions[sharedrules.ID242393].Args)
+	opts242393, err := getV2R3OptionOrNil[sharedrules.Options242393](ruleOptions[sharedrules.ID242393].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242393 error: %s", err.Error())
 	}
-	opts242394, err := getV2R1OptionOrNil[sharedrules.Options242394](ruleOptions[sharedrules.ID242394].Args)
+	opts242394, err := getV2R3OptionOrNil[sharedrules.Options242394](ruleOptions[sharedrules.ID242394].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242394 error: %s", err.Error())
 	}
-	opts242396, err := getV2R1OptionOrNil[sharedrules.Options242396](ruleOptions[sharedrules.ID242396].Args)
+	opts242396, err := getV2R3OptionOrNil[sharedrules.Options242396](ruleOptions[sharedrules.ID242396].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242396 error: %s", err.Error())
 	}
-	opts242400, err := getV2R1OptionOrNil[rules.Options242400](ruleOptions[sharedrules.ID242400].Args)
+	opts242400, err := getV2R3OptionOrNil[rules.Options242400](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242400 error: %s", err.Error())
 	}
-	opts242404, err := getV2R1OptionOrNil[sharedrules.Options242404](ruleOptions[sharedrules.ID242404].Args)
+	opts242404, err := getV2R3OptionOrNil[sharedrules.Options242404](ruleOptions[sharedrules.ID242404].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242404 error: %s", err.Error())
 	}
-	opts242406, err := getV2R1OptionOrNil[sharedrules.Options242406](ruleOptions[sharedrules.ID242406].Args)
+	opts242406, err := getV2R3OptionOrNil[sharedrules.Options242406](ruleOptions[sharedrules.ID242406].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242406 error: %s", err.Error())
 	}
-	opts242407, err := getV2R1OptionOrNil[sharedrules.Options242407](ruleOptions[sharedrules.ID242407].Args)
+	opts242407, err := getV2R3OptionOrNil[sharedrules.Options242407](ruleOptions[sharedrules.ID242407].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242407 error: %s", err.Error())
 	}
-	opts242414, err := getV2R1OptionOrNil[option.Options242414](ruleOptions[sharedrules.ID242414].Args)
+	opts242414, err := getV2R3OptionOrNil[option.Options242414](ruleOptions[sharedrules.ID242414].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242414 error: %s", err.Error())
 	}
-	opts242415, err := getV2R1OptionOrNil[option.Options242415](ruleOptions[sharedrules.ID242415].Args)
+	opts242415, err := getV2R3OptionOrNil[option.Options242415](ruleOptions[sharedrules.ID242415].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242415 error: %s", err.Error())
 	}
-	opts242417, err := getV2R1OptionOrNil[sharedrules.Options242417](ruleOptions[sharedrules.ID242417].Args)
+	opts242417, err := getV2R3OptionOrNil[sharedrules.Options242417](ruleOptions[sharedrules.ID242417].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242417 error: %s", err.Error())
 	}
-	opts242442, err := getV2R1OptionOrNil[rules.Options242442](ruleOptions[sharedrules.ID242442].Args)
+	opts242442, err := getV2R3OptionOrNil[rules.Options242442](ruleOptions[sharedrules.ID242442].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242442 error: %s", err.Error())
 	}
-	opts242447, err := getV2R1OptionOrNil[sharedrules.Options242447](ruleOptions[sharedrules.ID242447].Args)
+	opts242447, err := getV2R3OptionOrNil[sharedrules.Options242447](ruleOptions[sharedrules.ID242447].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242447 error: %s", err.Error())
 	}
-	opts242448, err := getV2R1OptionOrNil[sharedrules.Options242448](ruleOptions[sharedrules.ID242448].Args)
+	opts242448, err := getV2R3OptionOrNil[sharedrules.Options242448](ruleOptions[sharedrules.ID242448].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242448 error: %s", err.Error())
 	}
-	opts242449, err := getV2R1OptionOrNil[sharedrules.Options242449](ruleOptions[sharedrules.ID242449].Args)
+	opts242449, err := getV2R3OptionOrNil[sharedrules.Options242449](ruleOptions[sharedrules.ID242449].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242449 error: %s", err.Error())
 	}
-	opts242450, err := getV2R1OptionOrNil[sharedrules.Options242450](ruleOptions[sharedrules.ID242450].Args)
+	opts242450, err := getV2R3OptionOrNil[sharedrules.Options242450](ruleOptions[sharedrules.ID242450].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242450 error: %s", err.Error())
 	}
-	opts242451, err := getV2R1OptionOrNil[rules.Options242451](ruleOptions[sharedrules.ID242451].Args)
+	opts242451, err := getV2R3OptionOrNil[rules.Options242451](ruleOptions[sharedrules.ID242451].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242451 error: %s", err.Error())
 	}
-	opts242452, err := getV2R1OptionOrNil[sharedrules.Options242452](ruleOptions[sharedrules.ID242452].Args)
+	opts242452, err := getV2R3OptionOrNil[sharedrules.Options242452](ruleOptions[sharedrules.ID242452].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242452 error: %s", err.Error())
 	}
-	opts242453, err := getV2R1OptionOrNil[sharedrules.Options242453](ruleOptions[sharedrules.ID242453].Args)
+	opts242453, err := getV2R3OptionOrNil[sharedrules.Options242453](ruleOptions[sharedrules.ID242453].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242453 error: %s", err.Error())
 	}
-	opts242466, err := getV2R1OptionOrNil[rules.Options242466](ruleOptions[sharedrules.ID242466].Args)
+	opts242466, err := getV2R3OptionOrNil[rules.Options242466](ruleOptions[sharedrules.ID242466].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242466 error: %s", err.Error())
 	}
-	opts242467, err := getV2R1OptionOrNil[rules.Options242467](ruleOptions[sharedrules.ID242467].Args)
+	opts242467, err := getV2R3OptionOrNil[rules.Options242467](ruleOptions[sharedrules.ID242467].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242467 error: %s", err.Error())
 	}
@@ -849,7 +849,7 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 	return r.AddRules(rules...)
 }
 
-func parseV2R1Options[O rules.RuleOption](options any) (*O, error) {
+func parseV2R3Options[O rules.RuleOption](options any) (*O, error) {
 	optionsByte, err := json.Marshal(options)
 	if err != nil {
 		return nil, err
@@ -869,9 +869,9 @@ func parseV2R1Options[O rules.RuleOption](options any) (*O, error) {
 	return &parsedOptions, nil
 }
 
-func getV2R1OptionOrNil[O rules.RuleOption](options any) (*O, error) {
+func getV2R3OptionOrNil[O rules.RuleOption](options any) (*O, error) {
 	if options == nil {
 		return nil, nil
 	}
-	return parseV2R1Options[O](options)
+	return parseV2R3Options[O](options)
 }

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -31,7 +31,7 @@ var (
 	_ ruleset.Ruleset = &Ruleset{}
 	// SupportedVersions is a list of available versions for the DISA Kubernetes STIG Ruleset.
 	// Versions are sorted from newest to oldest.
-	SupportedVersions = []string{"v2r2", "v2r1"}
+	SupportedVersions = []string{"v2r3", "v2r2"}
 )
 
 // Ruleset implements DISA Kubernetes STIG.
@@ -116,12 +116,12 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 	}
 
 	switch rulesetConfig.Version {
-	case "v2r1":
-		if err := ruleset.registerV2R1Rules(ruleOptions); err != nil {
-			return nil, err
-		}
 	case "v2r2":
 		if err := ruleset.registerV2R2Rules(ruleOptions); err != nil {
+			return nil, err
+		}
+	case "v2r3":
+		if err := ruleset.registerV2R3Rules(ruleOptions); err != nil {
 			return nil, err
 		}
 	default:

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ import (
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
-func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
+func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
 	runtimeClient, err := client.New(r.RuntimeConfig, client.Options{})
 	if err != nil {
 		return err
@@ -31,19 +31,19 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return err
 	}
-	opts242445, err := getV2R1OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
+	opts242445, err := getV2R3OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242445 error: %s", err.Error())
 	}
-	opts242446, err := getV2R1OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242446].Args)
+	opts242446, err := getV2R3OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242446].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242446 error: %s", err.Error())
 	}
-	opts242451, err := getV2R1OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242451].Args)
+	opts242451, err := getV2R3OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242451].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242451 error: %s", err.Error())
 	}
-	opts245543, err := getV2R1OptionOrNil[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args)
+	opts245543, err := getV2R3OptionOrNil[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 245543 error: %s", err.Error())
 	}
@@ -740,7 +740,7 @@ func (r *Ruleset) registerV2R1Rules(ruleOptions map[string]config.RuleOptionsCon
 	return r.AddRules(rules...)
 }
 
-func parseV2R1Options[O rules.RuleOption](options any) (*O, error) {
+func parseV2R3Options[O rules.RuleOption](options any) (*O, error) {
 	optionsByte, err := json.Marshal(options)
 	if err != nil {
 		return nil, err
@@ -760,9 +760,9 @@ func parseV2R1Options[O rules.RuleOption](options any) (*O, error) {
 	return &parsedOptions, nil
 }
 
-func getV2R1OptionOrNil[O rules.RuleOption](options any) (*O, error) {
+func getV2R3OptionOrNil[O rules.RuleOption](options any) (*O, error) {
 	if options == nil {
 		return nil, nil
 	}
-	return parseV2R1Options[O](options)
+	return parseV2R3Options[O](options)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the latest version of DISA K8s STIG `v2r3` and drops support for version `v2r1`.

**Which issue(s) this PR fixes**:
Fixes #479

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Diki now supports DISA Kubernetes STIG version `v2r3`
```
```breaking user
Diki no longer supports DISA Kubernetes STIG version `v2r1`
```
