### PR TITLE
[Security Hardened Kubernetes Cluster] Modify Rule 2000 to check for a `default-allow` NetworkPolicy

### DIFF
--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -138,11 +138,12 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 				acceptedTarget = target.With("details", "traffic: ingress")
 			}
 
-			if accepted {
+			switch {
+			case accepted:
 				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, acceptedTarget))
-			} else if allowsAllIngress {
+			case allowsAllIngress:
 				checkResults = append(checkResults, rule.FailedCheckResult("All Ingress traffic is allowed by default.", allowsAllIngressTarget))
-			} else {
+			default:
 				checkResults = append(checkResults, rule.FailedCheckResult("Ingress traffic is not denied by default.", target))
 			}
 		}
@@ -162,11 +163,12 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 				acceptedTarget = target.With("details", "traffic: egress")
 			}
 
-			if accepted {
+			switch {
+			case accepted:
 				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, acceptedTarget))
-			} else if allowsAllEgress {
+			case allowsAllEgress:
 				checkResults = append(checkResults, rule.FailedCheckResult("All Egress traffic is allowed by default.", allowsAllEgressTarget))
-			} else {
+			default:
 				checkResults = append(checkResults, rule.FailedCheckResult("Egress traffic is not denied by default.", target))
 			}
 		}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -118,7 +118,7 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 				allowsAllEgress = true
 			}
 
-			if deniesIngress && deniesEgress || allowsAllIngress && allowsAllEgress {
+			if allowsAllIngress && allowsAllEgress {
 				break
 			}
 		}
@@ -172,7 +172,6 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 				} else {
 					checkResults = append(checkResults, rule.FailedCheckResult("Egress traffic is not denied by default.", target))
 				}
-
 			}
 		}
 	}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -59,6 +59,19 @@ var _ = Describe("#2000", func() {
 						Ingress: true,
 					},
 				},
+				{
+					AcceptedClusterObject: option.AcceptedClusterObject{
+						ClusterObjectSelector: option.ClusterObjectSelector{
+							MatchLabels: map[string]string{
+								"role": "test1",
+							},
+						},
+						Justification: "justification test",
+					},
+					AcceptedTraffic: rules.AcceptedTraffic{
+						Egress: true,
+					},
+				},
 			},
 		}
 
@@ -170,6 +183,76 @@ var _ = Describe("#2000", func() {
 
 		Expect(client.Create(ctx, nsFoo)).To(Succeed())
 
+		nsTest1 := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test1",
+				Labels: map[string]string{
+					"role": "test1",
+				},
+			},
+		}
+
+		Expect(client.Create(ctx, nsTest1)).To(Succeed())
+
+		npTest1 := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-allow",
+				Namespace: "test1",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{},
+						From:  []networkingv1.NetworkPolicyPeer{},
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{},
+						To:    []networkingv1.NetworkPolicyPeer{},
+					},
+				},
+			},
+		}
+
+		Expect(client.Create(ctx, npTest1)).To(Succeed())
+
+		nsTest2 := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test2",
+				Labels: map[string]string{
+					"role": "test2",
+				},
+			},
+		}
+
+		Expect(client.Create(ctx, nsTest2)).To(Succeed())
+
+		npTest2 := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mixed-allow",
+				Namespace: "test2",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{},
+						To:    []networkingv1.NetworkPolicyPeer{},
+					},
+				},
+			},
+		}
+
+		Expect(client.Create(ctx, npTest2)).To(Succeed())
+
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -191,8 +274,8 @@ var _ = Describe("#2000", func() {
 			},
 			{
 				Status:  rule.Failed,
-				Message: "Egress traffic is not denied by default.",
-				Target:  rule.NewTarget("namespace", "kube-system"),
+				Message: "All Egress traffic is allowed by default.",
+				Target:  rule.NewTarget("namespace", "kube-system", "kind", "networkPolicy", "name", "deny-ingress"),
 			},
 			{
 				Status:  rule.Passed,
@@ -223,6 +306,26 @@ var _ = Describe("#2000", func() {
 				Status:  rule.Accepted,
 				Message: "justification foo",
 				Target:  rule.NewTarget("namespace", "kube-foo", "details", "traffic: ingress"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "All Ingress traffic is allowed by default.",
+				Target:  rule.NewTarget("namespace", "test1", "kind", "networkPolicy", "name", "default-allow"),
+			},
+			{
+				Status:  rule.Accepted,
+				Message: "justification test",
+				Target:  rule.NewTarget("namespace", "test1", "details", "traffic: egress"),
+			},
+			{
+				Status:  rule.Passed,
+				Message: "Ingress traffic is denied by default.",
+				Target:  rule.NewTarget("namespace", "test2", "kind", "networkPolicy", "name", "mixed-allow"),
+			},
+			{
+				Status:  rule.Failed,
+				Message: "All Egress traffic is allowed by default.",
+				Target:  rule.NewTarget("namespace", "test2", "kind", "networkPolicy", "name", "mixed-allow"),
 			},
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Rule 2000 of the `Security Hardened Kubernetes Cluster` ruleset checks to see if unnecessary pod traffic is explicitly disabled for a specific namespace. If a `default-allow` NetworkPolicy is configured, all other NetworkPolicy rules are overwritten by it.

Example `default-allow` NetworkPolicy:

```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-allow
spec:
  # select all pods in the namespace
  podSelector: {}
  # allow all traffic
  ingress:
  - {}
  egress:
  - {}
  policyTypes:
  - Ingress
  - Egress
```
The modification checks specifically for this type of NetworkPolicy and specifies it in the Failed `CheckResult` Target.

**Which issue(s) this PR fixes**:
Fixes #439 

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[Security Hardened Kubernetes Cluster Ruleset] Rule 2000 now explicitly checks for a NetworkPolicy that allows all traffic in a specific namespace
```
