### PR TITLE
Implement `logr.LogSink` interface for `controller-runtime` clients

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -19,7 +19,9 @@ import (
 	"gopkg.in/yaml.v3"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/version"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/gardener/diki/cmd/internal/slogr"
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/metadata"
 	"github.com/gardener/diki/pkg/provider"
@@ -78,7 +80,7 @@ e.g. to check compliance of your hyperscaler accounts.`,
 		Short: "Run some rulesets and rules.",
 		Long:  "Run allows running rulesets and rules for the given provider(s).",
 		RunE: func(c *cobra.Command, _ []string) error {
-			return runCmd(c.Context(), providerCreateFuncs, opts)
+			return runCmd(c.Context(), providerCreateFuncs, opts, logger)
 		},
 	}
 
@@ -404,7 +406,11 @@ func generateCmd(args []string, rootOpts reportOptions, opts generateOptions, lo
 	}
 }
 
-func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.ProviderFromConfigFunc, opts runOptions) error {
+func runCmd(ctx context.Context, providerCreateFuncs map[string]provider.ProviderFromConfigFunc, opts runOptions, logger *slog.Logger) error {
+	// Set logger for controller-runtime clients
+	logr := slogr.NewLogr(logger)
+	logf.SetLogger(logr)
+
 	dikiConfig, err := readConfig(opts.configFile)
 	if err != nil {
 		return err

--- a/cmd/internal/slogr/slogr.go
+++ b/cmd/internal/slogr/slogr.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package slogr
+
+import (
+	"log/slog"
+
+	"github.com/go-logr/logr"
+)
+
+var (
+	_ logr.LogSink = &Slogr{}
+)
+
+// Slogr is a wrapper around slog.Logger to implement the logr.LogSink interface.
+type Slogr struct {
+	logger *slog.Logger
+}
+
+// NewLogr creates a new logr.Logger from a slog.Logger.
+func NewLogr(logger *slog.Logger) logr.Logger {
+	return logr.New(Slogr{logger: logger})
+}
+
+// Enabled implmenents the logr.LogSink interface.
+func (s Slogr) Enabled(_ int) bool {
+	return true
+}
+
+// Error logs an error message.
+func (s Slogr) Error(err error, msg string, keysAndValues ...interface{}) {
+	s.logger.Error(msg, append(keysAndValues, "error", err)...)
+}
+
+// Info logs an info message.
+func (s Slogr) Info(_ int, msg string, keysAndValues ...interface{}) {
+	s.logger.Info(msg, keysAndValues...)
+}
+
+// Init implments the logr.LogSink interface.
+func (s Slogr) Init(_ logr.RuntimeInfo) {
+}
+
+// WithName returns a new logr.Logger with the specified  group name.
+func (s Slogr) WithName(name string) logr.LogSink {
+	s.logger.WithGroup(name)
+	return &s
+}
+
+// WithValues returns a new logr.Logger with the specified key-value pairs.
+func (s Slogr) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	s.logger = s.logger.With(keysAndValues...)
+	return &s
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/gardener/gardener v1.119.0
 	github.com/gardener/gardener-extension-shoot-lakom-service v0.19.1
+	github.com/go-logr/logr v1.4.2
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
@@ -49,7 +50,6 @@ require (
 	github.com/gardener/etcd-druid/api v0.29.1 // indirect
 	github.com/gardener/machine-controller-manager v0.58.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
This PRs adds implementation of the `logr.LogSink` interface using `slog`. Such logger is required by `controller-runtime` clients. Currently diki runs get the following error when encountering a `controller-runtime` log.
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 30 [running]:
        >  runtime/debug.Stack()
        >       /Users/I550469/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.3.darwin-arm64/src/runtime/debug/stack.go:26 +0x64
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       /Users/I550469/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/log/log.go:60 +0xf4
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0x1400004f600, 0x0)
        >       /Users/I550469/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/log/deleg.go:111 +0x30
        >  github.com/go-logr/logr.Logger.Info({{0x107638c88?, 0x1400004f600?}, 0x0?}, {0x14000409900, 0xdf}, {0x0, 0x0, 0x0})
        >       /Users/I550469/go/pkg/mod/github.com/go-logr/logr@v1.4.2/logr.go:276 +0x5c
        >  sigs.k8s.io/controller-runtime/pkg/log.(*KubeAPIWarningLogger).HandleWarningHeader(0x140000e7930?, 0x14001924fc0?, {0x106967a29?, 0x7?}, {0x14000409900?, 0x0?})
        >       /Users/I550469/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/log/warning_handler.go:65 +0x178
        >  k8s.io/client-go/rest.handleWarnings(0x14000f0d6e0?, {0x107603320?, 0x140001628d0?})
        >       /Users/I550469/go/pkg/mod/k8s.io/client-go@v0.32.4/rest/warnings.go:144 +0xd0
        >  k8s.io/client-go/rest.(*Request).transformResponse(0x14000a84900, {0x1076337b0?, 0x1400051e000?}, 0x140016585a0, 0x14000315900)
        >       /Users/I550469/go/pkg/mod/k8s.io/client-go@v0.32.4/rest/request.go:1396 +0x2e4
        >  k8s.io/client-go/rest.(*Request).Do.func1(0x14000d629c0?, 0xa?)
        >       /Users/I550469/go/pkg/mod/k8s.io/client-go@v0.32.4/rest/request.go:1276 +0x44
        >  k8s.io/client-go/rest.(*Request).request.func3.1(...)
        >       /Users/I550469/go/pkg/mod/k8s.io/client-go@v0.32.4/rest/request.go:1247
        >  k8s.io/client-go/rest.(*Request).request.func3(0x140016585a0, 0x1400006aa50, {0x107633938?, 0x14000d629c0?}, 0x140016585a0?, 0x0?, 0x14000315900, {0x0?, 0x0?}, 0x105a3f678?)
        >       /Users/I550469/go/pkg/mod/k8s.io/client-go@v0.32.4/rest/request.go:1254 +0xb8
        >  k8s.io/client-go/rest.(*Request).request(0x14000a84900, {0x1076337b0, 0x1400051e000}, 0x1400006aa50)
        >       /Users/I550469/go/pkg/mod/k8s.io/client-go@v0.32.4/rest/request.go:1256 +0x3e8
        >  k8s.io/client-go/rest.(*Request).Do(0x14000a84900, {0x1076337b0, 0x1400051e000})
        >       /Users/I550469/go/pkg/mod/k8s.io/client-go@v0.32.4/rest/request.go:1275 +0xc8
        >  sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).Create(0x1400065d9e0, {0x1076337b0, 0x1400051e000}, {0x10765ae50, 0x14000f47b08}, {0x0, 0x0, 0x1062147f0?})
        >       /Users/I550469/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/client/typed_client.go:48 +0x2f0
        >  sigs.k8s.io/controller-runtime/pkg/client.(*client).Create(0x1400065d9e0?, {0x1076337b0?, 0x1400051e000?}, {0x10765ae50?, 0x14000f47b08?}, {0x0?, 0x0?, 0x0?})
        >       /Users/I550469/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/client/client.go:279 +0x9c
        >  github.com/gardener/diki/pkg/kubernetes/pod.(*SimplePodContext).Create(0x140001631d0, {0x1076337b0, 0x1400051e000}, 0xb?)
        >       /Users/I550469/go/src/github.com/gardener/diki/pkg/kubernetes/pod/pod.go:88 +0x17c
        >  github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules.(*Rule242460).Run(0x140006ae540, {0x1076337b0, 0x1400051e000})
        >       /Users/I550469/go/src/github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules/242460.go:117 +0xec0
        >  github.com/gardener/diki/pkg/rule/retry.(*RetryableRule).Run(0x140005b3ec0, {0x1076337b0, 0x1400051e000})
        >       /Users/I550469/go/src/github.com/gardener/diki/pkg/rule/retry/retryablerule.go:82 +0xa0
        >  github.com/gardener/diki/pkg/shared/ruleset.Run.func1()
        >       /Users/I550469/go/src/github.com/gardener/diki/pkg/shared/ruleset/ruleset.go:57 +0x194
        >  created by github.com/gardener/diki/pkg/shared/ruleset.Run in goroutine 1
        >       /Users/I550469/go/src/github.com/gardener/diki/pkg/shared/ruleset/ruleset.go:54 +0x320
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
A bug causing logs from `controller-runtime` clients to cause runtime errors has been fixed.
```
