### PR TITLE
Refactor rules from the Virtual Garden provider to use static targets

### DIFF
--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400.go
@@ -48,7 +48,7 @@ func (r *Rule242400) Run(ctx context.Context) (rule.RuleResult, error) {
 	)
 
 	for deploymentName, containerName := range deployments {
-		target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "deployment")
+		target := rule.NewTarget("name", deploymentName, "namespace", r.Namespace, "kind", "Deployment")
 
 		fgOptions, err := kubeutils.GetCommandOptionFromDeployment(ctx, r.Client, deploymentName, containerName, r.Namespace, "feature-gates")
 		if err != nil {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400_test.go
@@ -27,7 +27,7 @@ var _ = Describe("#242400", func() {
 		plainDeployment *appsv1.Deployment
 		kapiDeployment  *appsv1.Deployment
 		kcmDeployment   *appsv1.Deployment
-		target          = rule.NewTarget("namespace", namespace, "kind", "deployment")
+		target          = rule.NewTarget("namespace", namespace, "kind", "Deployment")
 	)
 
 	BeforeEach(func() {
@@ -91,8 +91,8 @@ var _ = Describe("#242400", func() {
 		ruleResult, err := r.Run(ctx)
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.PassedCheckResult("Option feature-gates.AllAlpha not set.", rule.NewTarget("kind", "deployment", "name", "virtual-garden-kube-apiserver", "namespace", "foo")),
-			rule.PassedCheckResult("Option feature-gates.AllAlpha set to allowed value.", rule.NewTarget("kind", "deployment", "name", "virtual-garden-kube-controller-manager", "namespace", "foo")),
+			rule.PassedCheckResult("Option feature-gates.AllAlpha not set.", rule.NewTarget("kind", "Deployment", "name", "virtual-garden-kube-apiserver", "namespace", "foo")),
+			rule.PassedCheckResult("Option feature-gates.AllAlpha set to allowed value.", rule.NewTarget("kind", "Deployment", "name", "virtual-garden-kube-controller-manager", "namespace", "foo")),
 		}
 
 		Expect(err).To(BeNil())
@@ -117,8 +117,8 @@ var _ = Describe("#242400", func() {
 		ruleResult, err := r.Run(ctx)
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.WarningCheckResult("Option feature-gates.AllAlpha set more than once in container command.", rule.NewTarget("kind", "deployment", "name", "virtual-garden-kube-apiserver", "namespace", "foo")),
-			rule.WarningCheckResult("Option feature-gates.AllAlpha set to neither 'true' nor 'false'.", rule.NewTarget("kind", "deployment", "name", "virtual-garden-kube-controller-manager", "namespace", "foo")),
+			rule.WarningCheckResult("Option feature-gates.AllAlpha set more than once in container command.", rule.NewTarget("kind", "Deployment", "name", "virtual-garden-kube-apiserver", "namespace", "foo")),
+			rule.WarningCheckResult("Option feature-gates.AllAlpha set to neither 'true' nor 'false'.", rule.NewTarget("kind", "Deployment", "name", "virtual-garden-kube-controller-manager", "namespace", "foo")),
 		}
 
 		Expect(err).To(BeNil())
@@ -146,8 +146,8 @@ var _ = Describe("#242400", func() {
 		ruleResult, err := r.Run(ctx)
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.PassedCheckResult("Option feature-gates.AllAlpha not set.", rule.NewTarget("kind", "deployment", "name", "virtual-garden-kube-apiserver", "namespace", "foo")),
-			rule.PassedCheckResult("Option feature-gates.AllAlpha set to allowed value.", rule.NewTarget("kind", "deployment", "name", "virtual-garden-kube-controller-manager", "namespace", "foo")),
+			rule.PassedCheckResult("Option feature-gates.AllAlpha not set.", rule.NewTarget("kind", "Deployment", "name", "virtual-garden-kube-apiserver", "namespace", "foo")),
+			rule.PassedCheckResult("Option feature-gates.AllAlpha set to allowed value.", rule.NewTarget("kind", "Deployment", "name", "virtual-garden-kube-controller-manager", "namespace", "foo")),
 		}
 
 		Expect(err).To(BeNil())

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
@@ -162,13 +162,20 @@ var _ = Describe("#242442", func() {
 		pod.Status.ContainerStatuses[0].Name = "not-foo"
 		pod.Status.ContainerStatuses[1].ImageID = "eu.gcr.io/image2@sha256:" + digest1
 		pod.Status.ContainerStatuses[2].ImageID = "eu.gcr.io/image3@sha256:" + digest2
+		pod.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "deployment",
+			},
+		}
 		Expect(fakeClient.Create(ctx, pod)).To(Succeed())
 
 		ruleResult, err := r.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("container", "foo", "name", "pod", "kind", "pod")),
+			rule.ErroredCheckResult("containerStatus not found for container", rule.NewTarget("container", "foo", "name", "deployment", "kind", "Deployment", "namespace", "foo")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
@@ -184,8 +191,8 @@ var _ = Describe("#242442", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foo", "name", "pod", "kind", "pod")),
-			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foobar", "name", "pod", "kind", "pod")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foo", "name", "pod", "kind", "Pod", "namespace", "foo")),
+			rule.WarningCheckResult("ImageID is empty in container status.", rule.NewTarget("container", "foobar", "name", "pod", "kind", "Pod", "namespace", "foo")),
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451_test.go
@@ -145,12 +145,24 @@ var _ = Describe("#242451", func() {
 		kubeAPIServerRS := plainReplicaSet.DeepCopy()
 		kubeAPIServerRS.Name = "virtual-garden-kube-apiserver"
 		kubeAPIServerRS.UID = "12"
-		kubeAPIServerRS.OwnerReferences[0].UID = "11"
+		kubeAPIServerRS.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "11",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-apiserver",
+			}
 
 		kubeControllerManagerRS := plainReplicaSet.DeepCopy()
 		kubeControllerManagerRS.Name = "virtual-garden-kube-controller-manager"
 		kubeControllerManagerRS.UID = "22"
-		kubeControllerManagerRS.OwnerReferences[0].UID = "21"
+		kubeControllerManagerRS.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "21",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-controller-manager",
+			}
 
 		plainPod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -206,21 +218,45 @@ var _ = Describe("#242451", func() {
 		etcdMainPod.Name = "1-pod"
 		etcdMainPod.Labels["name"] = "etcd"
 		etcdMainPod.Labels["app.kubernetes.io/part-of"] = "virtual-garden-etcd-main"
-		etcdMainPod.OwnerReferences[0].UID = "1"
+		etcdMainPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "1",
+				Kind:       "DaemonSet",
+				APIVersion: "apps/v1",
+				Name:       "etcd-main",
+			}
 
 		etcdEventsPod = plainPod.DeepCopy()
 		etcdEventsPod.Name = "etcd-events"
 		etcdEventsPod.Labels["name"] = "etcd"
 		etcdEventsPod.Labels["app.kubernetes.io/part-of"] = "virtual-garden-etcd-events"
-		etcdEventsPod.OwnerReferences[0].UID = "2"
+		etcdEventsPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "2",
+				Kind:       "DaemonSet",
+				APIVersion: "apps/v1",
+				Name:       "etcd-events",
+			}
 
 		kubeAPIServerPod = plainPod.DeepCopy()
 		kubeAPIServerPod.Name = "virtual-garden-kube-apiserver"
-		kubeAPIServerPod.OwnerReferences[0].UID = "12"
+		kubeAPIServerPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "12",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-apiserver",
+			}
 
 		kubeControllerManagerPod = plainPod.DeepCopy()
 		kubeControllerManagerPod.Name = "virtual-garden-kube-controller-manager"
-		kubeControllerManagerPod.OwnerReferences[0].UID = "22"
+		kubeControllerManagerPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "22",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-controller-manager",
+			}
 
 		fooPod = plainPod.DeepCopy()
 		fooPod.Name = "foo"
@@ -299,19 +335,19 @@ var _ = Describe("#242451", func() {
 			[][]string{{mounts, compliantFileStats, compliantDirStats, mounts, compliantFileStats2, compliantDirStats, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
 			}),
 		Entry("should return correct errored checkResults when old ETCD pods are partially found", nil, false,
 			[][]string{{mounts, compliantFileStats2, compliantDirStats, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", "instance=virtual-garden-etcd-main", "namespace", "foo")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
 			}))
 
 	DescribeTable("Run cases",
@@ -341,19 +377,19 @@ var _ = Describe("#242451", func() {
 			[][]string{{mounts, compliantFileStats, compliantDirStats, mounts, compliantFileStats2, compliantDirStats, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
 			}),
 		Entry("should return failed checkResults when files do not have expected owners", nil,
 			[][]string{{mounts, nonCompliantFileStats, nonCompliantDirStats, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, ownerGroup: 1000, expectedOwnerGroups: [0]")),
-				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file2.pem, ownerUser: 2000, expectedOwnerUsers: [0]")),
-				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 65532, expectedOwnerUsers: [0]")),
+				rule.FailedCheckResult("File has unexpected owner group", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, ownerGroup: 1000, expectedOwnerGroups: [0]")),
+				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file2.pem, ownerUser: 2000, expectedOwnerUsers: [0]")),
+				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 65532, expectedOwnerUsers: [0]")),
 			}),
 		Entry("should return correct checkResults when options are used", &option.FileOwnerOptions{
 			ExpectedFileOwner: option.ExpectedOwner{
@@ -364,36 +400,36 @@ var _ = Describe("#242451", func() {
 			[][]string{{mounts, nonCompliantFileStats, nonCompliantDirStats, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 1000")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file2.pem, ownerUser: 2000, ownerGroup: 0")),
-				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 65532, expectedOwnerUsers: [0 2000]")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 1000")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file2.pem, ownerUser: 2000, ownerGroup: 0")),
+				rule.FailedCheckResult("File has unexpected owner user", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 65532, expectedOwnerUsers: [0 2000]")),
 			}),
 		Entry("should correctly return errored checkResults when commands error", nil,
 			[][]string{{mounts, mounts, compliantFileStats2, mounts, compliantFileStats, "", emptyMounts}},
 			[][]error{{errors.New("foo"), nil, errors.New("bar"), nil, nil, errors.New("foo-bar"), nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "virtual-garden-kube-apiserver", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "virtual-garden-kube-apiserver", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
-				rule.ErroredCheckResult("foo-bar", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "virtual-garden-kube-apiserver", "namespace", "foo", "containerName", "test", "kind", "Deployment", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "virtual-garden-kube-apiserver", "namespace", "foo", "containerName", "test", "kind", "Deployment", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
+				rule.ErroredCheckResult("foo-bar", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
 			}),
 		Entry("should check files when GetMountedFilesStats errors", nil,
 			[][]string{{mountsMulty, compliantFileStats, emptyMounts, compliantDirStats, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, errors.New("bar"), nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file2.pem, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
 			}),
 		Entry("should correctly return all checkResults when commands error", nil,
 			[][]string{{mounts, mounts, compliantFileStats2, compliantDirStats, emptyMounts, emptyMounts}},
 			[][]error{{errors.New("foo"), nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
-				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.crt, ownerUser: 0, ownerGroup: 0")),
+				rule.PassedCheckResult("File has expected owners", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination, ownerUser: 0, ownerGroup: 0")),
 			}),
 	)
 })

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466_test.go
@@ -142,12 +142,22 @@ var _ = Describe("#242466", func() {
 		kubeAPIServerRS := plainReplicaSet.DeepCopy()
 		kubeAPIServerRS.Name = "virtual-garden-kube-apiserver"
 		kubeAPIServerRS.UID = "12"
-		kubeAPIServerRS.OwnerReferences[0].UID = "11"
+		kubeAPIServerRS.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:  "11",
+				Kind: "Deployment",
+				Name: "virtual-garden-kube-apiserver",
+			}
 
 		kubeControllerManagerRS := plainReplicaSet.DeepCopy()
 		kubeControllerManagerRS.Name = "virtual-garden-kube-controller-manager"
 		kubeControllerManagerRS.UID = "22"
-		kubeControllerManagerRS.OwnerReferences[0].UID = "21"
+		kubeControllerManagerRS.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:  "21",
+				Kind: "Deployment",
+				Name: "virtual-garden-kube-controller-manager",
+			}
 
 		plainPod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -203,21 +213,41 @@ var _ = Describe("#242466", func() {
 		etcdMainPod.Name = "1-pod"
 		etcdMainPod.Labels["name"] = "etcd"
 		etcdMainPod.Labels["app.kubernetes.io/part-of"] = "virtual-garden-etcd-main"
-		etcdMainPod.OwnerReferences[0].UID = "1"
+		etcdMainPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:  "1",
+				Kind: "DaemonSet",
+				Name: "etcd-main",
+			}
 
 		etcdEventsPod = plainPod.DeepCopy()
 		etcdEventsPod.Name = "etcd-events"
 		etcdEventsPod.Labels["name"] = "etcd"
 		etcdEventsPod.Labels["app.kubernetes.io/part-of"] = "virtual-garden-etcd-events"
-		etcdEventsPod.OwnerReferences[0].UID = "2"
+		etcdEventsPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:  "2",
+				Kind: "DaemonSet",
+				Name: "etcd-events",
+			}
 
 		kubeAPIServerPod = plainPod.DeepCopy()
 		kubeAPIServerPod.Name = "virtual-garden-kube-apiserver"
-		kubeAPIServerPod.OwnerReferences[0].UID = "12"
+		kubeAPIServerPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:  "12",
+				Kind: "Deployment",
+				Name: "virtual-garden-kube-apiserver",
+			}
 
 		kubeControllerManagerPod = plainPod.DeepCopy()
 		kubeControllerManagerPod.Name = "virtual-garden-kube-controller-manager"
-		kubeControllerManagerPod.OwnerReferences[0].UID = "22"
+		kubeControllerManagerPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:  "22",
+				Kind: "Deployment",
+				Name: "virtual-garden-kube-controller-manager",
+			}
 
 		fooPod = plainPod.DeepCopy()
 		fooPod.Name = "foo"
@@ -295,17 +325,17 @@ var _ = Describe("#242466", func() {
 			[][]string{{mounts, compliantStats, mounts, compliantStats2, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 644")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, permissions: 600")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.crt, permissions: 644")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.crt, permissions: 600")),
 			}),
 		Entry("should return correct errored checkResults when old ETCD pods are partially found", false,
 			[][]string{{mounts, compliantStats, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil}},
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", "instance=virtual-garden-etcd-events", "namespace", "foo")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 644")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.crt, permissions: 644")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
 			}))
 
 	DescribeTable("Run cases",
@@ -334,38 +364,38 @@ var _ = Describe("#242466", func() {
 			[][]string{{mounts, compliantStats, mounts, compliantStats2, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 644")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, permissions: 600")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.crt, permissions: 644")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.crt, permissions: 600")),
 			}),
 		Entry("should return failed checkResults when files have too wide permissions",
 			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 664, expectedPermissionsMax: 644")),
-				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 644")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.crt, permissions: 664, expectedPermissionsMax: 644")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 644")),
 			}),
 		Entry("should correctly return errored checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts}},
 			[][]error{{errors.New("foo"), nil, errors.New("bar"), nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
 			}),
 		Entry("should check files when GetMountedFilesStats errors",
 			[][]string{{mountsMulty, compliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, errors.New("bar"), nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.crt, permissions: 644")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.crt, permissions: 644")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
 			}),
 		Entry("should correctly return all checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts}},
 			[][]error{{errors.New("foo"), nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.crt, permissions: 600")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.crt, permissions: 600")),
 			}),
 	)
 })

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -70,7 +71,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	allPods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)
 	if err != nil {
-		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "podList"))), nil
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "PodList"))), nil
 	}
 
 	var (
@@ -119,7 +120,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	for _, deploymentName := range deploymentNames {
 		pods, err := kubeutils.GetDeploymentPods(ctx, r.Client, deploymentName, r.Namespace)
 		if err != nil {
-			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "podList")))
+			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "PodList")))
 			continue
 		}
 
@@ -135,9 +136,14 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.Result(r, checkResults...), nil
 	}
 
+	replicaSets, err := kubeutils.GetReplicaSets(ctx, r.Client, "", labels.NewSelector(), 300)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "ReplicaSetList"))), nil
+	}
+
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)
 	if err != nil {
-		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "nodeList"))), nil
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NodeList"))), nil
 	}
 	nodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allPods, nodes)
 	groupedPods, checks := kubeutils.SelectPodOfReferenceGroup(checkPods, nodesAllocatablePods, rule.NewTarget())
@@ -150,7 +156,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	for nodeName, pods := range groupedPods {
 		checkResults = append(checkResults,
-			r.checkPods(ctx, pods, nodeName, image.String(), expectedFilePermissionsMax)...)
+			r.checkPods(ctx, pods, replicaSets, nodeName, image.String(), expectedFilePermissionsMax)...)
 	}
 
 	return rule.Result(r, checkResults...), nil
@@ -159,13 +165,14 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 func (r *Rule242467) checkPods(
 	ctx context.Context,
 	pods []corev1.Pod,
+	replicaSets []appsv1.ReplicaSet,
 	nodeName, imageName string,
 	expectedFilePermissionsMax string,
 ) []rule.CheckResult {
 	var (
 		checkResults     []rule.CheckResult
 		podName          = fmt.Sprintf("diki-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
-		execPodTarget    = rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "pod")
+		execPodTarget    = rule.NewTarget("name", podName, "namespace", "kube-system", "kind", "Pod")
 		additionalLabels = map[string]string{pod.LabelInstanceID: r.InstanceID}
 	)
 
@@ -217,7 +224,7 @@ func (r *Rule242467) checkPods(
 					continue
 				}
 
-				containerTarget := rule.NewTarget("name", pod.Name, "namespace", pod.Namespace, "kind", "pod", "containerName", containerName)
+				containerTarget := kubeutils.TargetWithPod(rule.NewTarget("containerName", containerName), pod, replicaSets)
 				exceedFilePermissions, err := intutils.ExceedFilePermissions(fileStat.Permissions, expectedFilePermissionsMax)
 				if err != nil {
 					checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), containerTarget))

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467_test.go
@@ -142,12 +142,24 @@ var _ = Describe("#242467", func() {
 		kubeAPIServerRS := plainReplicaSet.DeepCopy()
 		kubeAPIServerRS.Name = "virtual-garden-kube-apiserver"
 		kubeAPIServerRS.UID = "12"
-		kubeAPIServerRS.OwnerReferences[0].UID = "11"
+		kubeAPIServerRS.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "11",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-apiserver",
+			}
 
 		kubeControllerManagerRS := plainReplicaSet.DeepCopy()
 		kubeControllerManagerRS.Name = "virtual-garden-kube-controller-manager"
 		kubeControllerManagerRS.UID = "22"
-		kubeControllerManagerRS.OwnerReferences[0].UID = "21"
+		kubeControllerManagerRS.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "21",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-controller-manager",
+			}
 
 		plainPod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -203,21 +215,45 @@ var _ = Describe("#242467", func() {
 		etcdMainPod.Name = "1-pod"
 		etcdMainPod.Labels["name"] = "etcd"
 		etcdMainPod.Labels["app.kubernetes.io/part-of"] = "virtual-garden-etcd-main"
-		etcdMainPod.OwnerReferences[0].UID = "1"
+		etcdMainPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "1",
+				Kind:       "DaemonSet",
+				APIVersion: "apps/v1",
+				Name:       "etcd-main",
+			}
 
 		etcdEventsPod = plainPod.DeepCopy()
 		etcdEventsPod.Name = "etcd-events"
 		etcdEventsPod.Labels["name"] = "etcd"
 		etcdEventsPod.Labels["app.kubernetes.io/part-of"] = "virtual-garden-etcd-events"
-		etcdEventsPod.OwnerReferences[0].UID = "2"
+		etcdEventsPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "2",
+				Kind:       "DaemonSet",
+				APIVersion: "apps/v1",
+				Name:       "etcd-events",
+			}
 
 		kubeAPIServerPod = plainPod.DeepCopy()
 		kubeAPIServerPod.Name = "virtual-garden-kube-apiserver"
-		kubeAPIServerPod.OwnerReferences[0].UID = "12"
+		kubeAPIServerPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "12",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-apiserver",
+			}
 
 		kubeControllerManagerPod = plainPod.DeepCopy()
 		kubeControllerManagerPod.Name = "virtual-garden-kube-controller-manager"
-		kubeControllerManagerPod.OwnerReferences[0].UID = "22"
+		kubeControllerManagerPod.OwnerReferences[0] =
+			metav1.OwnerReference{
+				UID:        "22",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "virtual-garden-kube-controller-manager",
+			}
 
 		fooPod = plainPod.DeepCopy()
 		fooPod.Name = "foo"
@@ -296,17 +332,17 @@ var _ = Describe("#242467", func() {
 			[][]string{{mounts, compliantStats, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 640")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.key, permissions: 600")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.key, permissions: 600")),
 			}),
 		Entry("should return correct errored checkResults when old ETCD pods are partially found", false,
 			[][]string{{mounts, compliantStats, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
 				rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", "instance=virtual-garden-etcd-events", "namespace", "foo")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 640")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
 			}))
 
 	DescribeTable("Run cases",
@@ -335,38 +371,38 @@ var _ = Describe("#242467", func() {
 			[][]string{{mounts, compliantStats, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 640")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.key, permissions: 600")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.key, permissions: 600")),
 			}),
 		Entry("should return failed checkResults when files have too wide permissions",
 			[][]string{{mounts, nonCompliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),
-				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),
+				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 700, expectedPermissionsMax: 640")),
 			}),
 		Entry("should correctly return errored checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{errors.New("foo"), nil, errors.New("bar"), nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
 			}),
 		Entry("should check files when GetMountedFilesStats errors",
 			[][]string{{mountsMulty, compliantStats, emptyMounts, emptyMounts, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{nil, nil, errors.New("bar"), nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file1.key, permissions: 640")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "1-pod", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
+				rule.ErroredCheckResult("bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, permissions: 640")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/bar/file2.pem, permissions: 400")),
 			}),
 		Entry("should correctly return all checkResults when commands error",
 			[][]string{{mounts, mounts, compliantStats2, emptyMounts, emptyMounts, emptyMounts}},
 			[][]error{{errors.New("foo"), nil, nil, nil, nil, nil}},
 			[]rule.CheckResult{
-				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "pod")),
-				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "pod", "details", "fileName: /destination/file3.key, permissions: 600")),
+				rule.ErroredCheckResult("foo", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
+				rule.PassedCheckResult("File has expected permissions", rule.NewTarget("name", "etcd-events", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file3.key, permissions: 600")),
 			}),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors rules, implemented specifically for the Virtual Garden provider to use static checkResult targets.

**Which issue(s) this PR fixes**:
Part of #504 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
