### PR TITLE
[DISA K8s STIG] List endpoints when options are missing for rule 242390

### DIFF
--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -148,7 +148,7 @@ func (r *Rule242390) Run(ctx context.Context) (rule.RuleResult, error) {
 	case authConfig.Anonymous == nil:
 		return rule.Result(r, rule.FailedCheckResult("The authentication configuration does not explicitly disable anonymous authentication.", target)), nil
 	case authConfig.Anonymous != nil && authConfig.Anonymous.Enabled:
-		if r.Options == nil || len(authConfig.Anonymous.Conditions) == 0 {
+		if len(authConfig.Anonymous.Conditions) == 0 {
 			return rule.Result(r, rule.FailedCheckResult("The authentication configuration has anonymous authentication enabled.", target)), nil
 		}
 
@@ -156,7 +156,7 @@ func (r *Rule242390) Run(ctx context.Context) (rule.RuleResult, error) {
 
 		for _, condition := range authConfig.Anonymous.Conditions {
 			endpointTarget := target.With("details", fmt.Sprintf("endpoint: %s", condition.Path))
-			if slices.ContainsFunc(r.Options.AcceptedEndpoints, func(acceptedPath AcceptedEndpoint) bool {
+			if r.Options != nil && slices.ContainsFunc(r.Options.AcceptedEndpoints, func(acceptedPath AcceptedEndpoint) bool {
 				return acceptedPath.Path == condition.Path
 			}) {
 				checkResults = append(checkResults, rule.AcceptedCheckResult("Anonymous authentication is accepted for the specified endpoints of the kube-apiserver.", endpointTarget))

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -231,7 +231,7 @@ anonymous:
 						Namespace: namespace,
 					},
 					Data: map[string]string{
-						"/etc/foo/bar": enabledAnonymousAuthenticationConfigWithConditions,
+						"/etc/foo/bar": enabledAnonymousAuthenticationConfigWithoutConditions,
 					},
 				}
 				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
@@ -268,13 +268,17 @@ anonymous:
 						Namespace: namespace,
 					},
 					Data: map[string]string{
-						"/etc/foo/bar": enabledAnonymousAuthenticationConfigWithoutConditions,
+						"/etc/foo/bar": enabledAnonymousAuthenticationConfigWithConditions,
 					},
 				}
 				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
 			},
 			nil,
-			[]rule.CheckResult{{Status: rule.Failed, Message: "The authentication configuration has anonymous authentication enabled.", Target: target}},
+			[]rule.CheckResult{
+				{Status: rule.Failed, Message: "Anonymous authentication is enabled for specific endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /healthz")},
+				{Status: rule.Failed, Message: "Anonymous authentication is enabled for specific endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /livez")},
+				{Status: rule.Failed, Message: "Anonymous authentication is enabled for specific endpoints of the kube-apiserver.", Target: target.With("details", "endpoint: /readyz")},
+			},
 			BeNil()),
 		Entry("should pass if the authentication configuration has anonymous authentication disabled.",
 			corev1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:
Improved rule 242390 from DISA K8s STIG to always return endpoints with anonymous authentication enabled in check results.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing Rule 242390 from DISA K8s STIG to not return endpoints with anonymous authentication enabled in check results when options for the rule were not configured has been fixed.
```
