### PR TITLE
[DISA K8s STIG] Refactor rule 242459

### DIFF
--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -29,6 +29,7 @@ type FileStats struct {
 	Permissions           string
 	UserOwner, GroupOwner string
 	FileType              string
+	Destination           string
 }
 
 // NewFileStats creates a new FileStats object from the result of
@@ -243,6 +244,10 @@ func getContainerMountedFileStatResults(
 			if err2 != nil {
 				err = errors.Join(err, err2)
 				continue
+			}
+
+			for i := range mountFileStats {
+				mountFileStats[i].Destination = mount.Destination
 			}
 			stats = append(stats, mountFileStats...)
 		}

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -122,6 +122,7 @@ var _ = Describe("utils", func() {
 				UserOwner:   "0",
 				GroupOwner:  "0",
 				FileType:    "regular file",
+				Destination: "/destination",
 			}
 			fooFileStats = utils.FileStats{
 				Path:        "/foo/file2.txt",
@@ -129,6 +130,7 @@ var _ = Describe("utils", func() {
 				UserOwner:   "0",
 				GroupOwner:  "65532",
 				FileType:    "regular file",
+				Destination: "/foo",
 			}
 			pod = corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/shared/ruleset/disak8sstig/rules/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459.go
@@ -196,9 +196,13 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 				checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), execPodTarget))
 			}
 
-			expectedFilePermissionsMax := "640"
 			for containerName, fileStats := range mappedFileStats {
 				for _, fileStat := range fileStats {
+					expectedFilePermissionsMax := "644"
+					if strings.Contains(fileStat.Destination, "/etcd/data") {
+						expectedFilePermissionsMax = "660"
+					}
+
 					containerTarget := rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod", "containerName", containerName)
 					exceedFilePermissions, err := intutils.ExceedFilePermissions(fileStat.Permissions, expectedFilePermissionsMax)
 					if err != nil {

--- a/pkg/shared/ruleset/disak8sstig/rules/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459.go
@@ -200,7 +200,7 @@ func (r *Rule242459) Run(ctx context.Context) (rule.RuleResult, error) {
 				for _, fileStat := range fileStats {
 					expectedFilePermissionsMax := "644"
 					if strings.Contains(fileStat.Destination, "/etcd/data") {
-						expectedFilePermissionsMax = "660"
+						expectedFilePermissionsMax = "600"
 					}
 
 					containerTarget := rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod", "containerName", containerName)

--- a/pkg/shared/ruleset/disak8sstig/rules/242459_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459_test.go
@@ -54,8 +54,8 @@ var _ = Describe("#242459", func() {
 		emptyMounts           = `[]`
 		compliantStats        = "644\t0\t0\tregular file\t/source1/file1.txt\n400\t0\t65532\tregular file\t/source1/bar/file2.txt"
 		compliantStats2       = "600\t0\t0\tregular file\t/source1/file3.txt\n640\t1000\t0\tregular file\t/source1/bar/file4.txt\n"
-		compliantDataStats    = "660\t0\t0\tregular file\t/source2/file1.txt\n400\t0\t65532\tregular file\t/source2/bar/file2.txt"
-		compliantDataStats2   = "600\t0\t0\tregular file\t/source2/file3.txt\n640\t1000\t0\tregular file\t/source2/bar/file4.txt\n"
+		compliantDataStats    = "600\t0\t0\tregular file\t/source2/file1.txt\n400\t0\t65532\tregular file\t/source2/bar/file2.txt"
+		compliantDataStats2   = "600\t0\t0\tregular file\t/source2/file3.txt\n200\t1000\t0\tregular file\t/source2/bar/file4.txt\n"
 		nonCompliantStats     = "660\t0\t0\tregular file\t/source1/file1.key\n700\t0\t0\tregular file\t/source1/bar/file2.key\n"
 		nonCompliantDataStats = "644\t0\t0\tregular file\t/source2/file1.key\n700\t0\t0\tregular file\t/source2/bar/file2.key\n"
 	)
@@ -229,12 +229,12 @@ var _ = Describe("#242459", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/file1.txt, permissions: 644")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/bar/file2.txt, permissions: 400")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.txt, permissions: 660")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.txt, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file2.txt, permissions: 400")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/file3.txt, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/bar/file4.txt, permissions: 640")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file3.txt, permissions: 600")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 200")),
 			}),
 		Entry("should return correct errored checkResults when old ETCD pods are partially found", false,
 			[][]string{{mounts, compliantStats, compliantDataStats}},
@@ -243,7 +243,7 @@ var _ = Describe("#242459", func() {
 				rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", "instance=etcd-events", "namespace", "foo")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/file1.txt, permissions: 644")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/bar/file2.txt, permissions: 400")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.txt, permissions: 660")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.txt, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file2.txt, permissions: 400")),
 			}))
 
@@ -277,12 +277,12 @@ var _ = Describe("#242459", func() {
 			[]rule.CheckResult{
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/file1.txt, permissions: 644")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/bar/file2.txt, permissions: 400")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.txt, permissions: 660")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.txt, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file2.txt, permissions: 400")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/file3.txt, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/bar/file4.txt, permissions: 640")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file3.txt, permissions: 600")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 200")),
 			}),
 		Entry("should return failed checkResults when files have too wide permissions",
 			[][]string{{mounts, nonCompliantStats, nonCompliantDataStats, emptyMounts}},
@@ -290,8 +290,8 @@ var _ = Describe("#242459", func() {
 			[]rule.CheckResult{
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/file1.key, permissions: 660, expectedPermissionsMax: 644")),
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/bar/file2.key, permissions: 700, expectedPermissionsMax: 644")),
-				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.key, permissions: 644, expectedPermissionsMax: 660")),
-				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file2.key, permissions: 700, expectedPermissionsMax: 660")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file1.key, permissions: 644, expectedPermissionsMax: 600")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file2.key, permissions: 700, expectedPermissionsMax: 600")),
 			}),
 		Entry("should correctly return errored checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, compliantDataStats2}},
@@ -300,7 +300,7 @@ var _ = Describe("#242459", func() {
 				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242459-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242459-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file3.txt, permissions: 600")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 200")),
 			}),
 		Entry("should check files when GetMountedFilesStats errors",
 			[][]string{{mountsMulty, compliantStats, compliantStats2, emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
@@ -320,7 +320,7 @@ var _ = Describe("#242459", func() {
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/file3.txt, permissions: 600")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source1/bar/file4.txt, permissions: 640")),
 				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/file3.txt, permissions: 600")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /source2/bar/file4.txt, permissions: 200")),
 			}),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the implementation of DISA K8s STIG rule 242459 to check etcd files for `644` permissions or more restrictive, as stated in [the rule](https://stigviewer.com/stigs/kubernetes/2024-08-22/finding/V-242459). Files in `/etcd/data` directory are expected to have a maximum of `600` permissions, as they should not be accessible by `other` group and require write permissions.

`600` permissions are the minimal required for files in `/etcd/data` since the `etcd` creates and manages these files.



`640` permissions are still being enforced for all `.key` & `.pem` files via diki's implementation of [rule 242467](https://stigviewer.com/stigs/kubernetes/2024-08-22/finding/V-242467).

`644` permissions should be good enough for the general case, files with such permissions will be readable by all users connected to the container, but most of the files will still be isolated on the host from users since the `kubelet` directory (which contains pod volume mounts) has `000` permissions [ref](https://github.com/gardener/gardener/blob/c6308703a6d84ca87cc038e1ddd35393c1aec35e/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig.go#L61-L64)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
DISA STIG rule 242459 now checks for `644` permissions or more restrictive, for files in `/etcd/data` directory it expects `600` permissions.
```
