### PR TITLE
Refactor Rules 242390 and 2000 to check for a Structured Authentication Configuration

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -6,10 +6,14 @@ package rules
 
 import (
 	"context"
+	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/gardener/diki/pkg/rule"
 )
@@ -18,6 +22,8 @@ var (
 	_ rule.Rule     = &Rule2000{}
 	_ rule.Severity = &Rule2000{}
 )
+
+const fileName = "config.yaml"
 
 type Rule2000 struct {
 	Client         client.Client
@@ -43,13 +49,40 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", r.ShootName, "namespace", r.ShootNamespace, "kind", "Shoot"))), nil
 	}
 
-	switch {
-	// EnableAnonymousAuthentication is deprecated but still used in the Gardener API
-	case shoot.Spec.Kubernetes.KubeAPIServer == nil || shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication == nil: //nolint:staticcheck
-		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is not enabled.", rule.NewTarget())), nil
-	case *shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication: //nolint:staticcheck
-		return rule.Result(r, rule.FailedCheckResult("Anonymous authentication is enabled for the kube-apiserver.", rule.NewTarget())), nil
-	default:
+	if shoot.Spec.Kubernetes.KubeAPIServer == nil {
+		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is not enabled for the kube-apiserver.", rule.NewTarget())), nil
+	}
+
+	// TODO (georgibaltiev): remove any references to the EnableAnonymousAuthentication field after it's deprecation
+	if shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication != nil { //nolint:staticcheck
+		if *shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication { //nolint:staticcheck
+			return rule.Result(r, rule.FailedCheckResult("Anonymous authentication is enabled for the kube-apiserver.", rule.NewTarget())), nil
+		}
 		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is disabled for the kube-apiserver.", rule.NewTarget())), nil
 	}
+
+	if shoot.Spec.Kubernetes.KubeAPIServer.StructuredAuthentication == nil {
+		return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is not enabled for the kube-apiserver.", rule.NewTarget())), nil
+	}
+
+	configMapName := shoot.Spec.Kubernetes.KubeAPIServer.StructuredAuthentication.ConfigMapName
+	configMap := &corev1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: configMapName, Namespace: r.ShootNamespace}}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", configMapName, "namespace", r.ShootNamespace, "kind", "ConfigMap"))), nil
+	}
+
+	authConfigString, ok := configMap.Data[fileName]
+	if !ok {
+		return rule.Result(r, rule.WarningCheckResult(fmt.Sprintf("The %s key is not present in the configMap.", fileName), rule.NewTarget("name", configMapName, "namespace", r.ShootNamespace, "kind", "ConfigMap"))), nil
+	}
+
+	authenticationConfig := &apiserverv1beta1.AuthenticationConfiguration{}
+	if err := yaml.Unmarshal([]byte(authConfigString), authenticationConfig); err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("name", configMapName, "namespace", r.ShootNamespace, "kind", "ConfigMap"))), nil
+	}
+
+	if authenticationConfig.Anonymous.Enabled {
+		return rule.Result(r, rule.FailedCheckResult("Anonymous authentication is enabled for the kube-apiserver.", rule.NewTarget("name", configMapName, "namespace", r.ShootNamespace, "kind", "ConfigMap"))), nil
+	}
+	return rule.Result(r, rule.PassedCheckResult("Anonymous authentication is disabled for the kube-apiserver.", rule.NewTarget("name", configMapName, "namespace", r.ShootNamespace, "kind", "ConfigMap"))), nil
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,11 +28,22 @@ var _ = Describe("#2000", func() {
 		shootName      = "foo"
 		shootNamespace = "bar"
 
+		authenticationConfigMap *corev1.ConfigMap
+
 		shoot    *gardencorev1beta1.Shoot
 		r        rule.Rule
 		ruleName = "Shoot clusters must have anonymous authentication disabled for the Kubernetes API server."
 		ruleID   = "2000"
 		severity = rule.SeverityHigh
+	)
+
+	const (
+		fileName                                              = "config.yaml"
+		configMapName                                         = "authentication-config"
+		invalidAnonymousAuthenticationConfig                  = "foo"
+		disabledAnonymousAuthenticationConfig                 = "apiVersion: apiserver.config.k8s.io/v1beta1\nkind: AuthenticationConfiguration\nanonymous:\n  enabled: false"
+		enabledAnonymousAuthenticationConfigWithConditions    = "apiVersion: apiserver.config.k8s.io/v1beta1\nkind: AuthenticationConfiguration\nanonymous:\n  enabled: true\n  conditions:\n  - path: /healthz\n  - path: /livez"
+		enabledAnonymousAuthenticationConfigWithoutConditions = "apiVersion: apiserver.config.k8s.io/v1beta1\nkind: AuthenticationConfiguration\nanonymous:\n  enabled: true"
 	)
 
 	BeforeEach(func() {
@@ -44,6 +56,13 @@ var _ = Describe("#2000", func() {
 			},
 		}
 
+		authenticationConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: shootNamespace,
+			},
+		}
+
 		r = &rules.Rule2000{
 			Client:         fakeClient,
 			ShootName:      shootName,
@@ -51,6 +70,7 @@ var _ = Describe("#2000", func() {
 		}
 	})
 
+	// TODO (georgibaltiev): remove any references to the EnableAnonymousAuthentication field after it's deprecation
 	DescribeTable("Run cases", func(updateFn func(), expectedCheckResult rule.CheckResult) {
 		updateFn()
 		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
@@ -64,21 +84,9 @@ var _ = Describe("#2000", func() {
 		),
 		Entry("should pass when kube-apiserver configuration is not set",
 			func() {},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()},
+			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
 		),
-		Entry("should pass when anonymous authentication is not set",
-			func() {
-				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
-					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-						KubernetesConfig: gardencorev1beta1.KubernetesConfig{
-							FeatureGates: map[string]bool{"foo": true},
-						},
-					},
-				}
-			},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled.", Target: rule.NewTarget()},
-		),
-		Entry("should pass when anonymous authentication is disabled",
+		Entry("should pass when the enabledAnoymousAuthentication flag is set to false",
 			func() {
 				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
 					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
@@ -88,7 +96,7 @@ var _ = Describe("#2000", func() {
 			},
 			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget()},
 		),
-		Entry("should fail when anonymous authentication is enabled",
+		Entry("should fail the enabledAnoymousAuthentication flag is set to true",
 			func() {
 				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
 					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
@@ -97,6 +105,120 @@ var _ = Describe("#2000", func() {
 				}
 			},
 			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget()},
+		),
+		Entry("should pass when neither the enableAnonymousAuthentication nor the structuredAuthenticaton flags are set",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+							FeatureGates: map[string]bool{"foo": true},
+						},
+					},
+				}
+			},
+			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+		),
+		Entry("should error if the structuredAuthentication configMap is not present",
+			func() {
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+							ConfigMapName: configMapName,
+						},
+					},
+				}
+			},
+			rule.CheckResult{Status: rule.Errored, Message: "configmaps \"authentication-config\" not found", Target: rule.NewTarget("name", configMapName, "namespace", shootNamespace, "kind", "ConfigMap")},
+		),
+		Entry("should warn if the structured authentication config does not contain a config.yaml key",
+			func() {
+				authenticationConfigMap.Data = map[string]string{
+					"foo": "bar",
+				}
+
+				Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+							ConfigMapName: configMapName,
+						},
+					},
+				}
+			},
+			rule.CheckResult{Status: rule.Warning, Message: "The config.yaml key is not present in the configMap.", Target: rule.NewTarget("name", configMapName, "namespace", shootNamespace, "kind", "ConfigMap")},
+		),
+		Entry("should error if the structuredAuthentication configMap contains an invalid value",
+			func() {
+				authenticationConfigMap.Data = map[string]string{
+					fileName: invalidAnonymousAuthenticationConfig,
+				}
+
+				Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+							ConfigMapName: configMapName,
+						},
+					},
+				}
+			},
+			rule.CheckResult{Status: rule.Errored, Message: "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `foo` into v1beta1.AuthenticationConfiguration", Target: rule.NewTarget("name", configMapName, "namespace", shootNamespace, "kind", "ConfigMap")},
+		),
+		Entry("should fail if the structuredAuthentication configuration has anonymous access enabled unconditionally",
+			func() {
+				authenticationConfigMap.Data = map[string]string{
+					fileName: enabledAnonymousAuthenticationConfigWithoutConditions,
+				}
+
+				Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+							ConfigMapName: configMapName,
+						},
+					},
+				}
+			},
+			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget("name", configMapName, "namespace", shootNamespace, "kind", "ConfigMap")},
+		),
+		Entry("should fail if the structured authentication config has anonymous access enabled with conditions",
+			func() {
+				authenticationConfigMap.Data = map[string]string{
+					fileName: enabledAnonymousAuthenticationConfigWithConditions,
+				}
+
+				Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+							ConfigMapName: configMapName,
+						},
+					},
+				}
+			},
+			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget("name", configMapName, "namespace", shootNamespace, "kind", "ConfigMap")},
+		),
+		Entry("should pass if the structured authentication config has anonymous access disabled",
+			func() {
+				authenticationConfigMap.Data = map[string]string{
+					fileName: disabledAnonymousAuthenticationConfig,
+				}
+
+				Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+				shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+							ConfigMapName: configMapName,
+						},
+					},
+				}
+			},
+			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget("name", configMapName, "namespace", shootNamespace, "kind", "ConfigMap")},
 		),
 	)
 })

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -21,6 +21,14 @@ import (
 )
 
 var _ = Describe("#242390", func() {
+
+	const (
+		disabledAnonymousAuthenticationConfig                 = "apiVersion: apiserver.config.k8s.io/v1beta1\nkind: AuthenticationConfiguration\nanonymous:\n  enabled: false"
+		enabledAnonymousAuthenticationConfigWithConditions    = "apiVersion: apiserver.config.k8s.io/v1beta1\nkind: AuthenticationConfiguration\nanonymous:\n  enabled: true\n  conditions:\n  - path: /healthz\n  - path: /livez"
+		enabledAnonymousAuthenticationConfigWithoutConditions = "apiVersion: apiserver.config.k8s.io/v1beta1\nkind: AuthenticationConfiguration\nanonymous:\n  enabled: true"
+		invalidAnoymousAuthenticationConfig                   = "foo"
+	)
+
 	var (
 		fakeClient client.Client
 		ctx        = context.TODO()
@@ -52,7 +60,6 @@ var _ = Describe("#242390", func() {
 			},
 		}
 	})
-
 	It("should error when kube-apiserver is not found", func() {
 		r := &rules.Rule242390{Client: fakeClient, Namespace: namespace}
 
@@ -69,7 +76,7 @@ var _ = Describe("#242390", func() {
 		))
 	})
 
-	DescribeTable("Run cases",
+	DescribeTable("Run cases for anonymous-authentication flag",
 		func(container corev1.Container, expectedCheckResults []rule.CheckResult, errorMatcher gomegatypes.GomegaMatcher) {
 			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
@@ -80,15 +87,6 @@ var _ = Describe("#242390", func() {
 
 			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 		},
-
-		Entry("should warn when anonymous-auth is not set",
-			corev1.Container{Name: "kube-apiserver", Command: []string{"--flag1=value1", "--flag2=value2"}},
-			[]rule.CheckResult{{Status: rule.Warning, Message: "Option anonymous-auth has not been set.", Target: target}},
-			BeNil()),
-		Entry("should fail when anonymous-auth is set to not allowed value true",
-			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=true"}},
-			[]rule.CheckResult{{Status: rule.Failed, Message: "Option anonymous-auth set to not allowed value.", Target: target}},
-			BeNil()),
 		Entry("should pass when anonymous-auth is set to allowed value false",
 			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=false"}},
 			[]rule.CheckResult{{Status: rule.Passed, Message: "Option anonymous-auth set to allowed value.", Target: target}},
@@ -101,5 +99,201 @@ var _ = Describe("#242390", func() {
 			corev1.Container{Name: "not-kube-apiserver", Command: []string{"--anonymous-auth=false"}},
 			[]rule.CheckResult{{Status: rule.Errored, Message: "deployment: kube-apiserver does not contain container: kube-apiserver", Target: target}},
 			BeNil()),
+		Entry("should fail when anonymous-auth is set to not allowed value true",
+			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=true"}},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Option anonymous-auth set to not allowed value.", Target: target}},
+			BeNil()),
+		Entry("should pass when anonymous-auth is set to allowed value fakse",
+			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=false"}},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Option anonymous-auth set to allowed value.", Target: target}},
+			BeNil()),
+	)
+
+	DescribeTable("Run cases for authentication-config flag",
+		func(container corev1.Container, expectedCheckResults []rule.CheckResult, errorMatcher gomegatypes.GomegaMatcher, modifyKAPIServer func()) {
+			ksDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
+			modifyKAPIServer()
+			Expect(fakeClient.Create(ctx, ksDeployment)).To(Succeed())
+
+			r := &rules.Rule242390{Client: fakeClient, Namespace: namespace}
+			ruleResult, err := r.Run(ctx)
+			Expect(err).To(errorMatcher)
+
+			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+		},
+		Entry("should warn if neither the anonymous-auth nor authentication-config options are set",
+			corev1.Container{Name: "kube-apiserver", Command: []string{}},
+			[]rule.CheckResult{{Status: rule.Warning, Message: "Neither options anonymous-auth nor authentication-config have been set.", Target: target}},
+			BeNil(),
+			func() {}),
+		Entry("should warn if the authentication-config flag is set more than once",
+			corev1.Container{
+				Name:    "kube-apiserver",
+				Command: []string{"--authentication-config=/etc/foo/bar", "--authentication-config=/etc/foo/baz"}},
+			[]rule.CheckResult{{Status: rule.Warning, Message: "Option authentication-config has been set more than once in container command.", Target: target}},
+			BeNil(),
+			func() {}),
+		Entry("should error if the volume can not be retrieved from the mount",
+			corev1.Container{
+				Name:    "kube-apiserver",
+				Command: []string{"--authentication-config=/etc/foo/bar"},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "authentication-config",
+						MountPath: "/etc/foo/bar",
+					},
+				},
+			},
+			[]rule.CheckResult{{Status: rule.Errored, Message: "deployment does not contain volume with name: authentication-config", Target: target}},
+			BeNil(),
+			func() {}),
+		Entry("should error if the configMap can not be parsed",
+			corev1.Container{
+				Name:    "kube-apiserver",
+				Command: []string{"--authentication-config=/etc/foo/bar"},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "authentication-config",
+						MountPath: "/etc/foo/bar",
+					},
+				},
+			},
+			[]rule.CheckResult{{Status: rule.Errored, Message: "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `foo` into v1beta1.AuthenticationConfiguration", Target: target}},
+			BeNil(),
+			func() {
+				ksDeployment.Spec.Template.Spec.Volumes = []corev1.Volume{{
+					Name: "authentication-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "authentication-config",
+							},
+						},
+					},
+				}}
+
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "authentication-config",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						"/etc/foo/bar": invalidAnoymousAuthenticationConfig,
+					},
+				}
+				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+			},
+		),
+		Entry("should fail if the authentication configuration has anonymous authentication enabled unconditionally.",
+			corev1.Container{
+				Name:    "kube-apiserver",
+				Command: []string{"--authentication-config=/etc/foo/bar"},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "authentication-config",
+						MountPath: "/etc/foo/bar",
+					},
+				},
+			},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "The authentication configuration has anonymous authentication enabled.", Target: target}},
+			BeNil(),
+			func() {
+				ksDeployment.Spec.Template.Spec.Volumes = []corev1.Volume{{
+					Name: "authentication-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "authentication-config",
+							},
+						},
+					},
+				}}
+
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "authentication-config",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						"/etc/foo/bar": enabledAnonymousAuthenticationConfigWithConditions,
+					},
+				}
+				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+			},
+		),
+		Entry("should fail if the authentication configuration has anonymous authentication enabled with conditions.",
+			corev1.Container{
+				Name:    "kube-apiserver",
+				Command: []string{"--authentication-config=/etc/foo/bar"},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "authentication-config",
+						MountPath: "/etc/foo/bar",
+					},
+				},
+			},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "The authentication configuration has anonymous authentication enabled.", Target: target}},
+			BeNil(),
+			func() {
+				ksDeployment.Spec.Template.Spec.Volumes = []corev1.Volume{{
+					Name: "authentication-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "authentication-config",
+							},
+						},
+					},
+				}}
+
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "authentication-config",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						"/etc/foo/bar": enabledAnonymousAuthenticationConfigWithoutConditions,
+					},
+				}
+				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+			},
+		),
+		Entry("should pass if the authentication configuration has anonymous authentication disabled.",
+			corev1.Container{
+				Name:    "kube-apiserver",
+				Command: []string{"--authentication-config=/etc/foo/bar"},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "authentication-config",
+						MountPath: "/etc/foo/bar",
+					},
+				},
+			},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "The authentication configuration has anonymous authentication disabled.", Target: target}},
+			BeNil(),
+			func() {
+				ksDeployment.Spec.Template.Spec.Volumes = []corev1.Volume{{
+					Name: "authentication-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "authentication-config",
+							},
+						},
+					},
+				}}
+
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "authentication-config",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						"/etc/foo/bar": disabledAnonymousAuthenticationConfig,
+					},
+				}
+				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+			},
+		),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
With Kubernetes 1.32, anonymous authentication for the `kube-apiserver` can be configured via a `StructuredAuthentication` configMap ([ref](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration)).

This PR adds additional checks to the following rules:

- 2000 of the Security Hardened Shoot Ruleset
- 242390 of the DISA Kubernetes STIG Ruleset

After the `enableAnonymousAuthentication` field is deprecated, the initial checks for the rules should be removed.

**Which issue(s) this PR fixes**:
Fixes #494 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Rules 242390 and 2000 now additionaly check the StructruedAuthentication configMap for enabled anonymous authentication
```
