### PR TITLE
Disable CGO on diki build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,13 +34,13 @@ jobs:
             runner: ubuntu-latest
           - os: linux
             arch: arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
           - os: darwin
             arch: amd64
             runner: ubuntu-latest
           - os: darwin
             arch: arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
           - os: windows
             arch: amd64
             runner: ubuntu-latest
@@ -64,6 +64,7 @@ jobs:
           arch=${{ matrix.args.arch }}
           extension=${{ matrix.args.os == 'windows' && '.exe' || '' }}
 
+          CGO_ENABLED=0 \
           GOOS=${{ matrix.args.os }} \
           GOARCH=${{ matrix.args.arch }} \
           GO111MODULE=on \


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use `ubuntu-24.04-arm` runner for diki executables builds in workflows.
```
```bugfix operator
Disable CGO for diki executables builds in workflows. This was causing the diki binaries to error in containers using alpine images.
```
