### PR TITLE
Refactor `unknown provider|ruleset|ruleset version` error messages to refer the user to the diki show command

### DIFF
--- a/pkg/provider/builder/garden.go
+++ b/pkg/provider/builder/garden.go
@@ -43,7 +43,7 @@ func GardenProviderFromConfig(conf config.ProviderConfig, fldPath *field.Path) (
 			setLoggerHardened(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider garden` to see all supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/garden.go
+++ b/pkg/provider/builder/garden.go
@@ -43,7 +43,7 @@ func GardenProviderFromConfig(conf config.ProviderConfig, fldPath *field.Path) (
 			setLoggerHardened(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s - use 'diki show provider garden' to see all supported rulesets", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use 'diki show provider garden' to see the provider's supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/garden.go
+++ b/pkg/provider/builder/garden.go
@@ -43,7 +43,7 @@ func GardenProviderFromConfig(conf config.ProviderConfig, fldPath *field.Path) (
 			setLoggerHardened(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider garden` to see all supported rulesets", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use 'diki show provider garden' to see all supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/gardener.go
+++ b/pkg/provider/builder/gardener.go
@@ -45,7 +45,7 @@ func GardenerProviderFromConfig(conf config.ProviderConfig, fldPath *field.Path)
 			setLoggerDISA(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider gardener` to see the provider's supported rulesets", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use 'diki show provider gardener' to see the provider's supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/gardener.go
+++ b/pkg/provider/builder/gardener.go
@@ -45,7 +45,7 @@ func GardenerProviderFromConfig(conf config.ProviderConfig, fldPath *field.Path)
 			setLoggerDISA(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider gardener` to see the provider's supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -52,7 +52,7 @@ func ManagedK8SProviderFromConfig(conf config.ProviderConfig, fldPath *field.Pat
 			setLoggerHardened(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider managedk8s` to see the provider's supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -52,7 +52,7 @@ func ManagedK8SProviderFromConfig(conf config.ProviderConfig, fldPath *field.Pat
 			setLoggerHardened(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider managedk8s` to see the provider's supported rulesets", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use 'diki show provider managedk8s' to see the provider's supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -43,7 +43,7 @@ func VirtualGardenProviderFromConfig(conf config.ProviderConfig, fldPath *field.
 			setLoggerDISA(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider virtualgarden` to see the provider's supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -43,7 +43,7 @@ func VirtualGardenProviderFromConfig(conf config.ProviderConfig, fldPath *field.
 			setLoggerDISA(ruleset)
 			rulesets = append(rulesets, ruleset)
 		default:
-			return nil, fmt.Errorf("unknown ruleset identifier: %s - use `diki show provider virtualgarden` to see the provider's supported rulesets", rulesetConfig.ID)
+			return nil, fmt.Errorf("unknown ruleset identifier: %s - use 'diki show provider virtualgarden' to see the provider's supported rulesets", rulesetConfig.ID)
 		}
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -143,7 +143,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider garden` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -143,7 +143,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider garden` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider garden' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -143,7 +143,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider gardener` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider gardener' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -143,7 +143,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider gardener` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -138,7 +138,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider managedk8s` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider managedk8s' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -138,7 +138,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider managedk8s` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
@@ -103,7 +103,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider managedk8s` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider managedk8s' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
@@ -103,7 +103,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider managedk8s` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -138,7 +138,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider virtualgarden` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -138,7 +138,7 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use `diki show provider virtualgarden` to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider virtualgarden' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
 	}
 
 	return ruleset, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a reference to the `diki show` command in the cases when an error is returned due to an incorrectly composed configuration file.

**Which issue(s) this PR fixes**:
Fixes #361 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Diki now refers to the `diki show` command when an error caused by a file misconfiguration occurs.
```
