### PR TITLE
Skip diki privileged pods from checks

### DIFF
--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -109,7 +109,7 @@ func (r *Rule2001) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 		)
 
-		// Diki privileged pods require privileged mode. During execution parallel diki rules might create pods.
+		// Diki privileged pods require privileged mode. During execution, parallel diki rules might create pods.
 		if utils.MatchLabels(pod.Labels, dikiPrivilegedPodLabels) {
 			checkResults = append(checkResults, rule.SkippedCheckResult("Diki privileged pod requires privileged mode.", podTarget))
 			continue

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
@@ -75,11 +75,16 @@ var _ = Describe("#2001", func() {
 	})
 
 	DescribeTable("Run cases",
-		func(securityContext *corev1.SecurityContext, initSecurityContext *corev1.SecurityContext, ruleOptions rules.Options2001, expectedResult rule.CheckResult) {
+		func(securityContext *corev1.SecurityContext, initSecurityContext *corev1.SecurityContext, ruleOptions rules.Options2001, dikiPod bool, expectedResult rule.CheckResult) {
 			r := &rules.Rule2001{Client: client, Options: &ruleOptions}
 			pod := plainPod.DeepCopy()
 			pod.Spec.Containers[0].SecurityContext = securityContext
 			pod.Spec.InitContainers[0].SecurityContext = initSecurityContext
+			if dikiPod {
+				pod.Labels = map[string]string{
+					"compliance.gardener.cloud/role": "diki-privileged-pod",
+				}
+			}
 
 			Expect(client.Create(ctx, pod)).To(Succeed())
 			Expect(client.Create(ctx, namespace)).To(Succeed())
@@ -90,35 +95,39 @@ var _ = Describe("#2001", func() {
 		},
 
 		Entry("should fail when securityContext is not set",
-			nil, validSecurityContext, rules.Options2001{},
+			nil, validSecurityContext, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when allowPrivilegeEscalation is not set",
-			&corev1.SecurityContext{}, validSecurityContext, rules.Options2001{},
+			&corev1.SecurityContext{}, validSecurityContext, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when allowPrivilegeEscalation is set to true",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, validSecurityContext, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, validSecurityContext, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when allowPrivilegeEscalation is set to true in initContainer",
-			validSecurityContext, &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, rules.Options2001{},
+			validSecurityContext, &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "initTest")},
 		),
 		Entry("should pass when allowPrivilegeEscalation is set to false",
-			validSecurityContext, validSecurityContext, rules.Options2001{},
+			validSecurityContext, validSecurityContext, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Passed, Message: "Pod does not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo")},
 		),
+		Entry("should skip when pod is diki privileged pod",
+			validSecurityContext, validSecurityContext, rules.Options2001{}, true,
+			rule.CheckResult{Status: rule.Skipped, Message: "Diki privileged pod requires privileged mode.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo")},
+		),
 		Entry("should fail when privileged is set to true",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Privileged: ptr.To(true)}, validSecurityContext, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Privileged: ptr.To(true)}, validSecurityContext, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when SYS_ADMIN capability is added",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}}}, validSecurityContext, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}}}, validSecurityContext, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should fail when CAP_SYS_ADMIN capability is added",
-			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_SYS_ADMIN"}}}, validSecurityContext, rules.Options2001{},
+			&corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_SYS_ADMIN"}}}, validSecurityContext, rules.Options2001{}, false,
 			rule.CheckResult{Status: rule.Failed, Message: "Pod must not escalate privileges.", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 		Entry("should pass when options are set",
@@ -133,7 +142,7 @@ var _ = Describe("#2001", func() {
 						Justification: "foo justify",
 					},
 				},
-			},
+			}, false,
 			rule.CheckResult{Status: rule.Accepted, Message: "foo justify", Target: rule.NewTarget("kind", "pod", "name", "foo", "namespace", "foo", "container", "test")},
 		),
 	)

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -98,7 +98,7 @@ func (r *Rule2003) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 		)
 
-		// Diki privileged pod uses hostPath volume. During execution parallel diki rules might create pods.
+		// Diki privileged pod uses hostPath volume. During execution, parallel diki rules might create pods.
 		if utils.MatchLabels(pod.Labels, dikiPrivilegedPodLabels) {
 			checkResults = append(checkResults, rule.SkippedCheckResult("Diki privileged pod requires the use of hostPaths.", podTarget))
 			continue

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/pkg/internal/utils"
+	kubepod "github.com/gardener/diki/pkg/kubernetes/pod"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
@@ -92,8 +93,20 @@ func (r *Rule2008) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	for _, pod := range pods {
-		podTarget := rule.NewTarget("kind", "pod", "name", pod.Name, "namespace", pod.Namespace)
-		uses := false
+		var (
+			uses                    = false
+			podTarget               = rule.NewTarget("kind", "pod", "name", pod.Name, "namespace", pod.Namespace)
+			dikiPrivilegedPodLabels = map[string]string{
+				kubepod.LabelComplianceRoleKey: kubepod.LabelComplianceRolePrivPod,
+			}
+		)
+
+		// Diki privileged pod uses hostPath volume. During execution parallel diki rules might create pods.
+		if utils.MatchLabels(pod.Labels, dikiPrivilegedPodLabels) {
+			checkResults = append(checkResults, rule.SkippedCheckResult("Diki privileged pod requires the use of hostPaths.", podTarget))
+			continue
+		}
+
 		for _, volume := range pod.Spec.Volumes {
 			volumeTarget := podTarget.With("volume", volume.Name)
 			if volume.HostPath != nil {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -101,7 +101,7 @@ func (r *Rule2008) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 		)
 
-		// Diki privileged pod uses hostPath volume. During execution parallel diki rules might create pods.
+		// Diki privileged pod uses hostPath volume. During execution, parallel diki rules might create pods.
 		if utils.MatchLabels(pod.Labels, dikiPrivilegedPodLabels) {
 			checkResults = append(checkResults, rule.SkippedCheckResult("Diki privileged pod requires the use of hostPaths.", podTarget))
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR skips the check of privileged diki pods from rules they violate.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing diki pods to appear in `Failed` rule checks has been fixed.
```
