### PR TITLE
Add a renovate configuration for the tailwindcss dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,21 @@
       ],
       "depNameTemplate": "containerd/nerdctl",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      // Generic detection for tailwindcss dependency in GitHub
+      "customType": "regex",
+      "fileMatch": [
+        "^hack\/tools\.mk$",
+        "^pkg\/report\/templates\/html\/_styles\.tpl$",
+        "^pkg\/report\/templates\/html\/output\.css$",
+      ],
+      "matchStrings": [
+          "tailwindcss (?<currentValue>v[0-9]+(\.[0-9]+){2})",
+          "TAILWINDCSS_VERSION \\?= (?<currentValue>v[0-9]+(\.[0-9]+){2})"
+      ],
+      "depNameTemplate": "tailwindlabs/tailwindcss",
+      "datasourceTemplate": "github-releases",
     }
   ],
   "packageRules": [


### PR DESCRIPTION
**What this PR does / why we need it**:
The RenovateBot currently is not configured to detect for version updsates of the `tailwindlabs/tailwindcss` dependency. This PR adds a customManager to the `renovate.json5` configuration

**Which issue(s) this PR fixes**:
Part of #379 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The tailwind dependency can now be detected by the repository's Renovate bot
```
