### PR TITLE
Refactor the Status of checkResults that imply an empty ImageID in Rules 2005 (Security Hardened Kubernetes) and 242442 (DISA STIG)

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
@@ -104,7 +104,7 @@ func (r *Rule242442) checkImages(cluster string, pods []corev1.Pod) []rule.Check
 
 				imageRef := containerStatuses[containerStatusIdx].ImageID
 				if len(imageRef) == 0 {
-					checkResults = append(checkResults, rule.ErroredCheckResult("imageID not found for container", containerTarget))
+					checkResults = append(checkResults, rule.WarningCheckResult("ImageID is empty in container status.", containerTarget))
 					continue
 				}
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442_test.go
@@ -245,7 +245,7 @@ var _ = Describe("#242442", func() {
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 	})
 
-	It("should return errored result when the imageID cannot be found for a given container", func() {
+	It("should return warning result when the imageID cannot be found for a given container", func() {
 		r := &rules.Rule242442{ClusterClient: fakeShootClient, ControlPlaneClient: fakeSeedClient, ControlPlaneNamespace: namespace}
 		seedPod.Status.ContainerStatuses[1].ImageID = "eu.gcr.io/image2@sha256:" + digest2
 		seedPod.Status.ContainerStatuses[2].ImageID = ""
@@ -255,9 +255,9 @@ var _ = Describe("#242442", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.ErroredCheckResult("imageID not found for container", rule.NewTarget("cluster", "seed", "container", "foo", "name", "seed-pod", "kind", "pod")),
-			rule.ErroredCheckResult("imageID not found for container", rule.NewTarget("cluster", "seed", "container", "foobar", "name", "seed-pod", "kind", "pod")),
-			rule.ErroredCheckResult("imageID not found for container", rule.NewTarget("cluster", "seed", "container", "initFoo", "name", "seed-pod", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("cluster", "seed", "container", "foo", "name", "seed-pod", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("cluster", "seed", "container", "foobar", "name", "seed-pod", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("cluster", "seed", "container", "initFoo", "name", "seed-pod", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -112,7 +112,7 @@ func (r *Rule242442) checkImages(pods []corev1.Pod, target rule.Target) []rule.C
 
 			imageRef := containerStatuses[containerStatusIdx].ImageID
 			if len(imageRef) == 0 {
-				checkResults = append(checkResults, rule.ErroredCheckResult("imageID not found for container", containerTarget))
+				checkResults = append(checkResults, rule.WarningCheckResult("ImageID is empty in container status.", containerTarget))
 				continue
 			}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
@@ -278,7 +278,7 @@ var _ = Describe("#242442", func() {
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 	})
 
-	It("should return errored result when the imageID cannot be found for a given container", func() {
+	It("should return warning result when the imageID cannot be found for a given container", func() {
 		r := &rules.Rule242442{Client: client}
 		pod1 := plainPod.DeepCopy()
 		pod1.Name = "pod1"
@@ -289,8 +289,8 @@ var _ = Describe("#242442", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.ErroredCheckResult("imageID not found for container", rule.NewTarget("container", "foo", "namespace", "foo", "name", "pod1", "kind", "pod")),
-			rule.ErroredCheckResult("imageID not found for container", rule.NewTarget("container", "foobar", "namespace", "foo", "name", "pod1", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foo", "namespace", "foo", "name", "pod1", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foobar", "namespace", "foo", "name", "pod1", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -105,7 +105,7 @@ func (r *Rule2005) Run(ctx context.Context) (rule.RuleResult, error) {
 			}
 
 			if len(containerStatuses[containerStatusIdx].ImageID) == 0 {
-				checkResults = append(checkResults, rule.ErroredCheckResult("ImageID is empty in container status.", containerTarget))
+				checkResults = append(checkResults, rule.WarningCheckResult("ImageID is empty in container status.", containerTarget))
 				continue
 			}
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
@@ -133,7 +133,7 @@ var _ = Describe("#2005", func() {
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 	})
 
-	It("should error when imageID is empty", func() {
+	It("should warn when imageID is empty", func() {
 		option.AllowedImages = append(option.AllowedImages, rules.AllowedImage{
 			Prefix: "eu.gcr.io/foo",
 		})
@@ -145,7 +145,7 @@ var _ = Describe("#2005", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.ErroredCheckResult("ImageID is empty in container status.", rule.NewTarget("kind", "pod", "name", "foo", "namespace", "bar", "container", "foo")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("kind", "pod", "name", "foo", "namespace", "bar", "container", "foo")),
 			rule.PassedCheckResult("Image has allowed prefix.", rule.NewTarget("kind", "pod", "name", "foo", "namespace", "bar", "container", "bar", "imageRef", "eu.gcr.io/foo/image@sha256:"+digest)),
 		}
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
@@ -75,7 +75,7 @@ func (r *Rule242442) checkImages(pods []corev1.Pod, images map[string]string, re
 
 			imageRef := containerStatuses[containerStatusIdx].ImageID
 			if len(imageRef) == 0 {
-				checkResults = append(checkResults, rule.ErroredCheckResult("imageID not found for container", containerTarget))
+				checkResults = append(checkResults, rule.WarningCheckResult("ImageID is empty in container status.", containerTarget))
 				continue
 			}
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
@@ -174,7 +174,7 @@ var _ = Describe("#242442", func() {
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 	})
 
-	It("should return errored result when the imageID cannot be found for a given container", func() {
+	It("should return warning result when the imageID cannot be found for a given container", func() {
 		r := &rules.Rule242442{Client: fakeClient, Namespace: namespace}
 		pod.Status.ContainerStatuses[1].ImageID = "eu.gcr.io/image2@sha256:" + digest1
 		pod.Status.ContainerStatuses[2].ImageID = ""
@@ -184,8 +184,8 @@ var _ = Describe("#242442", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.ErroredCheckResult("imageID not found for container", rule.NewTarget("container", "foo", "name", "pod", "kind", "pod")),
-			rule.ErroredCheckResult("imageID not found for container", rule.NewTarget("container", "foobar", "name", "pod", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foo", "name", "pod", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foobar", "name", "pod", "kind", "pod")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))


### PR DESCRIPTION
**What this PR does / why we need it**:

In #492. it is reported that rules checking the `ImageID` return an `Errored` result, when a Container has an unknown status or is not running. 

While this is an expected behavior, it should be noted that `Warning` would be a more suitable checkResult status for these cases, since it implies ambiguity in the evaluated target, while `Errored` [implies a runtime failure to evaluate the target](https://github.com/gardener/diki/blob/a59535d5f7123d3440d379b854dde70b7961b6f3/pkg/rule/rule.go#L150-L153).

This PR changes the checkResult status from `Errored` to `Warning` for these cases.

**Which issue(s) this PR fixes**:
Fixes #492

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Rule 2005 of the Security Hardened Kubernetes Cluster ruleset now warns when an ImageID of a container is empty
Rule 242442 of the DISA STIG ruleset now warns when an ImageID of a container is empty
```
