### PR TITLE
Retry rules on not found files by `stat`

### DIFF
--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
@@ -12,7 +12,7 @@ var (
 	// ContainerNotFoundOnNodeRegexp regex to match container on node not found
 	ContainerNotFoundOnNodeRegexp = regexp.MustCompile(`(?i)(command /bin/sh /run/containerd.*not found)`)
 	// ContainerFileNotFoundOnNodeRegexp regex to match container file path on node not found
-	ContainerFileNotFoundOnNodeRegexp = regexp.MustCompile(`(?i)(command /bin/sh find.*No such file or directory)`)
+	ContainerFileNotFoundOnNodeRegexp = regexp.MustCompile(`(?i)(command /bin/sh (find|stat).*No such file or directory)`)
 	// ContainerNotReadyRegexp regex to match container not yet in status or not running
 	ContainerNotReadyRegexp = regexp.MustCompile(`(?i)(container with name .* (not \(yet\) in status|not \(yet\) running))`)
 	// OpsPodNotFoundRegexp regex to match ops pod not found for DISA K8s STIG ruleset

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
@@ -25,7 +25,8 @@ var _ = Describe("retryerrors", func() {
 		func(s string, expectedResult bool) {
 			Expect(retryerrors.ContainerFileNotFoundOnNodeRegexp.MatchString(s)).To(Equal(expectedResult))
 		},
-		Entry("Should match container file not found", "command /bin/sh find /var/lib/kubelet/pods/container-id -type f No such file or directory", true),
+		Entry("Should match container file not found by 'find'", "command /bin/sh find /var/lib/kubelet/pods/container-id -type f No such file or directory", true),
+		Entry("Should match container file not found by 'stat'", "command /bin/sh stat /var/lib/kubelet/pods/container-id -type f No such file or directory", true),
 		Entry("Should not match when it is found", "command /bin/sh find /var/lib/kubelet/pods/container-id -type f found", false),
 		Entry("Should not match when it is not container file path", "command /bin/sh /run/containerd/io.containerd.runtime.v2.task/k8s.io/id foo No such file or directory", false),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds retry on not found files or directories by `stat`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
