### PR TITLE
Use ubuntu-latest for all diki builds (#569)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,13 +34,13 @@ jobs:
             runner: ubuntu-latest
           - os: linux
             arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest
           - os: darwin
             arch: amd64
             runner: ubuntu-latest
           - os: darwin
             arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest
           - os: windows
             arch: amd64
             runner: ubuntu-latest


### PR DESCRIPTION
(cherry picked from commit fb54189957b7ea8e184d8ff8cbddc56b4e5d8b88)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user bugfix
Reverted to using `ubuntu-latest` for all diki executables builds in workflows, since the linux-arm64 binary was broken with the new `ubuntu-24.04-arm` runner.
```
