### PR TITLE
Add exception to gardener services for example config

### DIFF
--- a/example/guides/security-hardened-k8s-shoot.yaml
+++ b/example/guides/security-hardened-k8s-shoot.yaml
@@ -38,6 +38,14 @@ providers:
           justification: "Gardener managed resources are accepted to use a wider range of volume types."
           volumeNames:
           - "*"
+    - ruleID: "2004"
+      args:
+        acceptedServices:
+        - matchLabels:
+            resources.gardener.cloud/managed-by: gardener
+          namespaceMatchLabels:
+            resources.gardener.cloud/managed-by: gardener
+          justification: "Gardener managed services are accepted to of type NodePort."
     - ruleID: "2006"
       args:
         acceptedRoles:


### PR DESCRIPTION
**What this PR does / why we need it**:
There are cases were Gardener uses `NodePort` services. e.g. [dual-stack gcp](https://github.com/gardener/gardener-extension-provider-gcp/blob/e969b5dac2825997b5236276f10683cdd81bfcec/charts/internal/shoot-system-components/charts/default-http-backend/templates/default-http-backend.yaml#L47-L66)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
