### PR TITLE
Configure rule options for rules 2000 of the Security Hardened Shoot Cluster ruleset and 242390 of the DISA STIG ruleset

### DIFF
--- a/example/config/garden.yaml
+++ b/example/config/garden.yaml
@@ -37,6 +37,11 @@ providers:       # contains information about known providers
     #     - KubeSystem
     #     - Cluster
     # - ruleID: "2000"
+    #   args:
+    #     allowedEndpoints:
+    #     - path: /readyz
+    #     - path: /healthz
+    # - ruleID: "2001"
     #   skip:
     #     enabled: true
     #     justification: "the whole rule is accepted for ... reasons"

--- a/example/config/garden.yaml
+++ b/example/config/garden.yaml
@@ -38,7 +38,7 @@ providers:       # contains information about known providers
     #     - Cluster
     # - ruleID: "2000"
     #   args:
-    #     allowedEndpoints:
+    #     acceptedEndpoints:
     #     - path: /readyz
     #     - path: /healthz
     # - ruleID: "2001"

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -25,7 +25,7 @@ providers:             # contains information about known providers
     #     justification: "the whole rule is accepted for ... reasons"
     # - ruleID: "242390"
     #   args:
-    #     allowedEndpoints:
+    #     acceptedEndpoints:
     #     - path: /healthz
     #     - path: /livez
     # - ruleID: "242400"

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -23,6 +23,11 @@ providers:             # contains information about known providers
     #   skip:
     #     enabled: true
     #     justification: "the whole rule is accepted for ... reasons"
+    # - ruleID: "242390"
+    #   args:
+    #     allowedEndpoints:
+    #     - path: /healthz
+    #     - path: /livez
     # - ruleID: "242400"
     #   args:
     #     kubeProxyDisabled: true # skip kube-proxy check

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -18,6 +18,11 @@ providers:               # contains information about known providers
     #   skip:
     #     enabled: true
     #     justification: "the whole rule is accepted for ... reasons"
+    # - ruleID: "242390"
+    #   args:
+    #     allowedEndpoints:
+    #     - path: /healthz
+    #     - path: /livez
     - ruleID: "242445"
       args:
         expectedFileOwner:

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -20,7 +20,7 @@ providers:               # contains information about known providers
     #     justification: "the whole rule is accepted for ... reasons"
     # - ruleID: "242390"
     #   args:
-    #     allowedEndpoints:
+    #     acceptedEndpoints:
     #     - path: /healthz
     #     - path: /livez
     - ruleID: "242445"

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -36,26 +36,26 @@ type Rule2000 struct {
 }
 
 type Options2000 struct {
-	AllowedEndpoints []AllowedEndpoint `yaml:"allowedEndpoints" json:"allowedEndpoints"`
+	AcceptedEndpoints []AcceptedEndpoint `yaml:"acceptedEndpoints" json:"acceptedEndpoints"`
 }
 
-type AllowedEndpoint struct {
+type AcceptedEndpoint struct {
 	Path string `yaml:"path" json:"path"`
 }
 
 func (o Options2000) Validate() field.ErrorList {
 	var (
-		allErrs              field.ErrorList
-		allowedEndpointsPath = field.NewPath("allowedEndpoints")
+		allErrs               field.ErrorList
+		acceptedEndpointsPath = field.NewPath("acceptedEndpoints")
 	)
 
-	if len(o.AllowedEndpoints) == 0 {
-		return field.ErrorList{field.Required(allowedEndpointsPath, "must not be empty")}
+	if len(o.AcceptedEndpoints) == 0 {
+		return field.ErrorList{field.Required(acceptedEndpointsPath, "must not be empty")}
 	}
 
-	for i, e := range o.AllowedEndpoints {
+	for i, e := range o.AcceptedEndpoints {
 		if len(e.Path) == 0 {
-			allErrs = append(allErrs, field.Required(allowedEndpointsPath.Index(i).Child("path"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(acceptedEndpointsPath.Index(i).Child("path"), "must not be empty"))
 		}
 	}
 
@@ -128,15 +128,15 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 		var checkResults []rule.CheckResult
 
 		for _, condition := range authenticationConfig.Anonymous.Conditions {
-			if !slices.ContainsFunc(r.Options.AllowedEndpoints, func(allowedPath AllowedEndpoint) bool {
-				return allowedPath.Path == condition.Path
+			if !slices.ContainsFunc(r.Options.AcceptedEndpoints, func(acceptedPath AcceptedEndpoint) bool {
+				return acceptedPath.Path == condition.Path
 			}) {
-				checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Anonymous authentication is not allowed for endpoint %s of the kube-apiserver.", condition.Path), configMapTarget))
+				checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Anonymous authentication is not accepted for endpoint %s of the kube-apiserver.", condition.Path), configMapTarget))
 			}
 		}
 
 		if len(checkResults) == 0 {
-			return rule.Result(r, rule.AcceptedCheckResult("Anonymous authentication is allowed for the specified endpoints of the kube-apiserver.", configMapTarget)), nil
+			return rule.Result(r, rule.AcceptedCheckResult("Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", configMapTarget)), nil
 		}
 		return rule.Result(r, checkResults...), nil
 	default:

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -43,10 +43,10 @@ type AcceptedEndpoint struct {
 	Path string `yaml:"path" json:"path"`
 }
 
-func (o Options2000) Validate() field.ErrorList {
+func (o Options2000) Validate(fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs               field.ErrorList
-		acceptedEndpointsPath = field.NewPath("acceptedEndpoints")
+		acceptedEndpointsPath = fldPath.Child("acceptedEndpoints")
 	)
 
 	if len(o.AcceptedEndpoints) == 0 {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -275,7 +275,7 @@ kind: AuthenticationConfiguration
 			nil,
 			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
-		Entry("should be accepted if the structured authentication's conditions are present in the configured accepted endpoints", func() {
+		Entry("should be accepted when anonymous authentication is enabled for accepted endpoints in options", func() {
 			authenticationConfigMap.Data = map[string]string{
 				fileName: enabledAnonymousAuthenticationConfigWithConditions,
 			}
@@ -311,7 +311,7 @@ kind: AuthenticationConfiguration
 				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap", "details", "endpoint: /readyz")},
 			},
 		),
-		Entry("should fail if the structured authentication's enabled conditions contain an endpoint that is not present in the rule options", func() {
+		Entry("should be failed when anonymous authentication is enabled for not accepted endpoints in options", func() {
 			authenticationConfigMap.Data = map[string]string{
 				fileName: enabledAnonymousAuthenticationConfigWithConditions,
 			}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -379,7 +379,7 @@ kind: AuthenticationConfiguration
 		It("should deny empty accepted endpoints list", func() {
 			options := rules.Options2000{}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -405,7 +405,7 @@ kind: AuthenticationConfiguration
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -53,6 +53,7 @@ anonymous:
   conditions:
   - path: /healthz
   - path: /livez
+  - path: /readyz
 `
 
 		enabledAnonymousAuthenticationConfigWithoutConditions = `apiVersion: apiserver.config.k8s.io/v1beta1
@@ -82,29 +83,33 @@ kind: AuthenticationConfiguration
 				Namespace: shootNamespace,
 			},
 		}
+	})
+
+	// TODO (georgibaltiev): remove any references to the EnableAnonymousAuthentication field after it's removal
+	DescribeTable("Run cases", func(updateFn func(), options *rules.Options2000, expectedCheckResults []rule.CheckResult) {
+		updateFn()
 
 		r = &rules.Rule2000{
 			Client:         fakeClient,
 			ShootName:      shootName,
 			ShootNamespace: shootNamespace,
+			Options:        options,
 		}
-	})
 
-	// TODO (georgibaltiev): remove any references to the EnableAnonymousAuthentication field after it's removal
-	DescribeTable("Run cases", func(updateFn func(), expectedCheckResult rule.CheckResult) {
-		updateFn()
 		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 		res, err := r.Run(ctx)
 		Expect(err).To(BeNil())
-		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: []rule.CheckResult{expectedCheckResult}}))
+		Expect(res).To(Equal(rule.RuleResult{RuleID: ruleID, RuleName: ruleName, Severity: severity, CheckResults: expectedCheckResults}))
 	},
 		Entry("should error when the shoot is not found",
 			func() { shoot.Name = "notFoo" },
-			rule.CheckResult{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Errored, Message: "shoots.core.gardener.cloud \"foo\" not found", Target: rule.NewTarget("kind", "Shoot", "name", "foo", "namespace", "bar")}},
 		),
 		Entry("should pass when kube-apiserver configuration is not set",
 			func() {},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+			nil,
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget()}},
 		),
 		Entry("should pass when the enabledAnoymousAuthentication flag is set to false",
 			func() {
@@ -114,7 +119,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget()},
+			nil,
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget()}},
 		),
 		Entry("should fail when the enabledAnoymousAuthentication flag is set to true",
 			func() {
@@ -124,7 +130,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget()},
+			nil,
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget()}},
 		),
 		Entry("should pass when neither the enableAnonymousAuthentication nor the structuredAuthenticaton flags are set",
 			func() {
@@ -136,7 +143,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget()},
+			nil,
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget()}},
 		),
 		Entry("should error if the structuredAuthentication configMap is not present",
 			func() {
@@ -148,7 +156,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Errored, Message: "configmaps \"authentication-config\" not found", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Errored, Message: "configmaps \"authentication-config\" not found", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 		Entry("should warn if the structured authentication config does not contain a config.yaml key",
 			func() {
@@ -166,7 +175,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Errored, Message: "configMap: authentication-config does not contain field: config.yaml in Data field", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Errored, Message: "configMap: authentication-config does not contain field: config.yaml in Data field", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 		Entry("should error if the structuredAuthentication configMap contains an invalid value",
 			func() {
@@ -184,7 +194,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Errored, Message: "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `foo` into v1beta1.AuthenticationConfiguration", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Errored, Message: "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `foo` into v1beta1.AuthenticationConfiguration", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 		Entry("should pass if the structuredAuthentication configuration does not have anonymous authentication config set",
 			func() {
@@ -202,7 +213,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is not enabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 		Entry("should fail if the structuredAuthentication configuration has anonymous access enabled unconditionally",
 			func() {
@@ -220,7 +232,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 		Entry("should fail if the structured authentication config has anonymous access enabled with conditions",
 			func() {
@@ -238,7 +251,8 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 		Entry("should pass if the structured authentication config has anonymous access disabled",
 			func() {
@@ -256,7 +270,101 @@ kind: AuthenticationConfiguration
 					},
 				}
 			},
-			rule.CheckResult{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			nil,
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
+		),
+		Entry("should be accepted if the structured authentication's conditions are present in the configured allowed endpoints", func() {
+			authenticationConfigMap.Data = map[string]string{
+				fileName: enabledAnonymousAuthenticationConfigWithConditions,
+			}
+			Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+					StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+						ConfigMapName: configMapName,
+					},
+				},
+			}
+		},
+			&rules.Options2000{
+				AllowedEndpoints: []rules.AllowedEndpoint{
+					{
+						Path: "/healthz",
+					},
+					{
+						Path: "/livez",
+					},
+					{
+						Path: "/readyz",
+					},
+					{
+						Path: "/fooz",
+					},
+				},
+			},
+			[]rule.CheckResult{{Status: rule.Accepted, Message: "Anonymous authentication is allowed for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
+		),
+		Entry("should fail if the structured authentication's enabled conditions contain an endpoint that is not present in the rule options", func() {
+			authenticationConfigMap.Data = map[string]string{
+				fileName: enabledAnonymousAuthenticationConfigWithConditions,
+			}
+			Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+					StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+						ConfigMapName: configMapName,
+					},
+				},
+			}
+		},
+			&rules.Options2000{
+				AllowedEndpoints: []rules.AllowedEndpoint{
+					{
+						Path: "/livez",
+					},
+					{
+						Path: "/fooz",
+					},
+					{
+						Path: "/barzmak",
+					},
+					{
+						Path: "/bazz",
+					},
+				},
+			},
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Anonymous authentication is not allowed for endpoint /healthz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+				{Status: rule.Failed, Message: "Anonymous authentication is not allowed for endpoint /readyz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+			},
+		),
+		Entry("should fail if the structured authentication's enabled without conditions and options are still present", func() {
+			authenticationConfigMap.Data = map[string]string{
+				fileName: enabledAnonymousAuthenticationConfigWithoutConditions,
+			}
+			Expect(fakeClient.Create(ctx, authenticationConfigMap)).To(Succeed())
+
+			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+					StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{
+						ConfigMapName: configMapName,
+					},
+				},
+			}
+		},
+			&rules.Options2000{
+				AllowedEndpoints: []rules.AllowedEndpoint{
+					{
+						Path: "/livez",
+					},
+					{
+						Path: "/healthz",
+					},
+				},
+			},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Anonymous authentication is enabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 	)
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -305,7 +305,11 @@ kind: AuthenticationConfiguration
 					},
 				},
 			},
-			[]rule.CheckResult{{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
+			[]rule.CheckResult{
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap", "details", "endpoint: /healthz")},
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap", "details", "endpoint: /livez")},
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap", "details", "endpoint: /readyz")},
+			},
 		),
 		Entry("should fail if the structured authentication's enabled conditions contain an endpoint that is not present in the rule options", func() {
 			authenticationConfigMap.Data = map[string]string{
@@ -338,8 +342,9 @@ kind: AuthenticationConfiguration
 				},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /healthz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
-				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /readyz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+				{Status: rule.Failed, Message: "Anonymous authentication is enabled for specific endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap", "details", "endpoint: /healthz")},
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap", "details", "endpoint: /livez")},
+				{Status: rule.Failed, Message: "Anonymous authentication is enabled for specific endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap", "details", "endpoint: /readyz")},
 			},
 		),
 		Entry("should fail if the structured authentication's enabled without conditions and options are still present", func() {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -275,7 +275,7 @@ kind: AuthenticationConfiguration
 			nil,
 			[]rule.CheckResult{{Status: rule.Passed, Message: "Anonymous authentication is disabled for the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
-		Entry("should be accepted if the structured authentication's conditions are present in the configured allowed endpoints", func() {
+		Entry("should be accepted if the structured authentication's conditions are present in the configured accepted endpoints", func() {
 			authenticationConfigMap.Data = map[string]string{
 				fileName: enabledAnonymousAuthenticationConfigWithConditions,
 			}
@@ -290,7 +290,7 @@ kind: AuthenticationConfiguration
 			}
 		},
 			&rules.Options2000{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/healthz",
 					},
@@ -305,7 +305,7 @@ kind: AuthenticationConfiguration
 					},
 				},
 			},
-			[]rule.CheckResult{{Status: rule.Accepted, Message: "Anonymous authentication is allowed for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
+			[]rule.CheckResult{{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")}},
 		),
 		Entry("should fail if the structured authentication's enabled conditions contain an endpoint that is not present in the rule options", func() {
 			authenticationConfigMap.Data = map[string]string{
@@ -322,7 +322,7 @@ kind: AuthenticationConfiguration
 			}
 		},
 			&rules.Options2000{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/livez",
 					},
@@ -338,8 +338,8 @@ kind: AuthenticationConfiguration
 				},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Anonymous authentication is not allowed for endpoint /healthz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
-				{Status: rule.Failed, Message: "Anonymous authentication is not allowed for endpoint /readyz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /healthz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
+				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /readyz of the kube-apiserver.", Target: rule.NewTarget("name", "authentication-config", "namespace", "bar", "kind", "ConfigMap")},
 			},
 		),
 		Entry("should fail if the structured authentication's enabled without conditions and options are still present", func() {
@@ -357,7 +357,7 @@ kind: AuthenticationConfiguration
 			}
 		},
 			&rules.Options2000{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/livez",
 					},
@@ -371,7 +371,7 @@ kind: AuthenticationConfiguration
 	)
 
 	Describe("#ValidateOptions2000", func() {
-		It("should deny empty allowed endpoints list", func() {
+		It("should deny empty accepted endpoints list", func() {
 			options := rules.Options2000{}
 
 			result := options.Validate()
@@ -379,7 +379,7 @@ kind: AuthenticationConfiguration
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("allowedEndpoints"),
+					"Field":  Equal("acceptedEndpoints"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))
@@ -387,7 +387,7 @@ kind: AuthenticationConfiguration
 
 		It("should correctly validate options", func() {
 			options := rules.Options2000{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/healthz",
 					},
@@ -405,7 +405,7 @@ kind: AuthenticationConfiguration
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("allowedEndpoints[1].path"),
+					"Field":  Equal("acceptedEndpoints[1].path"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
@@ -9,5 +9,6 @@ type RuleOption interface {
 		Options1001 |
 		Options1002 |
 		Options1003 |
+		Options2000 |
 		Options2007
 }

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -29,6 +29,10 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 	if err != nil {
 		return fmt.Errorf("rule option 1000 error: %s", err.Error())
 	}
+	opts2000, err := getV02OptionOrNil[rules.Options2000](ruleOptions["2000"].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 2000 error: %s", err.Error())
+	}
 	opts2007, err := getV01OptionOrNil[rules.Options2007](ruleOptions["2007"].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 2007 error: %s", err.Error())
@@ -45,6 +49,7 @@ func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConf
 			Client:         c,
 			ShootName:      r.args.ShootName,
 			ShootNamespace: r.args.ProjectNamespace,
+			Options:        opts2000,
 		},
 		&rules.Rule2001{
 			Client:         c,

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -41,6 +41,10 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 	if err != nil {
 		return fmt.Errorf("rule option 1003 error: %s", err.Error())
 	}
+	opts2000, err := getV02OptionOrNil[rules.Options2000](ruleOptions["2000"].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 2000 error: %s", err.Error())
+	}
 	opts2007, err := getV02OptionOrNil[rules.Options2007](ruleOptions["2007"].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 2007 error: %s", err.Error())
@@ -75,6 +79,7 @@ func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConf
 			Client:         c,
 			ShootName:      r.args.ShootName,
 			ShootNamespace: r.args.ProjectNamespace,
+			Options:        opts2000,
 		},
 		&rules.Rule2001{
 			Client:         c,

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
@@ -10,7 +10,8 @@ import (
 )
 
 type RuleOption interface {
-	option.Options242414 |
+	sharedrules.Options242390 |
+		option.Options242414 |
 		option.Options242415 |
 		Options242451 |
 		sharedrules.Options245543 |

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
@@ -78,7 +78,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 
 	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
 	if err != nil {
-		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+		return fmt.Errorf("rule option 242390 error: %s", err.Error())
 	}
 	opts242400, err := getV2R2OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
@@ -76,6 +76,10 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
+	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+	}
 	opts242400, err := getV2R2OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242400 error: %s", err.Error())
@@ -168,7 +172,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		},
 		&sharedrules.Rule242388{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242389{Client: seedClient, Namespace: r.shootNamespace},
-		&sharedrules.Rule242390{Client: seedClient, Namespace: r.shootNamespace},
+		&sharedrules.Rule242390{Client: seedClient, Namespace: r.shootNamespace, Options: opts242390},
 		&sharedrules.Rule242391{
 			Client:       shootClient,
 			V1RESTClient: shootClientSet.CoreV1().RESTClient(),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
@@ -76,6 +76,10 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
+	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+	}
 	opts242400, err := getV2R3OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242400 error: %s", err.Error())
@@ -168,7 +172,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		},
 		&sharedrules.Rule242388{Client: seedClient, Namespace: r.shootNamespace},
 		&sharedrules.Rule242389{Client: seedClient, Namespace: r.shootNamespace},
-		&sharedrules.Rule242390{Client: seedClient, Namespace: r.shootNamespace},
+		&sharedrules.Rule242390{Client: seedClient, Namespace: r.shootNamespace, Options: opts242390},
 		&sharedrules.Rule242391{
 			Client:       shootClient,
 			V1RESTClient: shootClientSet.CoreV1().RESTClient(),

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
@@ -78,7 +78,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 
 	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
 	if err != nil {
-		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+		return fmt.Errorf("rule option 242390 error: %s", err.Error())
 	}
 	opts242400, err := getV2R3OptionOrNil[option.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/options.go
@@ -10,5 +10,5 @@ import (
 )
 
 type RuleOption interface {
-	sharedrules.Options245543 | sharedrules.Options254800 | option.FileOwnerOptions
+	sharedrules.Options242390 | sharedrules.Options245543 | sharedrules.Options254800 | option.FileOwnerOptions
 }

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
@@ -33,7 +33,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 	}
 	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
 	if err != nil {
-		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+		return fmt.Errorf("rule option 242390 error: %s", err.Error())
 	}
 	opts242445, err := getV2R2OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
 	if err != nil {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r2_ruleset.go
@@ -31,6 +31,10 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return err
 	}
+	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+	}
 	opts242445, err := getV2R2OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242445 error: %s", err.Error())
@@ -163,6 +167,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 			Namespace:      ns,
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
+			Options:        opts242390,
 		},
 		rule.NewSkipRule(
 			sharedrules.ID242391,

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
@@ -33,7 +33,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 	}
 	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
 	if err != nil {
-		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+		return fmt.Errorf("rule option 242390 error: %s", err.Error())
 	}
 	opts242445, err := getV2R3OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
 	if err != nil {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r3_ruleset.go
@@ -31,6 +31,10 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return err
 	}
+	opts242390, err := getV2R2OptionOrNil[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args)
+	if err != nil {
+		return fmt.Errorf("rule option 242445 error: %s", err.Error())
+	}
 	opts242445, err := getV2R3OptionOrNil[option.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242445 error: %s", err.Error())
@@ -163,6 +167,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 			Namespace:      ns,
 			DeploymentName: apiserverDeploymentName,
 			ContainerName:  apiserverContainerName,
+			Options:        opts242390,
 		},
 		rule.NewSkipRule(
 			sharedrules.ID242391,

--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -36,26 +36,26 @@ type Rule242390 struct {
 }
 
 type Options242390 struct {
-	AllowedEndpoints []AllowedEndpoint `yaml:"allowedEndpoints" json:"allowedEndpoints"`
+	AcceptedEndpoints []AcceptedEndpoint `yaml:"acceptedEndpoints" json:"acceptedEndpoints"`
 }
 
-type AllowedEndpoint struct {
+type AcceptedEndpoint struct {
 	Path string `yaml:"path" json:"path"`
 }
 
 func (o Options242390) Validate() field.ErrorList {
 	var (
-		allErrs              field.ErrorList
-		allowedEndpointsPath = field.NewPath("allowedEndpoints")
+		allErrs               field.ErrorList
+		acceptedEndpointsPath = field.NewPath("acceptedEndpoints")
 	)
 
-	if len(o.AllowedEndpoints) == 0 {
-		return field.ErrorList{field.Required(allowedEndpointsPath, "must not be empty")}
+	if len(o.AcceptedEndpoints) == 0 {
+		return field.ErrorList{field.Required(acceptedEndpointsPath, "must not be empty")}
 	}
 
-	for i, e := range o.AllowedEndpoints {
+	for i, e := range o.AcceptedEndpoints {
 		if len(e.Path) == 0 {
-			allErrs = append(allErrs, field.Required(allowedEndpointsPath.Index(i).Child("path"), "must not be empty"))
+			allErrs = append(allErrs, field.Required(acceptedEndpointsPath.Index(i).Child("path"), "must not be empty"))
 		}
 	}
 
@@ -102,9 +102,9 @@ func (r *Rule242390) Run(ctx context.Context) (rule.RuleResult, error) {
 		case len(optSlice) > 1:
 			return rule.Result(r, rule.WarningCheckResult(fmt.Sprintf("Option %s has been set more than once in container command.", anonymousAuthOption), target)), nil
 		case optSlice[0] == "true":
-			return rule.Result(r, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not allowed value.", anonymousAuthOption), target)), nil
+			return rule.Result(r, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not accepted value.", anonymousAuthOption), target)), nil
 		case optSlice[0] == "false":
-			return rule.Result(r, rule.PassedCheckResult(fmt.Sprintf("Option %s set to allowed value.", anonymousAuthOption), target)), nil
+			return rule.Result(r, rule.PassedCheckResult(fmt.Sprintf("Option %s set to accepted value.", anonymousAuthOption), target)), nil
 		default:
 			return rule.Result(r, rule.WarningCheckResult(fmt.Sprintf("Option %s set to neither 'true' nor 'false'.", anonymousAuthOption), target)), nil
 		}
@@ -156,15 +156,15 @@ func (r *Rule242390) Run(ctx context.Context) (rule.RuleResult, error) {
 		var checkResults []rule.CheckResult
 
 		for _, condition := range authConfig.Anonymous.Conditions {
-			if !slices.ContainsFunc(r.Options.AllowedEndpoints, func(allowedPath AllowedEndpoint) bool {
-				return allowedPath.Path == condition.Path
+			if !slices.ContainsFunc(r.Options.AcceptedEndpoints, func(acceptedPath AcceptedEndpoint) bool {
+				return acceptedPath.Path == condition.Path
 			}) {
-				checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Anonymous authentication is not allowed for endpoint %s of the kube-apiserver.", condition.Path), target))
+				checkResults = append(checkResults, rule.FailedCheckResult(fmt.Sprintf("Anonymous authentication is not accepted for endpoint %s of the kube-apiserver.", condition.Path), target))
 			}
 		}
 
 		if len(checkResults) == 0 {
-			return rule.Result(r, rule.AcceptedCheckResult("The authentication configuration is allowed to have anonymous authentication enabled.", target)), nil
+			return rule.Result(r, rule.AcceptedCheckResult("The authentication configuration is accepted to have anonymous authentication enabled.", target)), nil
 		}
 
 		return rule.Result(r, checkResults...), nil

--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -43,10 +43,10 @@ type AcceptedEndpoint struct {
 	Path string `yaml:"path" json:"path"`
 }
 
-func (o Options242390) Validate() field.ErrorList {
+func (o Options242390) Validate(fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs               field.ErrorList
-		acceptedEndpointsPath = field.NewPath("acceptedEndpoints")
+		acceptedEndpointsPath = fldPath.Child("acceptedEndpoints")
 	)
 
 	if len(o.AcceptedEndpoints) == 0 {

--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -102,9 +102,9 @@ func (r *Rule242390) Run(ctx context.Context) (rule.RuleResult, error) {
 		case len(optSlice) > 1:
 			return rule.Result(r, rule.WarningCheckResult(fmt.Sprintf("Option %s has been set more than once in container command.", anonymousAuthOption), target)), nil
 		case optSlice[0] == "true":
-			return rule.Result(r, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not accepted value.", anonymousAuthOption), target)), nil
+			return rule.Result(r, rule.FailedCheckResult(fmt.Sprintf("Option %s set to not allowed value.", anonymousAuthOption), target)), nil
 		case optSlice[0] == "false":
-			return rule.Result(r, rule.PassedCheckResult(fmt.Sprintf("Option %s set to accepted value.", anonymousAuthOption), target)), nil
+			return rule.Result(r, rule.PassedCheckResult(fmt.Sprintf("Option %s set to allowed value.", anonymousAuthOption), target)), nil
 		default:
 			return rule.Result(r, rule.WarningCheckResult(fmt.Sprintf("Option %s set to neither 'true' nor 'false'.", anonymousAuthOption), target)), nil
 		}
@@ -148,7 +148,6 @@ func (r *Rule242390) Run(ctx context.Context) (rule.RuleResult, error) {
 	case authConfig.Anonymous == nil:
 		return rule.Result(r, rule.FailedCheckResult("The authentication configuration does not explicitly disable anonymous authentication.", target)), nil
 	case authConfig.Anonymous != nil && authConfig.Anonymous.Enabled:
-
 		if r.Options == nil || len(authConfig.Anonymous.Conditions) == 0 {
 			return rule.Result(r, rule.FailedCheckResult("The authentication configuration has anonymous authentication enabled.", target)), nil
 		}

--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -12,16 +12,19 @@ import (
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
 var (
 	_ rule.Rule     = &Rule242390{}
 	_ rule.Severity = &Rule242390{}
+	_ option.Option = &Options242390{}
 )
 
 type Rule242390 struct {
@@ -38,6 +41,25 @@ type Options242390 struct {
 
 type AllowedEndpoint struct {
 	Path string `yaml:"path" json:"path"`
+}
+
+func (o Options242390) Validate() field.ErrorList {
+	var (
+		allErrs              field.ErrorList
+		allowedEndpointsPath = field.NewPath("allowedEndpoints")
+	)
+
+	if len(o.AllowedEndpoints) == 0 {
+		return field.ErrorList{field.Required(allowedEndpointsPath, "must not be empty")}
+	}
+
+	for i, e := range o.AllowedEndpoints {
+		if len(e.Path) == 0 {
+			allErrs = append(allErrs, field.Required(allowedEndpointsPath.Index(i).Child("path"), "must not be empty"))
+		}
+	}
+
+	return allErrs
 }
 
 func (r *Rule242390) ID() string {

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -363,7 +363,11 @@ anonymous:
 					},
 				},
 			},
-			[]rule.CheckResult{{Status: rule.Accepted, Message: "The authentication configuration is accepted to have anonymous authentication enabled.", Target: target}},
+			[]rule.CheckResult{
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /healthz")},
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /livez")},
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /readyz")},
+			},
 			BeNil()),
 		Entry("should fail if an enabled condition endpoint is not configured in the rule options.",
 			corev1.Container{
@@ -413,8 +417,9 @@ anonymous:
 				},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /livez of the kube-apiserver.", Target: target},
-				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /readyz of the kube-apiserver.", Target: target},
+				{Status: rule.Accepted, Message: "Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /healthz")},
+				{Status: rule.Failed, Message: "Anonymous authentication is enabled for specific endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /livez")},
+				{Status: rule.Failed, Message: "Anonymous authentication is enabled for specific endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /readyz")},
 			},
 			BeNil()),
 		Entry("should fail if anonymous authentication is enabled unconditionally and options are configured",

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -105,9 +105,9 @@ anonymous:
 
 			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 		},
-		Entry("should pass when anonymous-auth is set to accepted value false",
+		Entry("should pass when anonymous-auth is set to allowed value false",
 			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=false"}},
-			[]rule.CheckResult{{Status: rule.Passed, Message: "Option anonymous-auth set to accepted value.", Target: target}},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Option anonymous-auth set to allowed value.", Target: target}},
 			BeNil()),
 		Entry("should warn when anonymous-auth is set more than once",
 			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=false"}, Args: []string{"--anonymous-auth=true"}},
@@ -117,9 +117,9 @@ anonymous:
 			corev1.Container{Name: "not-kube-apiserver", Command: []string{"--anonymous-auth=false"}},
 			[]rule.CheckResult{{Status: rule.Errored, Message: "deployment: kube-apiserver does not contain container: kube-apiserver", Target: target}},
 			BeNil()),
-		Entry("should fail when anonymous-auth is set to not accepted value true",
+		Entry("should fail when anonymous-auth is set to not allowed value true",
 			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=true"}},
-			[]rule.CheckResult{{Status: rule.Failed, Message: "Option anonymous-auth set to not accepted value.", Target: target}},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Option anonymous-auth set to not allowed value.", Target: target}},
 			BeNil()),
 	)
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -477,7 +477,7 @@ anonymous:
 		It("should deny empty accepted endpoints list", func() {
 			options := rules.Options242390{}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -503,7 +503,7 @@ anonymous:
 				},
 			}
 
-			result := options.Validate()
+			result := options.Validate(nil)
 
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -105,9 +105,9 @@ anonymous:
 
 			Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 		},
-		Entry("should pass when anonymous-auth is set to allowed value false",
+		Entry("should pass when anonymous-auth is set to accepted value false",
 			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=false"}},
-			[]rule.CheckResult{{Status: rule.Passed, Message: "Option anonymous-auth set to allowed value.", Target: target}},
+			[]rule.CheckResult{{Status: rule.Passed, Message: "Option anonymous-auth set to accepted value.", Target: target}},
 			BeNil()),
 		Entry("should warn when anonymous-auth is set more than once",
 			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=false"}, Args: []string{"--anonymous-auth=true"}},
@@ -117,9 +117,9 @@ anonymous:
 			corev1.Container{Name: "not-kube-apiserver", Command: []string{"--anonymous-auth=false"}},
 			[]rule.CheckResult{{Status: rule.Errored, Message: "deployment: kube-apiserver does not contain container: kube-apiserver", Target: target}},
 			BeNil()),
-		Entry("should fail when anonymous-auth is set to not allowed value true",
+		Entry("should fail when anonymous-auth is set to not accepted value true",
 			corev1.Container{Name: "kube-apiserver", Command: []string{"--anonymous-auth=true"}},
-			[]rule.CheckResult{{Status: rule.Failed, Message: "Option anonymous-auth set to not allowed value.", Target: target}},
+			[]rule.CheckResult{{Status: rule.Failed, Message: "Option anonymous-auth set to not accepted value.", Target: target}},
 			BeNil()),
 	)
 
@@ -348,7 +348,7 @@ anonymous:
 				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
 			},
 			&rules.Options242390{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/healthz",
 					},
@@ -363,7 +363,7 @@ anonymous:
 					},
 				},
 			},
-			[]rule.CheckResult{{Status: rule.Accepted, Message: "The authentication configuration is allowed to have anonymous authentication enabled.", Target: target}},
+			[]rule.CheckResult{{Status: rule.Accepted, Message: "The authentication configuration is accepted to have anonymous authentication enabled.", Target: target}},
 			BeNil()),
 		Entry("should fail if an enabled condition endpoint is not configured in the rule options.",
 			corev1.Container{
@@ -400,7 +400,7 @@ anonymous:
 				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
 			},
 			&rules.Options242390{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/healthz",
 					},
@@ -413,8 +413,8 @@ anonymous:
 				},
 			},
 			[]rule.CheckResult{
-				{Status: rule.Failed, Message: "Anonymous authentication is not allowed for endpoint /livez of the kube-apiserver.", Target: target},
-				{Status: rule.Failed, Message: "Anonymous authentication is not allowed for endpoint /readyz of the kube-apiserver.", Target: target},
+				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /livez of the kube-apiserver.", Target: target},
+				{Status: rule.Failed, Message: "Anonymous authentication is not accepted for endpoint /readyz of the kube-apiserver.", Target: target},
 			},
 			BeNil()),
 		Entry("should fail if anonymous authentication is enabled unconditionally and options are configured",
@@ -452,7 +452,7 @@ anonymous:
 				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
 			},
 			&rules.Options242390{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/healthz",
 					},
@@ -469,7 +469,7 @@ anonymous:
 	)
 
 	Describe("#ValidateOptions242390", func() {
-		It("should deny empty allowed endpoints list", func() {
+		It("should deny empty accepted endpoints list", func() {
 			options := rules.Options242390{}
 
 			result := options.Validate()
@@ -477,7 +477,7 @@ anonymous:
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("allowedEndpoints"),
+					"Field":  Equal("acceptedEndpoints"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))
@@ -485,7 +485,7 @@ anonymous:
 
 		It("should correctly validate options", func() {
 			options := rules.Options242390{
-				AllowedEndpoints: []rules.AllowedEndpoint{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
 					{
 						Path: "/healthz",
 					},
@@ -503,7 +503,7 @@ anonymous:
 			Expect(result).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("allowedEndpoints[1].path"),
+					"Field":  Equal("acceptedEndpoints[1].path"),
 					"Detail": Equal("must not be empty"),
 				})),
 			))


### PR DESCRIPTION
**What this PR does / why we need it**:

Diki supports two rules that check for enabled anonymous authentication to the `kube-apiserver`:

- Rule 242390 of the `DISA STIG` ruleset
- Rule 2000 of the `Security Hardened Shoot Cluster` ruleset

Currently, these rules check the `kube-apiserver`'s `AuthenticationConfiguration`. If the the `.anonymous.enabled` field is set to true, Diki returns a `Failed` checkResult, regardless of whether condition endpoints are present in the configuration. In order to perform more precise checks, `ruleOptions` should be introduced to allow anonymous authentication to specific endpoints.

For both rules, this PR configures `ruleOptions`, which represent a list of allowed endpoints. If the `kube-apiserver`'s `AuthenticationConfiguration` contains a subset of the allowed endpoints, Diki returns an `Accepted` check result. 
All other endpoints, which are not present in the `ruleOptions` will be returned as `Failed` checkResults.

Users can add `ruleOptions` in their configuration files via the following way:
```yaml
ruleOptions:
 - ruleID: ("242390"|"2000")
   args:
     acceptedEndpoints:
     - path: /healthz
     - path: /livez
```

**Which issue(s) this PR fixes**:
Fixes #541 

**Special notes for your reviewer**:
The `Managed Kubernetes`-specific implementation of DISA rule 242390 does not have options configured, since the rule is not able to perform any checks on the `AuthenticationConfguration` resource. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Rules 242390 of the DISA STIG ruleset and 2000 of the Security Hardened Shoot Cluster ruleset now support options to exempt specific endpoints from disabling their anonymous authentication.
```
