### PR TITLE
Retry rules on not found object by `nerdctl`

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
@@ -125,6 +125,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		*retryerrors.ContainerFileNotFoundOnNodeRegexp,
 		*retryerrors.ContainerNotReadyRegexp,
 		*retryerrors.OpsPodNotFoundRegexp,
+		*retryerrors.ObjectNotFoundRegexp,
 	)
 
 	// Gardener images use distroless nonroot user with ID 65532

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
@@ -125,6 +125,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		*retryerrors.ContainerFileNotFoundOnNodeRegexp,
 		*retryerrors.ContainerNotReadyRegexp,
 		*retryerrors.OpsPodNotFoundRegexp,
+		*retryerrors.ObjectNotFoundRegexp,
 	)
 
 	// Gardener images use distroless nonroot user with ID 65532

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -139,6 +139,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		*retryerrors.ContainerFileNotFoundOnNodeRegexp,
 		*retryerrors.ContainerNotReadyRegexp,
 		*retryerrors.OpsPodNotFoundRegexp,
+		*retryerrors.ObjectNotFoundRegexp,
 	)
 
 	const (

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -139,6 +139,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		*retryerrors.ContainerFileNotFoundOnNodeRegexp,
 		*retryerrors.ContainerNotReadyRegexp,
 		*retryerrors.OpsPodNotFoundRegexp,
+		*retryerrors.ObjectNotFoundRegexp,
 	)
 
 	const (

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
@@ -53,6 +53,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		*retryerrors.ContainerFileNotFoundOnNodeRegexp,
 		*retryerrors.ContainerNotReadyRegexp,
 		*retryerrors.OpsPodNotFoundRegexp,
+		*retryerrors.ObjectNotFoundRegexp,
 	)
 
 	const (

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
@@ -53,6 +53,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		*retryerrors.ContainerFileNotFoundOnNodeRegexp,
 		*retryerrors.ContainerNotReadyRegexp,
 		*retryerrors.OpsPodNotFoundRegexp,
+		*retryerrors.ObjectNotFoundRegexp,
 	)
 
 	const (

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
@@ -17,4 +17,6 @@ var (
 	ContainerNotReadyRegexp = regexp.MustCompile(`(?i)(container with name .* (not \(yet\) in status|not \(yet\) running))`)
 	// OpsPodNotFoundRegexp regex to match ops pod not found for DISA K8s STIG ruleset
 	OpsPodNotFoundRegexp = regexp.MustCompile(`(?i)(pods "diki-[\d]{6}-.{10}" not found)`)
+	// ObjectNotFoundRegexp regex to match object not found by nerdctl
+	ObjectNotFoundRegexp = regexp.MustCompile(`(?i)(command /bin/sh /.*/nerdctl .* \[no such object)`)
 )

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
@@ -40,12 +40,21 @@ var _ = Describe("retryerrors", func() {
 		Entry("Should not match non containers", "bar with name foo not (yet) in status", false),
 	)
 
-	DescribeTable("#DikiDISAPodNotFoundRegexp",
+	DescribeTable("#OpsPodNotFoundRegexp",
 		func(s string, expectedResult bool) {
 			Expect(retryerrors.OpsPodNotFoundRegexp.MatchString(s)).To(Equal(expectedResult))
 		},
 		Entry("Should match diki pod not found", `pods "diki-111111-asdasdasda" not found`, true),
 		Entry("Should not match when pod is not diki", `pods "foo" not found`, false),
 		Entry("Should not match when Pod does not fit diki pod regex", `pods "diki-1111-asdasdasda" not found`, false),
+	)
+
+	DescribeTable("#ObjectNotFoundRegexp",
+		func(s string, expectedResult bool) {
+			Expect(retryerrors.ObjectNotFoundRegexp.MatchString(s)).To(Equal(expectedResult))
+		},
+		Entry("Should match nerdctl object not found", `command /bin/sh /run/containerd/usr/local/bin/nerdctl 1 | jq -r .[0].Spec.mounts stderr output: msg="1 errors: [no such object 1]"`, true),
+		Entry("Should not match when command is not nerdctl", `command /bin/sh /run/containerd/usr/local/bin/systemctl 1 stderr output: msg="1 errors: [no such object 1]`, false),
+		Entry("Should not match when error is not not matched", `command /bin/sh /run/containerd/usr/local/bin/nerdctl 1 | jq -r .[0].Spec.mounts stderr output: msg="1 errors: [error object 1]`, false),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds retry on not found objects by `nerdctl`. In most cases these objects are the IDs of pod containers, which may may no longer exist when we try to find them with `nerdctl`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
