### PR TITLE
Refactor the Validate() method of the Option Interface

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/version"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -570,9 +571,11 @@ func readConfig(filePath string) (*config.DikiConfig, error) {
 
 func getProvidersFromConfig(c *config.DikiConfig, providerCreateFuncs map[string]provider.ProviderFromConfigFunc) (map[string]provider.Provider, error) {
 	providers := map[string]provider.Provider{}
-	for _, providerConfig := range c.Providers {
+	rootPath := field.NewPath("providers")
+
+	for providerIdx, providerConfig := range c.Providers {
 		if providerFunc, ok := providerCreateFuncs[providerConfig.ID]; ok {
-			p, err := providerFunc(providerConfig)
+			p, err := providerFunc(providerConfig, rootPath.Index(providerIdx))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/internal/config/option_config.go
+++ b/pkg/internal/config/option_config.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "github.com/gardener/diki/pkg/config"
+
+// IndexedRuleOptionsConfig represents per rule options and the index at which the option is configured in the YAML spec.
+type IndexedRuleOptionsConfig struct {
+	config.RuleOptionsConfig
+	// Index is the rule option's index in the file configuration
+	Index int
+}

--- a/pkg/internal/config/option_config.go
+++ b/pkg/internal/config/option_config.go
@@ -9,6 +9,6 @@ import "github.com/gardener/diki/pkg/config"
 // IndexedRuleOptionsConfig represents per rule options and the index at which the option is configured in the ruleOptions configuration.
 type IndexedRuleOptionsConfig struct {
 	config.RuleOptionsConfig
-	// Index is the rule option's index in the ruleOptions configuration
+	// Index is the rule option's index in the ruleOptions configuration.
 	Index int
 }

--- a/pkg/internal/config/option_config.go
+++ b/pkg/internal/config/option_config.go
@@ -6,9 +6,9 @@ package config
 
 import "github.com/gardener/diki/pkg/config"
 
-// IndexedRuleOptionsConfig represents per rule options and the index at which the option is configured in the YAML spec.
+// IndexedRuleOptionsConfig represents per rule options and the index at which the option is configured in the ruleOptions configuration.
 type IndexedRuleOptionsConfig struct {
 	config.RuleOptionsConfig
-	// Index is the rule option's index in the file configuration
+	// Index is the rule option's index in the ruleOptions configuration
 	Index int
 }

--- a/pkg/provider/builder/garden.go
+++ b/pkg/provider/builder/garden.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/metadata"
 	"github.com/gardener/diki/pkg/provider"
@@ -17,7 +19,7 @@ import (
 )
 
 // GardenProviderFromConfig retuns a Provider from a [ProviderConfig].
-func GardenProviderFromConfig(conf config.ProviderConfig) (provider.Provider, error) {
+func GardenProviderFromConfig(conf config.ProviderConfig, _ *field.Path) (provider.Provider, error) {
 	p, err := garden.FromGenericConfig(conf)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/builder/gardener.go
+++ b/pkg/provider/builder/gardener.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
 
 	"github.com/gardener/diki/pkg/config"
@@ -19,7 +20,7 @@ import (
 )
 
 // GardenerProviderFromConfig retuns a Provider from a ProviderConfig.
-func GardenerProviderFromConfig(conf config.ProviderConfig) (provider.Provider, error) {
+func GardenerProviderFromConfig(conf config.ProviderConfig, _ *field.Path) (provider.Provider, error) {
 	p, err := gardener.FromGenericConfig(conf)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/metadata"
 	"github.com/gardener/diki/pkg/provider"
@@ -18,18 +20,20 @@ import (
 )
 
 // ManagedK8SProviderFromConfig retuns a Provider from a [ProviderConfig].
-func ManagedK8SProviderFromConfig(conf config.ProviderConfig) (provider.Provider, error) {
+func ManagedK8SProviderFromConfig(conf config.ProviderConfig, rootPath *field.Path) (provider.Provider, error) {
 	p, err := managedk8s.FromGenericConfig(conf)
 	if err != nil {
 		return nil, err
 	}
+
+	rulesetsPath := rootPath.Child("rulesets")
 
 	setConfigDefaults(p.Config)
 	providerLogger := slog.Default().With("provider", p.ID())
 	setLoggerFunc := managedk8s.WithLogger(providerLogger)
 	setLoggerFunc(p)
 	rulesets := make([]ruleset.Ruleset, 0, len(conf.Rulesets))
-	for _, rulesetConfig := range conf.Rulesets {
+	for rulesetIdx, rulesetConfig := range conf.Rulesets {
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
 			ruleset, err := disak8sstig.FromGenericConfig(rulesetConfig, p.AdditionalOpsPodLabels, p.Config)
@@ -40,7 +44,7 @@ func ManagedK8SProviderFromConfig(conf config.ProviderConfig) (provider.Provider
 			setLoggerDISA(ruleset)
 			rulesets = append(rulesets, ruleset)
 		case securityhardenedk8s.RulesetID:
-			ruleset, err := securityhardenedk8s.FromGenericConfig(rulesetConfig, p.Config)
+			ruleset, err := securityhardenedk8s.FromGenericConfig(rulesetConfig, p.Config, *rulesetsPath.Index(rulesetIdx))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/metadata"
 	"github.com/gardener/diki/pkg/provider"
@@ -17,7 +19,7 @@ import (
 )
 
 // VirtualGardenProviderFromConfig retuns a Provider from a [ProviderConfig].
-func VirtualGardenProviderFromConfig(conf config.ProviderConfig) (provider.Provider, error) {
+func VirtualGardenProviderFromConfig(conf config.ProviderConfig, _ *field.Path) (provider.Provider, error) {
 	p, err := virtualgarden.FromGenericConfig(conf)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
@@ -33,15 +33,15 @@ type Extension struct {
 	Type string `json:"type" yaml:"type"`
 }
 
-func (o Options1000) Validate() field.ErrorList {
+func (o Options1000) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("extensions")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("extensions")
 	)
 
 	for _, extension := range o.Extensions {
 		if len(extension.Type) == 0 {
-			allErrs = append(allErrs, field.Required(rootPath.Child("type"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must not be empty"))
 		}
 	}
 	return allErrs

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
@@ -258,7 +258,7 @@ var _ = Describe("#1000", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(BeEmpty())
 		})
 		It("should error when options are incorrect", func() {
@@ -272,7 +272,7 @@ var _ = Describe("#1000", func() {
 					},
 				},
 			}
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(Equal(field.ErrorList{
 				{
 					Type:     field.ErrorTypeRequired,

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -37,10 +37,10 @@ type Options1001 struct {
 	AllowedClassifications []gardencorev1beta1.VersionClassification `json:"allowedClassifications" yaml:"allowedClassifications"`
 }
 
-func (o Options1001) Validate() field.ErrorList {
+func (o Options1001) Validate(_ *field.Path) field.ErrorList {
 	var (
 		allErrs                field.ErrorList
-		rootPath               = field.NewPath("allowedClassifications")
+		fldPath                = field.NewPath("allowedClassifications")
 		versionClassifications = []gardencorev1beta1.VersionClassification{
 			gardencorev1beta1.ClassificationPreview,
 			gardencorev1beta1.ClassificationSupported,
@@ -50,7 +50,7 @@ func (o Options1001) Validate() field.ErrorList {
 
 	for _, c := range o.AllowedClassifications {
 		if !slices.Contains(versionClassifications, c) {
-			allErrs = append(allErrs, field.NotSupported(rootPath, c, versionClassifications))
+			allErrs = append(allErrs, field.NotSupported(fldPath, c, versionClassifications))
 		}
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -290,7 +290,7 @@ var _ = Describe("#1001", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(BeEmpty())
 		})
 		It("should error when options are incorrect", func() {
@@ -300,7 +300,7 @@ var _ = Describe("#1001", func() {
 					fakeClassification,
 				},
 			}
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(Equal(field.ErrorList{
 				{
 					Type:     field.ErrorTypeNotSupported,

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
@@ -42,10 +42,10 @@ type MachineImage struct {
 	AllowedClassifications []gardencorev1beta1.VersionClassification `json:"allowedClassifications" yaml:"allowedClassifications"`
 }
 
-func (o Options1002) Validate() field.ErrorList {
+func (o Options1002) Validate(_ *field.Path) field.ErrorList {
 	var (
 		allErrs                field.ErrorList
-		rootPath               = field.NewPath("machineImages")
+		fldPath                = field.NewPath("machineImages")
 		versionClassifications = []gardencorev1beta1.VersionClassification{
 			gardencorev1beta1.ClassificationPreview,
 			gardencorev1beta1.ClassificationSupported,
@@ -55,12 +55,12 @@ func (o Options1002) Validate() field.ErrorList {
 
 	for _, machineImage := range o.MachineImages {
 		if len(machineImage.Name) == 0 {
-			allErrs = append(allErrs, field.Required(rootPath.Child("name"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must not be empty"))
 		}
 
 		for _, c := range machineImage.AllowedClassifications {
 			if !slices.Contains(versionClassifications, c) {
-				allErrs = append(allErrs, field.NotSupported(rootPath.Child("allowedClassifications"), c, versionClassifications))
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("allowedClassifications"), c, versionClassifications))
 			}
 		}
 	}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
@@ -449,7 +449,7 @@ var _ = Describe("#1002", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(BeEmpty())
 		})
 		It("should error when options are incorrect", func() {
@@ -469,7 +469,7 @@ var _ = Describe("#1002", func() {
 					},
 				},
 			}
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(Equal(field.ErrorList{
 				{
 					Type:     field.ErrorTypeRequired,

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
@@ -41,15 +41,15 @@ type Options1003 struct {
 	AllowedLakomScopes []lakomapi.ScopeType `json:"allowedLakomScopes" yaml:"allowedLakomScopes"`
 }
 
-func (o Options1003) Validate() field.ErrorList {
+func (o Options1003) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("minLakomScope")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("minLakomScope")
 	)
 
 	for _, lakomScope := range o.AllowedLakomScopes {
 		if !lakomapi.AllowedScopes.Has(lakomScope) {
-			allErrs = append(allErrs, field.Invalid(rootPath, lakomScope, "must be valid Lakom Scope"))
+			allErrs = append(allErrs, field.Invalid(fldPath, lakomScope, "must be valid Lakom Scope"))
 		}
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
@@ -279,14 +279,14 @@ var _ = Describe("#1003", func() {
 				AllowedLakomScopes: []lakomapi.ScopeType{kubeSystemManagedByGardenerScope, kubeSystemScope, clusterScope},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(BeEmpty())
 		})
 		It("should error when options are incorrect", func() {
 			options := rules.Options1003{
 				AllowedLakomScopes: []lakomapi.ScopeType{kubeSystemScope, fakeScope, clusterScope},
 			}
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(Equal(field.ErrorList{
 				{
 					Type:     field.ErrorTypeInvalid,

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
@@ -34,7 +34,7 @@ type Options2007 struct {
 	MinPodSecurityStandardsProfile intkubeutils.PodSecurityStandardProfile `json:"minPodSecurityStandardsProfile" yaml:"minPodSecurityStandardsProfile"`
 }
 
-func (o Options2007) Validate() field.ErrorList {
+func (o Options2007) Validate(_ *field.Path) field.ErrorList {
 	if !slices.Contains([]intkubeutils.PodSecurityStandardProfile{intkubeutils.PSSProfileBaseline, intkubeutils.PSSProfilePrivileged, intkubeutils.PSSProfileRestricted}, o.MinPodSecurityStandardsProfile) {
 		return field.ErrorList{field.Invalid(field.NewPath("minPodSecurityStandardsProfile"), o.MinPodSecurityStandardsProfile, "must be one of 'restricted', 'baseline' or 'privileged'")}
 	}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
@@ -269,7 +269,7 @@ var _ = Describe("#2007", func() {
 				MinPodSecurityStandardsProfile: "baseline",
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(BeNil())
 		})
@@ -278,7 +278,7 @@ var _ = Describe("#2007", func() {
 				MinPodSecurityStandardsProfile: "foo",
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(Equal(field.ErrorList{
 				{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -122,7 +122,7 @@ func parseV01Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -144,7 +144,7 @@ func parseV02Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -54,9 +54,9 @@ type Options242451 struct {
 
 var _ option.Option = (*Options242451)(nil)
 
-func (o Options242451) Validate() field.ErrorList {
+func (o Options242451) Validate(_ *field.Path) field.ErrorList {
 	if o.FileOwnerOptions != nil {
-		return o.FileOwnerOptions.Validate()
+		return o.FileOwnerOptions.Validate(nil)
 	}
 	return nil
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
@@ -35,7 +35,7 @@ func parseV2R2Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
@@ -35,7 +35,7 @@ func parseV2R3Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -54,7 +54,7 @@ type Options242400 struct {
 
 var _ option.Option = (*Options242400)(nil)
 
-func (o Options242400) Validate() field.ErrorList {
+func (o Options242400) Validate(_ *field.Path) field.ErrorList {
 	return validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 }
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -37,7 +37,7 @@ type Options242442 struct {
 
 var _ option.Option = (*Options242442)(nil)
 
-func (o Options242442) Validate() field.ErrorList {
+func (o Options242442) Validate(_ *field.Path) field.ErrorList {
 	return validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 }
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
@@ -53,11 +53,11 @@ type Options242451 struct {
 
 var _ option.Option = (*Options242451)(nil)
 
-func (o Options242451) Validate() field.ErrorList {
+func (o Options242451) Validate(_ *field.Path) field.ErrorList {
 	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 	allErrs = append(allErrs, option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))...)
 	if o.FileOwnerOptions != nil {
-		return append(allErrs, o.FileOwnerOptions.Validate()...)
+		return append(allErrs, o.FileOwnerOptions.Validate(nil)...)
 	}
 	return allErrs
 }

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
@@ -52,7 +52,7 @@ type Options242466 struct {
 
 var _ option.Option = (*Options242466)(nil)
 
-func (o Options242466) Validate() field.ErrorList {
+func (o Options242466) Validate(_ *field.Path) field.ErrorList {
 	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 	return append(allErrs, option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))...)
 }

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
@@ -52,7 +52,7 @@ type Options242467 struct {
 
 var _ option.Option = (*Options242467)(nil)
 
-func (o Options242467) Validate() field.ErrorList {
+func (o Options242467) Validate(_ *field.Path) field.ErrorList {
 	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 	return append(allErrs, option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))...)
 }

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -862,7 +862,7 @@ func parseV2R2Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -862,7 +862,7 @@ func parseV2R3Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -39,11 +39,13 @@ type Options2001 struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options2001) Validate() field.ErrorList {
+func (o Options2001) Validate(fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	for _, p := range o.AcceptedPods {
-		allErrs = append(allErrs, p.Validate()...)
+	acceptedPodsPath := fldPath.Child("acceptedPods")
+
+	for pIdx, p := range o.AcceptedPods {
+		allErrs = append(allErrs, p.Validate(acceptedPodsPath.Index(pIdx))...)
 	}
 
 	return allErrs

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
@@ -37,11 +37,13 @@ type Options2002 struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options2002) Validate() field.ErrorList {
+func (o Options2002) Validate(fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	for _, sc := range o.AcceptedStorageClasses {
-		allErrs = append(allErrs, sc.Validate()...)
+	acceptedStorageClassesPath := fldPath.Child("acceptedStorageClasses")
+
+	for scIdx, sc := range o.AcceptedStorageClasses {
+		allErrs = append(allErrs, sc.Validate(acceptedStorageClassesPath.Index(scIdx))...)
 	}
 
 	return allErrs

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -37,19 +37,19 @@ type AcceptedPods2003 struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options2003) Validate() field.ErrorList {
+func (o Options2003) Validate(fldPath *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("acceptedPods")
+		allErrs          field.ErrorList
+		acceptedPodsPath = fldPath.Child("acceptedPods")
 	)
-	for _, p := range o.AcceptedPods {
-		allErrs = append(allErrs, p.Validate()...)
+	for pIdx, p := range o.AcceptedPods {
+		allErrs = append(allErrs, p.Validate(acceptedPodsPath.Index(pIdx))...)
 		if len(p.VolumeNames) == 0 {
-			allErrs = append(allErrs, field.Required(rootPath.Child("volumeNames"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(acceptedPodsPath.Index(pIdx).Child("volumeNames"), "must not be empty"))
 		}
 		for i, volumeName := range p.VolumeNames {
 			if len(volumeName) == 0 {
-				allErrs = append(allErrs, field.Invalid(rootPath.Child("volumeNames").Index(i), volumeName, "must not be empty"))
+				allErrs = append(allErrs, field.Invalid(acceptedPodsPath.Index(pIdx).Child("volumeNames").Index(i), volumeName, "must not be empty"))
 			}
 		}
 	}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
@@ -528,17 +528,17 @@ var _ = Describe("#2003", func() {
 				},
 			}
 
-			result := options.Validate(field.NewPath(""))
+			result := options.Validate(field.NewPath("foo"))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].acceptedPods[0].volumeNames"),
+					"Field":  Equal("foo.acceptedPods[0].volumeNames"),
 					"Detail": Equal("must not be empty"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].acceptedPods[2].volumeNames[0]"),
+					"Field":    Equal("foo.acceptedPods[2].volumeNames[0]"),
 					"BadValue": Equal(""),
 					"Detail":   Equal("must not be empty"),
 				})),

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
@@ -528,17 +528,17 @@ var _ = Describe("#2003", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(field.NewPath(""))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("acceptedPods.volumeNames"),
+					"Field":  Equal("[].acceptedPods[0].volumeNames"),
 					"Detail": Equal("must not be empty"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.volumeNames[0]"),
+					"Field":    Equal("[].acceptedPods[2].volumeNames[0]"),
 					"BadValue": Equal(""),
 					"Detail":   Equal("must not be empty"),
 				})),

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
@@ -37,11 +37,13 @@ type Options2004 struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options2004) Validate() field.ErrorList {
+func (o Options2004) Validate(fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	for _, s := range o.AcceptedServices {
-		allErrs = append(allErrs, s.Validate()...)
+	acceptedServicesPath := fldPath.Child("acceptedServices")
+
+	for sIdx, s := range o.AcceptedServices {
+		allErrs = append(allErrs, s.Validate(acceptedServicesPath.Index(sIdx))...)
 	}
 
 	return allErrs

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -39,10 +39,10 @@ type AllowedImage struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options2005) Validate() field.ErrorList {
+func (o Options2005) Validate(fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs      field.ErrorList
-		allowImgPath = field.NewPath("allowedImages")
+		allowImgPath = fldPath.Child("allowedImages")
 	)
 
 	if len(o.AllowedImages) == 0 {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
@@ -274,12 +274,12 @@ var _ = Describe("#2005", func() {
 		It("should deny empty allowed images list", func() {
 			options := rules.Options2005{}
 
-			result := options.Validate(field.NewPath(""))
+			result := options.Validate(field.NewPath("foo"))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].allowedImages"),
+					"Field":  Equal("foo.allowedImages"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))
@@ -300,12 +300,12 @@ var _ = Describe("#2005", func() {
 				},
 			}
 
-			result := options.Validate(field.NewPath(""))
+			result := options.Validate(field.NewPath("foo"))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].allowedImages[1].prefix"),
+					"Field":  Equal("foo.allowedImages[1].prefix"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
@@ -274,12 +274,12 @@ var _ = Describe("#2005", func() {
 		It("should deny empty allowed images list", func() {
 			options := rules.Options2005{}
 
-			result := options.Validate()
+			result := options.Validate(field.NewPath(""))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("allowedImages"),
+					"Field":  Equal("[].allowedImages"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))
@@ -300,12 +300,12 @@ var _ = Describe("#2005", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(field.NewPath(""))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("allowedImages[1].prefix"),
+					"Field":  Equal("[].allowedImages[1].prefix"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
@@ -40,15 +40,15 @@ type Options2006 struct {
 }
 
 // Validate validates that option configurations are correctly defined.
-func (o Options2006) Validate() field.ErrorList {
+func (o Options2006) Validate(fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	for _, r := range o.AcceptedRoles {
-		allErrs = append(allErrs, r.Validate()...)
+	for rIdx, r := range o.AcceptedRoles {
+		allErrs = append(allErrs, r.Validate(fldPath.Child("acceptedRoles").Index(rIdx))...)
 	}
 
-	for _, c := range o.AcceptedClusterRoles {
-		allErrs = append(allErrs, c.Validate()...)
+	for cIdx, c := range o.AcceptedClusterRoles {
+		allErrs = append(allErrs, c.Validate(fldPath.Child("acceptedClusterRoles").Index(cIdx))...)
 	}
 
 	return allErrs

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
@@ -40,15 +40,15 @@ type Options2007 struct {
 }
 
 // Validate validates that option configurations are correctly defined.
-func (o Options2007) Validate() field.ErrorList {
+func (o Options2007) Validate(fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	for _, r := range o.AcceptedRoles {
-		allErrs = append(allErrs, r.Validate()...)
+	for rIdx, r := range o.AcceptedRoles {
+		allErrs = append(allErrs, r.Validate(fldPath.Child("acceptedRoles").Index(rIdx))...)
 	}
 
-	for _, c := range o.AcceptedClusterRoles {
-		allErrs = append(allErrs, c.Validate()...)
+	for cIdx, c := range o.AcceptedClusterRoles {
+		allErrs = append(allErrs, c.Validate(fldPath.Child("acceptedClusterRoles").Index(cIdx))...)
 	}
 
 	return allErrs

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -44,19 +44,19 @@ type AcceptedPods2008 struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options2008) Validate() field.ErrorList {
+func (o Options2008) Validate(fldPath *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("acceptedPods")
+		allErrs          field.ErrorList
+		acceptedPodsPath = fldPath.Child("acceptedPods")
 	)
-	for _, p := range o.AcceptedPods {
-		allErrs = append(allErrs, p.Validate()...)
+	for pIdx, p := range o.AcceptedPods {
+		allErrs = append(allErrs, p.Validate(acceptedPodsPath.Index(pIdx))...)
 		if len(p.VolumeNames) == 0 {
-			allErrs = append(allErrs, field.Required(rootPath.Child("volumeNames"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(acceptedPodsPath.Index(pIdx).Child("volumeNames"), "must not be empty"))
 		}
 		for i, volumeName := range p.VolumeNames {
 			if len(volumeName) == 0 {
-				allErrs = append(allErrs, field.Invalid(rootPath.Child("volumeNames").Index(i), volumeName, "must not be empty"))
+				allErrs = append(allErrs, field.Invalid(acceptedPodsPath.Index(pIdx).Child("volumeNames").Index(i), volumeName, "must not be empty"))
 			}
 		}
 	}

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
@@ -418,17 +418,17 @@ var _ = Describe("#2008", func() {
 				},
 			}
 
-			result := options.Validate(field.NewPath(""))
+			result := options.Validate(field.NewPath("foo"))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].acceptedPods[0].volumeNames"),
+					"Field":  Equal("foo.acceptedPods[0].volumeNames"),
 					"Detail": Equal("must not be empty"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].acceptedPods[2].volumeNames[0]"),
+					"Field":    Equal("foo.acceptedPods[2].volumeNames[0]"),
 					"BadValue": Equal(""),
 					"Detail":   Equal("must not be empty"),
 				})),

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
@@ -418,17 +418,17 @@ var _ = Describe("#2008", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(field.NewPath(""))
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("acceptedPods.volumeNames"),
+					"Field":  Equal("[].acceptedPods[0].volumeNames"),
 					"Detail": Equal("must not be empty"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("acceptedPods.volumeNames[0]"),
+					"Field":    Equal("[].acceptedPods[2].volumeNames[0]"),
 					"BadValue": Equal(""),
 					"Detail":   Equal("must not be empty"),
 				})),

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
@@ -22,7 +22,7 @@ func (r *Ruleset) validateV01RuleOptions(ruleOptions map[string]internalconfig.I
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV01Options[rules.Options2000](ruleOptions["2000"].Args, *fldPath.Index(ruleOptions["2000"].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV01Options[rules.Options2001](ruleOptions["2001"].Args, *fldPath.Index(ruleOptions["2002"].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV01Options[rules.Options2001](ruleOptions["2001"].Args, *fldPath.Index(ruleOptions["2001"].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV01Options[rules.Options2002](ruleOptions["2002"].Args, *fldPath.Index(ruleOptions["2002"].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV01Options[rules.Options2003](ruleOptions["2003"].Args, *fldPath.Index(ruleOptions["2003"].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV01Options[rules.Options2004](ruleOptions["2004"].Args, *fldPath.Index(ruleOptions["2004"].Index).Child("args"))...)
@@ -140,9 +140,7 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 }
 
 func validateV01Options[O rules.RuleOption](options any, fldPath field.Path) field.ErrorList {
-
 	parsedOptions, err := parseV01Options[O](options)
-
 	if err != nil {
 		return field.ErrorList{
 			field.InternalError(&fldPath, err),

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -7,6 +7,8 @@ package provider
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/metadata"
 	"github.com/gardener/diki/pkg/rule"
@@ -32,7 +34,7 @@ type ProviderResult struct {
 }
 
 // ProviderFromConfigFunc constructs a Provider from ProviderConfig.
-type ProviderFromConfigFunc func(conf config.ProviderConfig) (Provider, error)
+type ProviderFromConfigFunc func(conf config.ProviderConfig, fldPath *field.Path) (Provider, error)
 
 // MetadataFunc constructs a detailed Provider metadata object.
 type MetadataFunc func() metadata.ProviderDetailed

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
@@ -753,7 +753,7 @@ func parseV2R2Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
@@ -753,7 +753,7 @@ func parseV2R3Options[O rules.RuleOption](options any) (*O, error) {
 	}
 
 	if val, ok := any(parsedOptions).(option.Option); ok {
-		if err := val.Validate().ToAggregate(); err != nil {
+		if err := val.Validate(nil).ToAggregate(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -20,17 +20,17 @@ type ClusterObjectSelector struct {
 var _ option.Option = (*ClusterObjectSelector)(nil)
 
 // Validate validates that option configurations are correctly defined.
-func (s *ClusterObjectSelector) Validate() field.ErrorList {
+func (s *ClusterObjectSelector) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("")
 	)
 
 	if len(s.MatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(rootPath.Child("matchLabels"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("matchLabels"), "must not be empty"))
 	}
 
-	allErrs = append(allErrs, metav1validation.ValidateLabels(s.MatchLabels, rootPath.Child("matchLabels"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(s.MatchLabels, fldPath.Child("matchLabels"))...)
 
 	return allErrs
 }
@@ -44,23 +44,22 @@ type NamespacedObjectSelector struct {
 // TODO: Implement new Option interface in this package with Validate method, which recieves field.Path.
 var _ option.Option = (*NamespacedObjectSelector)(nil)
 
-// Validate validates that option configurations are correctly defined.
-func (s *NamespacedObjectSelector) Validate() field.ErrorList {
+// Validate validates that option configurations are correctly defined. It accepts an additional paremeter to which to append the erorred configuration's fields.
+func (s *NamespacedObjectSelector) Validate(fldPath *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("")
+		allErrs field.ErrorList
 	)
 
 	if len(s.NamespaceMatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(rootPath.Child("namespaceMatchLabels"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("namespaceMatchLabels"), "must not be empty"))
 	}
 
 	if len(s.MatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(rootPath.Child("matchLabels"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("matchLabels"), "must not be empty"))
 	}
 
-	allErrs = append(allErrs, metav1validation.ValidateLabels(s.NamespaceMatchLabels, rootPath.Child("namespaceMatchLabels"))...)
-	allErrs = append(allErrs, metav1validation.ValidateLabels(s.MatchLabels, rootPath.Child("matchLabels"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(s.NamespaceMatchLabels, fldPath.Child("namespaceMatchLabels"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(s.MatchLabels, fldPath.Child("matchLabels"))...)
 	return allErrs
 }
 

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -20,10 +20,9 @@ type ClusterObjectSelector struct {
 var _ option.Option = (*ClusterObjectSelector)(nil)
 
 // Validate validates that option configurations are correctly defined.
-func (s *ClusterObjectSelector) Validate(_ *field.Path) field.ErrorList {
+func (s *ClusterObjectSelector) Validate(fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs field.ErrorList
-		fldPath = field.NewPath("")
 	)
 
 	if len(s.MatchLabels) == 0 {
@@ -44,7 +43,7 @@ type NamespacedObjectSelector struct {
 // TODO: Implement new Option interface in this package with Validate method, which recieves field.Path.
 var _ option.Option = (*NamespacedObjectSelector)(nil)
 
-// Validate validates that option configurations are correctly defined. It accepts an additional paremeter to which to append the erorred configuration's fields.
+// Validate validates that option configurations are correctly defined. It accepts a [field.Path] parameter with the rootPath.
 func (s *NamespacedObjectSelector) Validate(fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs field.ErrorList

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -37,7 +37,7 @@ var _ = Describe("options", func() {
 
 			var result field.ErrorList
 			for _, p := range attributes {
-				result = append(result, p.Validate()...)
+				result = append(result, p.Validate(field.NewPath(""))...)
 			}
 
 			Expect(result).To(ConsistOf(
@@ -102,7 +102,7 @@ var _ = Describe("options", func() {
 
 			var result field.ErrorList
 			for _, p := range attributes {
-				result = append(result, p.Validate()...)
+				result = append(result, p.Validate(field.NewPath(""))...)
 			}
 
 			Expect(result).To(ConsistOf(

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -37,25 +37,25 @@ var _ = Describe("options", func() {
 
 			var result field.ErrorList
 			for _, p := range attributes {
-				result = append(result, p.Validate(field.NewPath(""))...)
+				result = append(result, p.Validate(field.NewPath("foo"))...)
 			}
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].matchLabels"),
+					"Field":    Equal("foo.matchLabels"),
 					"BadValue": Equal("bar."),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].matchLabels"),
+					"Field":    Equal("foo.matchLabels"),
 					"BadValue": Equal("at$a"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].matchLabels"),
+					"Field":  Equal("foo.matchLabels"),
 					"Detail": Equal("must not be empty"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].matchLabels"),
+					"Field":  Equal("foo.matchLabels"),
 					"Detail": Equal("must not be empty"),
 				}))))
 		})
@@ -102,46 +102,46 @@ var _ = Describe("options", func() {
 
 			var result field.ErrorList
 			for _, p := range attributes {
-				result = append(result, p.Validate(field.NewPath(""))...)
+				result = append(result, p.Validate(field.NewPath("foo"))...)
 			}
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].namespaceMatchLabels"),
+					"Field":    Equal("foo.namespaceMatchLabels"),
 					"BadValue": Equal("_foo"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].matchLabels"),
+					"Field":    Equal("foo.matchLabels"),
 					"BadValue": Equal("bar."),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].namespaceMatchLabels"),
+					"Field":    Equal("foo.namespaceMatchLabels"),
 					"BadValue": Equal("fo?o"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].namespaceMatchLabels"),
+					"Field":    Equal("foo.namespaceMatchLabels"),
 					"BadValue": Equal("ba/r"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("[].matchLabels"),
+					"Field":    Equal("foo.matchLabels"),
 					"BadValue": Equal("at$a"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].namespaceMatchLabels"),
+					"Field":  Equal("foo.namespaceMatchLabels"),
 					"Detail": Equal("must not be empty"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].namespaceMatchLabels"),
+					"Field":  Equal("foo.namespaceMatchLabels"),
 					"Detail": Equal("must not be empty"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].matchLabels"),
+					"Field":  Equal("foo.matchLabels"),
 					"Detail": Equal("must not be empty"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("[].matchLabels"),
+					"Field":  Equal("foo.matchLabels"),
 					"Detail": Equal("must not be empty"),
 				}))))
 		})

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -15,7 +15,7 @@ import (
 // Option that can be validated in order to ensure
 // that configurations are correctly defined
 type Option interface {
-	Validate() field.ErrorList
+	Validate(fldPath *field.Path) field.ErrorList
 }
 
 // PodSelector contains generalized options for matching entities by their attribute labels
@@ -27,22 +27,22 @@ type PodSelector struct {
 var _ Option = (*PodSelector)(nil)
 
 // Validate validates that option configurations are correctly defined
-func (e PodSelector) Validate() field.ErrorList {
+func (e PodSelector) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("")
 	)
 
 	if len(e.NamespaceMatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(rootPath.Child("namespaceMatchLabels"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("namespaceMatchLabels"), "must not be empty"))
 	}
 
 	if len(e.PodMatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(rootPath.Child("podMatchLabels"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("podMatchLabels"), "must not be empty"))
 	}
 
-	allErrs = append(allErrs, metav1validation.ValidateLabels(e.NamespaceMatchLabels, rootPath.Child("namespaceMatchLabels"))...)
-	allErrs = append(allErrs, metav1validation.ValidateLabels(e.PodMatchLabels, rootPath.Child("podMatchLabels"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(e.NamespaceMatchLabels, fldPath.Child("namespaceMatchLabels"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(e.PodMatchLabels, fldPath.Child("podMatchLabels"))...)
 	return allErrs
 }
 
@@ -60,30 +60,30 @@ type ExpectedOwner struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o FileOwnerOptions) Validate() field.ErrorList {
+func (o FileOwnerOptions) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("expectedFileOwner")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("expectedFileOwner")
 	)
 	for _, user := range o.ExpectedFileOwner.Users {
 		userID, err := strconv.ParseInt(user, 10, 64)
 		if err != nil {
-			allErrs = append(allErrs, field.InternalError(rootPath.Child("users"), err))
+			allErrs = append(allErrs, field.InternalError(fldPath.Child("users"), err))
 			continue
 		}
 		for _, msg := range validation.IsValidUserID(userID) {
-			allErrs = append(allErrs, field.Invalid(rootPath.Child("users"), user, msg))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("users"), user, msg))
 		}
 	}
 
 	for _, group := range o.ExpectedFileOwner.Groups {
 		groupID, err := strconv.ParseInt(group, 10, 64)
 		if err != nil {
-			allErrs = append(allErrs, field.InternalError(rootPath.Child("groups"), err))
+			allErrs = append(allErrs, field.InternalError(fldPath.Child("groups"), err))
 			continue
 		}
 		for _, msg := range validation.IsValidGroupID(groupID) {
-			allErrs = append(allErrs, field.Invalid(rootPath.Child("groups"), group, msg))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("groups"), group, msg))
 		}
 	}
 	return allErrs
@@ -104,19 +104,19 @@ type AcceptedPods242414 struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options242414) Validate() field.ErrorList {
+func (o Options242414) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("acceptedPods")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("acceptedPods")
 	)
 	for _, p := range o.AcceptedPods {
-		allErrs = append(allErrs, p.Validate()...)
+		allErrs = append(allErrs, p.Validate(nil)...)
 		if len(p.Ports) == 0 {
-			allErrs = append(allErrs, field.Required(rootPath.Child("ports"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("ports"), "must not be empty"))
 		}
 		for _, port := range p.Ports {
 			if port < 0 {
-				allErrs = append(allErrs, field.Invalid(rootPath.Child("ports"), port, "must not be lower than 0"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("ports"), port, "must not be lower than 0"))
 			}
 		}
 	}
@@ -138,19 +138,19 @@ type AcceptedPods242415 struct {
 }
 
 // Validate validates that option configurations are correctly defined
-func (o Options242415) Validate() field.ErrorList {
+func (o Options242415) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("acceptedPods")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("acceptedPods")
 	)
 	for _, p := range o.AcceptedPods {
-		allErrs = append(allErrs, p.Validate()...)
+		allErrs = append(allErrs, p.Validate(nil)...)
 		if len(p.EnvironmentVariables) == 0 {
-			allErrs = append(allErrs, field.Required(rootPath.Child("environmentVariables"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("environmentVariables"), "must not be empty"))
 		}
 		for _, env := range p.EnvironmentVariables {
 			for _, msg := range validation.IsEnvVarName(env) {
-				allErrs = append(allErrs, field.Invalid(rootPath.Child("environmentVariables"), env, msg))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("environmentVariables"), env, msg))
 			}
 		}
 	}

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -22,7 +22,7 @@ var _ = Describe("options", func() {
 					Groups: []string{"", "asd", "111"},
 				},
 			}
-			result := options.Validate()
+			result := options.Validate(nil)
 			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
 				"Field":    Equal("expectedFileOwner.users"),
@@ -83,7 +83,7 @@ var _ = Describe("options", func() {
 
 			var result field.ErrorList
 			for _, p := range podAttributes {
-				result = append(result, p.Validate()...)
+				result = append(result, p.Validate(nil)...)
 			}
 
 			Expect(result).To(ConsistOf(
@@ -166,7 +166,7 @@ var _ = Describe("options", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -211,7 +211,7 @@ var _ = Describe("options", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/shared/ruleset/disak8sstig/rules/242383.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383.go
@@ -46,15 +46,15 @@ type AcceptedResources242383 struct {
 	Status        string `json:"status" yaml:"status"`
 }
 
-func (o Options242383) Validate() field.ErrorList {
+func (o Options242383) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("acceptedResources")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("acceptedResources")
 	)
 	for _, p := range o.AcceptedResources {
-		allErrs = append(allErrs, p.Validate()...)
+		allErrs = append(allErrs, p.Validate(nil)...)
 		if !slices.Contains([]string{"Passed", "Accepted"}, p.Status) && len(p.Status) > 0 {
-			allErrs = append(allErrs, field.Invalid(rootPath.Child("status"), p.Status, "must be one of 'Passed' or 'Accepted'"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("status"), p.Status, "must be one of 'Passed' or 'Accepted'"))
 		}
 	}
 	return allErrs
@@ -69,10 +69,10 @@ type ObjectSelector struct {
 
 var _ option.Option = (*ObjectSelector)(nil)
 
-func (s ObjectSelector) Validate() field.ErrorList {
+func (s ObjectSelector) Validate(_ *field.Path) field.ErrorList {
 	var (
 		allErrs          field.ErrorList
-		rootPath         = field.NewPath("acceptedResources")
+		fldPath          = field.NewPath("acceptedResources")
 		checkedResources = map[string][]string{
 			"v1":             {"Pod", "ReplicationController", "Service"},
 			"apps/v1":        {"Deployment", "DaemonSet", "ReplicaSet", "StatefulSet"},
@@ -82,21 +82,21 @@ func (s ObjectSelector) Validate() field.ErrorList {
 	)
 
 	if len(s.NamespaceMatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(rootPath.Child("namespaceMatchLabels"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("namespaceMatchLabels"), "must not be empty"))
 	}
 
 	if len(s.MatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(rootPath.Child("matchLabels"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("matchLabels"), "must not be empty"))
 	}
 
 	if kinds, ok := checkedResources[s.APIVersion]; !ok {
-		allErrs = append(allErrs, field.Invalid(rootPath.Child("apiVersion"), s.APIVersion, "not checked apiVersion"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("apiVersion"), s.APIVersion, "not checked apiVersion"))
 	} else if !slices.Contains(kinds, s.Kind) && s.Kind != "*" {
-		allErrs = append(allErrs, field.Invalid(rootPath.Child("kind"), s.Kind, fmt.Sprintf("not checked kind for apiVerion %s", s.APIVersion)))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), s.Kind, fmt.Sprintf("not checked kind for apiVerion %s", s.APIVersion)))
 	}
 
-	allErrs = append(allErrs, metav1validation.ValidateLabels(s.MatchLabels, rootPath.Child("matchLabels"))...)
-	allErrs = append(allErrs, metav1validation.ValidateLabels(s.NamespaceMatchLabels, rootPath.Child("namespaceMatchLabels"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(s.MatchLabels, fldPath.Child("matchLabels"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(s.NamespaceMatchLabels, fldPath.Child("namespaceMatchLabels"))...)
 
 	return allErrs
 }

--- a/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
@@ -453,7 +453,7 @@ var _ = Describe("#242383", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/shared/ruleset/disak8sstig/rules/242393.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242393.go
@@ -47,7 +47,7 @@ type Options242393 struct {
 
 var _ option.Option = (*Options242393)(nil)
 
-func (o Options242393) Validate() field.ErrorList {
+func (o Options242393) Validate(_ *field.Path) field.ErrorList {
 	return option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242394.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242394.go
@@ -47,7 +47,7 @@ type Options242394 struct {
 
 var _ option.Option = (*Options242394)(nil)
 
-func (o Options242394) Validate() field.ErrorList {
+func (o Options242394) Validate(_ *field.Path) field.ErrorList {
 	return option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242396.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242396.go
@@ -49,7 +49,7 @@ type Options242396 struct {
 
 var _ option.Option = (*Options242396)(nil)
 
-func (o Options242396) Validate() field.ErrorList {
+func (o Options242396) Validate(_ *field.Path) field.ErrorList {
 	return option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242404.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242404.go
@@ -45,7 +45,7 @@ type Options242404 struct {
 
 var _ option.Option = (*Options242404)(nil)
 
-func (o Options242404) Validate() field.ErrorList {
+func (o Options242404) Validate(_ *field.Path) field.ErrorList {
 	return option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242406.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242406.go
@@ -46,10 +46,10 @@ type Options242406 struct {
 
 var _ option.Option = (*Options242406)(nil)
 
-func (o Options242406) Validate() field.ErrorList {
+func (o Options242406) Validate(_ *field.Path) field.ErrorList {
 	allErrs := option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 	if o.FileOwnerOptions != nil {
-		return append(allErrs, o.FileOwnerOptions.Validate()...)
+		return append(allErrs, o.FileOwnerOptions.Validate(nil)...)
 	}
 	return allErrs
 }

--- a/pkg/shared/ruleset/disak8sstig/rules/242407.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242407.go
@@ -45,7 +45,7 @@ type Options242407 struct {
 
 var _ option.Option = (*Options242407)(nil)
 
-func (o Options242407) Validate() field.ErrorList {
+func (o Options242407) Validate(_ *field.Path) field.ErrorList {
 	return option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242417.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417.go
@@ -44,16 +44,16 @@ type AcceptedPods242417 struct {
 	Status        string `json:"status" yaml:"status"`
 }
 
-func (o Options242417) Validate() field.ErrorList {
+func (o Options242417) Validate(_ *field.Path) field.ErrorList {
 	var (
-		allErrs  field.ErrorList
-		rootPath = field.NewPath("acceptedPods")
+		allErrs field.ErrorList
+		fldPath = field.NewPath("acceptedPods")
 	)
 
 	for _, p := range o.AcceptedPods {
-		allErrs = append(allErrs, p.Validate()...)
+		allErrs = append(allErrs, p.Validate(nil)...)
 		if !slices.Contains([]string{"Passed", "Accepted"}, p.Status) && len(p.Status) > 0 {
-			allErrs = append(allErrs, field.Invalid(rootPath.Child("status"), p.Status, "must be one of 'Passed' or 'Accepted'"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("status"), p.Status, "must be one of 'Passed' or 'Accepted'"))
 		}
 	}
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -375,7 +375,7 @@ var _ = Describe("#242417", func() {
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),

--- a/pkg/shared/ruleset/disak8sstig/rules/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447.go
@@ -49,7 +49,7 @@ type Options242447 struct {
 
 var _ option.Option = (*Options242447)(nil)
 
-func (o Options242447) Validate() field.ErrorList {
+func (o Options242447) Validate(_ *field.Path) field.ErrorList {
 	return validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -50,10 +50,10 @@ type Options242448 struct {
 
 var _ option.Option = (*Options242448)(nil)
 
-func (o Options242448) Validate() field.ErrorList {
+func (o Options242448) Validate(_ *field.Path) field.ErrorList {
 	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, field.NewPath("kubeProxyMatchLabels"))
 	if o.FileOwnerOptions != nil {
-		return append(allErrs, o.FileOwnerOptions.Validate()...)
+		return append(allErrs, o.FileOwnerOptions.Validate(nil)...)
 	}
 	return allErrs
 }

--- a/pkg/shared/ruleset/disak8sstig/rules/242449.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242449.go
@@ -46,7 +46,7 @@ type Options242449 struct {
 
 var _ option.Option = (*Options242449)(nil)
 
-func (o Options242449) Validate() field.ErrorList {
+func (o Options242449) Validate(_ *field.Path) field.ErrorList {
 	return option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242450.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242450.go
@@ -47,10 +47,10 @@ type Options242450 struct {
 
 var _ option.Option = (*Options242450)(nil)
 
-func (o Options242450) Validate() field.ErrorList {
+func (o Options242450) Validate(_ *field.Path) field.ErrorList {
 	allErrs := option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 	if o.FileOwnerOptions != nil {
-		return append(allErrs, o.FileOwnerOptions.Validate()...)
+		return append(allErrs, o.FileOwnerOptions.Validate(nil)...)
 	}
 	return allErrs
 }

--- a/pkg/shared/ruleset/disak8sstig/rules/242452.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242452.go
@@ -46,7 +46,7 @@ type Options242452 struct {
 
 var _ option.Option = (*Options242452)(nil)
 
-func (o Options242452) Validate() field.ErrorList {
+func (o Options242452) Validate(_ *field.Path) field.ErrorList {
 	return option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 }
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242453.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242453.go
@@ -47,10 +47,10 @@ type Options242453 struct {
 
 var _ option.Option = (*Options242453)(nil)
 
-func (o Options242453) Validate() field.ErrorList {
+func (o Options242453) Validate(_ *field.Path) field.ErrorList {
 	allErrs := option.ValidateLabelNames(o.NodeGroupByLabels, field.NewPath("nodeGroupByLabels"))
 	if o.FileOwnerOptions != nil {
-		return append(allErrs, o.FileOwnerOptions.Validate()...)
+		return append(allErrs, o.FileOwnerOptions.Validate(nil)...)
 	}
 	return allErrs
 }

--- a/pkg/shared/ruleset/disak8sstig/rules/245543.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245543.go
@@ -42,7 +42,7 @@ type Options245543 struct {
 
 var _ option.Option = (*Options245543)(nil)
 
-func (o Options245543) Validate() field.ErrorList {
+func (o Options245543) Validate(_ *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for _, acceptedToken := range o.AcceptedTokens {
 		if len(acceptedToken.User) == 0 {

--- a/pkg/shared/ruleset/disak8sstig/rules/245543_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245543_test.go
@@ -273,7 +273,7 @@ bar,for,bar,`
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),

--- a/pkg/shared/ruleset/disak8sstig/rules/254800.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/254800.go
@@ -46,7 +46,7 @@ type Options254800 struct {
 
 var _ option.Option = (*Options254800)(nil)
 
-func (o Options254800) Validate() field.ErrorList {
+func (o Options254800) Validate(_ *field.Path) field.ErrorList {
 	if !slices.Contains([]intkubeutils.PodSecurityStandardProfile{intkubeutils.PSSProfileBaseline, intkubeutils.PSSProfilePrivileged, intkubeutils.PSSProfileRestricted}, o.MinPodSecurityStandardsProfile) {
 		return field.ErrorList{field.Invalid(field.NewPath("minPodSecurityStandardsProfile"), o.MinPodSecurityStandardsProfile, "must be one of 'restricted', 'baseline' or 'privileged'")}
 	}

--- a/pkg/shared/ruleset/disak8sstig/rules/254800_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/254800_test.go
@@ -208,7 +208,7 @@ kind: PodSecurityConfiguration`
 				MinPodSecurityStandardsProfile: "baseline",
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(BeNil())
 		})
@@ -217,7 +217,7 @@ kind: PodSecurityConfiguration`
 				MinPodSecurityStandardsProfile: "foo",
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when we start a `diki run` command, the app parses the YAML configuration specified with the `--config` option, and validates the passed `ruleOptions` for the specified ruleset before the actual execution of the checks starts. When a `ruleOption` is not configured properly in the YAML file, an error log specifying the issue is returned.

However, the error logs do not specify the exact path of the errored YAML field.

For example, if we remove [the following line from the Managed Kubernetes example configuration file](https://github.com/gardener/diki/blob/c048128ab0e6e86ece6e79b1c1a19fa7c894d4e0/example/config/managedk8s.yaml#L201), and we run the `Security Hardened Kubernetes` ruleset, we get the following error log:
```
{
  "time": "2025-07-09T16:36:30.256519+03:00",
  "level": "INFO",
  "msg": "rule option 2002 error: [].matchLabels: Required value: must not be empty"
}
```
The YAML error path is not absolute, and for larger files this could lead to ambiguities.

This PR refactors the validation interface of the rule options by adding an additional parameter that specifies the root path (which specifies the provider and ruleset in which the ruleOption is located). The errored fields are then appended to the passed parameter, thereby creating more understandable error messages.

The same error as above looks like this after the refactoring:
```
{
  "time": "2025-07-11T14:01:56.829501+03:00",
  "level": "INFO", 
  "msg": "rule option 2002 error: providers[0].rulesets[1].ruleOptions[2].args.acceptedStorageClasses[0].matchLabels: Required value: must not be empty"
}
```

To provide an example, the rule options of the `Security Hardened Kubernetes` ruleset of the `Managed Kubernetes` provider are refactored to log absolute YAML paths.

**Which issue(s) this PR fixes**:
Part of #322 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
