### PR TITLE
Refactor object selectors to use `NamespacedObject` selector

### DIFF
--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -34,27 +34,33 @@ providers:             # contains information about known providers
     - ruleID: "242414"
       args:
         acceptedPods:
-        - podMatchLabels:
-            k8s-app: node-local-dns
-          namespaceMatchLabels:
-            kubernetes.io/metadata.name: kube-system
+        - labelSelector:
+            matchLabels:
+              k8s-app: node-local-dns
+          namespaceLabelSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           justification: "Node local dns requires port 53 in order to operate properly."
           ports:
           - 53
-        - podMatchLabels:
-            app: node-problem-detector
-          namespaceMatchLabels:
-            kubernetes.io/metadata.name: kube-system
+        - labelSelector:
+            matchLabels:
+              app: node-problem-detector
+          namespaceLabelSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           ports:
           - 1011
           - 1012
     # - ruleID: "242415"
     #   args:
     #     acceptedPods:
-    #     - podMatchLabels:
-    #         label: foo
-    #       namespaceMatchLabels:
-    #         label: foo
+    #     - labelSelector:
+    #         matchLabels:
+    #           label: foo
+    #       namespaceLabelSelector:
+    #         matchLabels:
+    #           label: foo
     #       justification: "justification"
     #       environmentVariables:
     #       - FOO_BAR

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -24,12 +24,14 @@ providers:                   # contains information about known providers
     #     - apiVersion: "v1"
     #       # if set to "*" match all kinds
     #       kind: "Pod"
-    #       matchLabels:
-    #         foo: bar
+    #       labelSelector:
+    #         matchLabels:
+    #           foo: bar
     #       # only pods in namespaces ["default", "kube-public", "kube-node-lease"] are meaningful to be selected with namespaceMatchLabels
     #       # since the rule does not perform checks on objects in namespaces different from the listed above
-    #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: default
+    #       namespaceLabelSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: default
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted
@@ -79,32 +81,38 @@ providers:                   # contains information about known providers
     # - ruleID: "242414"
     #   args:
     #     acceptedPods:
-    #     - podMatchLabels:
-    #         label: foo
-    #       namespaceMatchLabels:
-    #         label: foo
+    #     - labelSelector:
+    #         matchLabels:
+    #           label: foo
+    #       namespaceLabelSelector:
+    #         matchLabels:
+    #           label: foo
     #       justification: "justification"
     #       ports:
     #       - 53
     # - ruleID: "242415"
     #   args:
     #     acceptedPods:
-    #     - podMatchLabels:
-    #         label: foo
-    #       namespaceMatchLabels:
-    #         label: foo
+    #     - labelSelector:
+    #         matchLabels:
+    #           label: foo
+    #       namespaceLabelSelector:
+    #         matchLabels:
+    #           label: foo
     #       justification: "justification"
     #       environmentVariables:
     #       - FOO_BAR
     # - ruleID: "242417"
     #   args:
     #     acceptedPods:
-    #     - podMatchLabels:
-    #         foo: bar
+    #     - labelSelector:
+    #         matchLabels:
+    #           foo: bar
     #       # only pods in namespaces ["kube-system", "kube-public", "kube-node-lease"] are meaningful to be selected with namespaceMatchLabels
     #       # since the rule does not perform checks on objects in namespaces different from the listed above
-    #       namespaceMatchLabels:
-    #         kubernetes.io/metadata.name: kube-system
+    #       namespaceLabelSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: kube-system
     #       justification: "justification"
     #       # relates to the result status in the report
     #       # can be set to Passed or Accepted. Defaults to Accepted

--- a/example/guides/disa-k8s-stig-shoot.yaml
+++ b/example/guides/disa-k8s-stig-shoot.yaml
@@ -45,20 +45,24 @@ providers:
     - ruleID: "242414"
       args:
         acceptedPods:
-        - podMatchLabels:
-            k8s-app: node-local-dns
-          namespaceMatchLabels:
-            kubernetes.io/metadata.name: kube-system
+        - labelSelector:
+            matchLabels:
+              k8s-app: node-local-dns
+          namespaceLabelSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           justification: "Node local dns requires port 53 in order to operate properly."
           ports:
           - 53
     - ruleID: "242417"
       args:
         acceptedPods:
-        - podMatchLabels:
-            resources.gardener.cloud/managed-by: gardener
-          namespaceMatchLabels:
-            kubernetes.io/metadata.name: kube-system
+        - labelSelector:
+            matchLabels:
+              resources.gardener.cloud/managed-by: gardener
+          namespaceLabelSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           justification: "Pods managed by Gardener are not considered as user pods."
     - ruleID: "242449"
       args:

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -16,14 +16,15 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
 var _ = Describe("#242414", func() {
 	var (
 		fakeSeedClient     client.Client
 		fakeShootClient    client.Client
-		options            option.Options242414
+		options            disaoption.Options242414
 		seedPod            *corev1.Pod
 		shootPod           *corev1.Pod
 		ctx                = context.TODO()
@@ -183,22 +184,34 @@ var _ = Describe("#242414", func() {
 	})
 
 	It("should return correct results when options are present", func() {
-		options = option.Options242414{
-			AcceptedPods: []option.AcceptedPods242414{
+		options = disaoption.Options242414{
+			AcceptedPods: []disaoption.AcceptedPods242414{
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{"foo": "bar"},
-						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "not-bar"},
+							},
+						},
 					},
 					Ports: []int32{58},
 				},
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{"foo": "bar"},
-						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+						},
+						Justification: "foo justify",
 					},
-					Justification: "foo justify",
-					Ports:         []int32{53},
+					Ports: []int32{53},
 				},
 			},
 		}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/diki/pkg/internal/utils"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
@@ -66,7 +65,10 @@ func (r *Rule242415) Run(ctx context.Context) (rule.RuleResult, error) {
 	if err != nil {
 		return rule.Result(r, rule.ErroredCheckResult(err.Error(), seedTarget.With("kind", "NamespaceList"))), nil
 	}
-	checkResults := r.checkPods(filteredSeedPods, seedNamespaces, seedReplicaSets, seedTarget)
+	checkResults, err := r.checkPods(filteredSeedPods, seedNamespaces, seedReplicaSets, seedTarget)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), err
+	}
 
 	shootPods, err := kubeutils.GetPods(ctx, r.ClusterClient, "", labels.NewSelector(), 300)
 	if err != nil {
@@ -84,12 +86,16 @@ func (r *Rule242415) Run(ctx context.Context) (rule.RuleResult, error) {
 	if err != nil {
 		return rule.Result(r, rule.ErroredCheckResult(err.Error(), shootTarget.With("kind", "NamespaceList"))), nil
 	}
-	checkResults = append(checkResults, r.checkPods(filteredShootPods, shootNamespaces, shootReplicaSets, shootTarget)...)
+	shootCheckResults, err := r.checkPods(filteredShootPods, shootNamespaces, shootReplicaSets, shootTarget)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), err
+	}
+	checkResults = append(checkResults, shootCheckResults...)
 
 	return rule.Result(r, checkResults...), nil
 }
 
-func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.Namespace, replicaSets []appsv1.ReplicaSet, clusterTarget rule.Target) []rule.CheckResult {
+func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.Namespace, replicaSets []appsv1.ReplicaSet, clusterTarget rule.Target) ([]rule.CheckResult, error) {
 	var checkResults []rule.CheckResult
 	for _, pod := range pods {
 		var (
@@ -100,7 +106,9 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 			for _, env := range container.Env {
 				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 					containerTarget := target.With("container", container.Name, "details", fmt.Sprintf("variableName: %s, keyRef: %s", env.Name, env.ValueFrom.SecretKeyRef.Key))
-					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, env.Name); accepted {
+					if accepted, justification, err := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, env.Name); err != nil {
+						return nil, err
+					} else if accepted {
 						msg := cmp.Or(justification, "Pod accepted to use environment to inject secret.")
 						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, containerTarget))
 					} else {
@@ -114,24 +122,25 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, namespaces map[string]corev1.N
 		}
 		checkResults = append(checkResults, podCheckResults...)
 	}
-	return checkResults
+	return checkResults, nil
 }
 
-func (r *Rule242415) accepted(podLabels, namespaceLabels map[string]string, environmentVariable string) (bool, string) {
+func (r *Rule242415) accepted(podLabels, namespaceLabels map[string]string, environmentVariable string) (bool, string, error) {
 	if r.Options == nil {
-		return false, ""
+		return false, "", nil
 	}
 
 	for _, acceptedPod := range r.Options.AcceptedPods {
-		if utils.MatchLabels(podLabels, acceptedPod.PodMatchLabels) &&
-			utils.MatchLabels(namespaceLabels, acceptedPod.NamespaceMatchLabels) {
+		if matches, err := acceptedPod.Matches(podLabels, namespaceLabels); err != nil {
+			return false, "", err
+		} else if matches {
 			for _, acceptedEnvironmentVariable := range acceptedPod.EnvironmentVariables {
 				if acceptedEnvironmentVariable == environmentVariable {
-					return true, acceptedPod.Justification
+					return true, acceptedPod.Justification, nil
 				}
 			}
 		}
 	}
 
-	return false, ""
+	return false, "", nil
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
 var _ = Describe("#242415", func() {
 	var (
 		fakeSeedClient     client.Client
 		fakeShootClient    client.Client
-		options            *option.Options242415
+		options            *disaoption.Options242415
 		seedPod            *corev1.Pod
 		shootPod           *corev1.Pod
 		ctx                = context.TODO()
@@ -90,7 +91,7 @@ var _ = Describe("#242415", func() {
 				},
 			},
 		}
-		options = &option.Options242415{}
+		options = &disaoption.Options242415{}
 	})
 
 	It("should return correct results when all pods pass", func() {
@@ -191,12 +192,18 @@ var _ = Describe("#242415", func() {
 	})
 
 	It("should return correct results when a pod has accepted environment variables", func() {
-		options = &option.Options242415{
-			AcceptedPods: []option.AcceptedPods242415{
+		options = &disaoption.Options242415{
+			AcceptedPods: []disaoption.AcceptedPods242415{
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{"foo": "bar"},
-						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+						},
 					},
 					EnvironmentVariables: []string{"SECRET_TEST"},
 				},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
@@ -396,16 +396,14 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodSelector: disaoption.PodSelector{
-							PodMatchLabels: map[string]string{
-								resourcesv1alpha1.ManagedBy: "gardener",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								MatchLabels:          map[string]string{resourcesv1alpha1.ManagedBy: "gardener"},
+								NamespaceMatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
 							},
-							NamespaceMatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "kube-system",
-							},
+							Justification: "Gardener managed pods are not user pods",
 						},
-						Justification: "Gardener managed pods are not user pods",
-						Status:        "Passed",
+						Status: "Passed",
 					},
 				},
 			},

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
@@ -396,16 +396,14 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 			Options: &sharedrules.Options242417{
 				AcceptedPods: []sharedrules.AcceptedPods242417{
 					{
-						PodSelector: disaoption.PodSelector{
-							PodMatchLabels: map[string]string{
-								resourcesv1alpha1.ManagedBy: "gardener",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								MatchLabels:          map[string]string{resourcesv1alpha1.ManagedBy: "gardener"},
+								NamespaceMatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
 							},
-							NamespaceMatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "kube-system",
-							},
+							Justification: "Gardener managed pods are not user pods",
 						},
-						Justification: "Gardener managed pods are not user pods",
-						Status:        "Passed",
+						Status: "Passed",
 					},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/diki/pkg/internal/utils"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
@@ -60,12 +59,15 @@ func (r *Rule242414) Run(ctx context.Context) (rule.RuleResult, error) {
 	if err != nil {
 		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NamespaceList"))), nil
 	}
-	checkResults := r.checkPods(filteredPods, replicaSets, namespaces)
+	checkResults, err := r.checkPods(filteredPods, replicaSets, namespaces)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), err
+	}
 
 	return rule.Result(r, checkResults...), nil
 }
 
-func (r *Rule242414) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet, namespaces map[string]corev1.Namespace) []rule.CheckResult {
+func (r *Rule242414) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet, namespaces map[string]corev1.Namespace) ([]rule.CheckResult, error) {
 	var checkResults []rule.CheckResult
 	for _, pod := range pods {
 		var (
@@ -76,7 +78,9 @@ func (r *Rule242414) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSe
 			for _, port := range container.Ports {
 				if port.HostPort != 0 && port.HostPort < 1024 {
 					target := target.With("container", container.Name, "details", fmt.Sprintf("port: %d", port.HostPort))
-					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, port.HostPort); accepted {
+					if accepted, justification, err := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, port.HostPort); err != nil {
+						return nil, err
+					} else if accepted {
 						msg := cmp.Or(justification, "Pod accepted to have containers using hostPort < 1024.")
 						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, target))
 					} else {
@@ -90,24 +94,25 @@ func (r *Rule242414) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSe
 		}
 		checkResults = append(checkResults, podCheckResults...)
 	}
-	return checkResults
+	return checkResults, nil
 }
 
-func (r *Rule242414) accepted(podLabels, namespaceLabels map[string]string, hostPort int32) (bool, string) {
+func (r *Rule242414) accepted(podLabels, namespaceLabels map[string]string, hostPort int32) (bool, string, error) {
 	if r.Options == nil {
-		return false, ""
+		return false, "", nil
 	}
 
 	for _, acceptedPod := range r.Options.AcceptedPods {
-		if utils.MatchLabels(podLabels, acceptedPod.PodMatchLabels) &&
-			utils.MatchLabels(namespaceLabels, acceptedPod.NamespaceMatchLabels) {
+		if matches, err := acceptedPod.Matches(podLabels, namespaceLabels); err != nil {
+			return false, "", err
+		} else if matches {
 			for _, acceptedHostPort := range acceptedPod.Ports {
 				if acceptedHostPort == hostPort {
-					return true, acceptedPod.Justification
+					return true, acceptedPod.Justification, nil
 				}
 			}
 		}
 	}
 
-	return false, ""
+	return false, "", nil
 }

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
 var _ = Describe("#242414", func() {
 	var (
 		client        client.Client
-		options       option.Options242414
+		options       disaoption.Options242414
 		plainPod      *corev1.Pod
 		ctx           = context.TODO()
 		namespaceName = "foo"
@@ -160,22 +161,34 @@ var _ = Describe("#242414", func() {
 	})
 
 	It("should return correct results when options are present", func() {
-		options = option.Options242414{
-			AcceptedPods: []option.AcceptedPods242414{
+		options = disaoption.Options242414{
+			AcceptedPods: []disaoption.AcceptedPods242414{
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{"foo": "bar"},
-						NamespaceMatchLabels: map[string]string{"foo": "not-bar"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "not-bar"},
+							},
+						},
 					},
 					Ports: []int32{58},
 				},
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{"foo": "bar"},
-						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+						},
+						Justification: "foo justify",
 					},
-					Justification: "foo justify",
-					Ports:         []int32{53},
+					Ports: []int32{53},
 				},
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/diki/pkg/internal/utils"
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
@@ -66,12 +65,15 @@ func (r *Rule242415) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	filteredPods := kubeutils.FilterPodsByOwnerRef(pods)
 
-	checkResults := r.checkPods(filteredPods, replicaSets, namespaces)
+	checkResults, err := r.checkPods(filteredPods, replicaSets, namespaces)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), err
+	}
 
 	return rule.Result(r, checkResults...), nil
 }
 
-func (r *Rule242415) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet, namespaces map[string]corev1.Namespace) []rule.CheckResult {
+func (r *Rule242415) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet, namespaces map[string]corev1.Namespace) ([]rule.CheckResult, error) {
 	var checkResults []rule.CheckResult
 	for _, pod := range pods {
 		var (
@@ -82,7 +84,9 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSe
 			for _, env := range container.Env {
 				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 					target = target.With("container", container.Name, "details", fmt.Sprintf("variableName: %s, keyRef: %s", env.Name, env.ValueFrom.SecretKeyRef.Key))
-					if accepted, justification := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, env.Name); accepted {
+					if accepted, justification, err := r.accepted(pod.Labels, namespaces[pod.Namespace].Labels, env.Name); err != nil {
+						return nil, err
+					} else if accepted {
 						msg := cmp.Or(justification, "Pod accepted to use environment to inject secret.")
 						podCheckResults = append(podCheckResults, rule.AcceptedCheckResult(msg, target))
 					} else {
@@ -96,24 +100,25 @@ func (r *Rule242415) checkPods(pods []corev1.Pod, replicaSets []appsv1.ReplicaSe
 		}
 		checkResults = append(checkResults, podCheckResults...)
 	}
-	return checkResults
+	return checkResults, nil
 }
 
-func (r *Rule242415) accepted(podLabels, namespaceLabels map[string]string, environmentVariable string) (bool, string) {
+func (r *Rule242415) accepted(podLabels, namespaceLabels map[string]string, environmentVariable string) (bool, string, error) {
 	if r.Options == nil {
-		return false, ""
+		return false, "", nil
 	}
 
 	for _, acceptedPod := range r.Options.AcceptedPods {
-		if utils.MatchLabels(podLabels, acceptedPod.PodMatchLabels) &&
-			utils.MatchLabels(namespaceLabels, acceptedPod.NamespaceMatchLabels) {
+		if matches, err := acceptedPod.Matches(podLabels, namespaceLabels); err != nil {
+			return false, "", err
+		} else if matches {
 			for _, acceptedEnvironmentVariable := range acceptedPod.EnvironmentVariables {
 				if acceptedEnvironmentVariable == environmentVariable {
-					return true, acceptedPod.Justification
+					return true, acceptedPod.Justification, nil
 				}
 			}
 		}
 	}
 
-	return false, ""
+	return false, "", nil
 }

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
@@ -17,13 +17,14 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
 var _ = Describe("#242415", func() {
 	var (
 		fakeClient    client.Client
-		options       *option.Options242415
+		options       *disaoption.Options242415
 		pod           *corev1.Pod
 		ctx           = context.TODO()
 		namespaceName = "foo"
@@ -59,7 +60,7 @@ var _ = Describe("#242415", func() {
 				},
 			},
 		}
-		options = &option.Options242415{}
+		options = &disaoption.Options242415{}
 	})
 
 	It("should pass when no pods are deployed", func() {
@@ -159,12 +160,18 @@ var _ = Describe("#242415", func() {
 	})
 
 	It("should return correct results when a pod has accepted environment variables", func() {
-		options = &option.Options242415{
-			AcceptedPods: []option.AcceptedPods242415{
+		options = &disaoption.Options242415{
+			AcceptedPods: []disaoption.AcceptedPods242415{
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{"foo": "bar"},
-						NamespaceMatchLabels: map[string]string{"foo": "bar"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
+						},
 					},
 					EnvironmentVariables: []string{"SECRET_TEST"},
 				},
@@ -200,7 +207,7 @@ var _ = Describe("#242415", func() {
 	})
 
 	It("should return correct targets when the pods have owner references", func() {
-		options = &option.Options242415{}
+		options = &disaoption.Options242415{}
 
 		r := &rules.Rule242415{Client: fakeClient, Options: options}
 

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -14,33 +14,6 @@ import (
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 )
 
-// PodSelector contains generalized options for matching entities by their attribute labels
-type PodSelector struct {
-	PodMatchLabels       map[string]string `json:"podMatchLabels" yaml:"podMatchLabels"`
-	NamespaceMatchLabels map[string]string `json:"namespaceMatchLabels" yaml:"namespaceMatchLabels"`
-}
-
-var _ option.Option = (*PodSelector)(nil)
-
-// Validate validates that option configurations are correctly defined.
-func (e PodSelector) Validate(fldPath *field.Path) field.ErrorList {
-	var (
-		allErrs field.ErrorList
-	)
-
-	if len(e.NamespaceMatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("namespaceMatchLabels"), "must not be empty"))
-	}
-
-	if len(e.PodMatchLabels) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("podMatchLabels"), "must not be empty"))
-	}
-
-	allErrs = append(allErrs, metav1validation.ValidateLabels(e.NamespaceMatchLabels, fldPath.Child("namespaceMatchLabels"))...)
-	allErrs = append(allErrs, metav1validation.ValidateLabels(e.PodMatchLabels, fldPath.Child("podMatchLabels"))...)
-	return allErrs
-}
-
 // FileOwnerOptions contains expected user and group owners for files
 type FileOwnerOptions struct {
 	ExpectedFileOwner ExpectedOwner `json:"expectedFileOwner" yaml:"expectedFileOwner"`
@@ -93,9 +66,8 @@ var _ option.Option = (*Options242414)(nil)
 
 // AcceptedPods242414 contains option specifications for accepted pods
 type AcceptedPods242414 struct {
-	PodSelector
-	Justification string  `json:"justification" yaml:"justification"`
-	Ports         []int32 `json:"ports" yaml:"ports"`
+	option.AcceptedNamespacedObject
+	Ports []int32 `json:"ports" yaml:"ports"`
 }
 
 // Validate validates that option configurations are correctly defined.
@@ -127,8 +99,7 @@ var _ option.Option = (*Options242415)(nil)
 
 // AcceptedPods242415 contains option specifications for accepted pods
 type AcceptedPods242415 struct {
-	PodSelector
-	Justification        string   `json:"justification" yaml:"justification"`
+	option.AcceptedNamespacedObject
 	EnvironmentVariables []string `json:"environmentVariables" yaml:"environmentVariables"`
 }
 

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -8,16 +8,18 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
 var _ = Describe("options", func() {
 	Describe("#ValidateFileOwnerOptions", func() {
 		It("should correctly validate options", func() {
-			options := option.FileOwnerOptions{
-				ExpectedFileOwner: option.ExpectedOwner{
+			options := disaoption.FileOwnerOptions{
+				ExpectedFileOwner: disaoption.ExpectedOwner{
 					Users:  []string{"-1", "0", "100"},
 					Groups: []string{"", "asd", "111"},
 				},
@@ -42,123 +44,44 @@ var _ = Describe("options", func() {
 			))
 		})
 	})
-	Describe("#ValidatePodSelector", func() {
-		It("should correctly validate labels", func() {
-			podAttributes := []option.PodSelector{
-				{
-					NamespaceMatchLabels: map[string]string{"_foo": "bar"},
-					PodMatchLabels:       map[string]string{"foo": "bar."},
-				},
-				{
-					NamespaceMatchLabels: map[string]string{"foo?baz": "bar"},
-					PodMatchLabels:       map[string]string{"foo": "bar"},
-				},
-				{
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
-					PodMatchLabels:       map[string]string{"at_ta": "bar"},
-				},
-				{
-					NamespaceMatchLabels: map[string]string{"this": "is_a"},
-					PodMatchLabels:       map[string]string{"Valid": "label-pair"},
-				},
-				{
-					NamespaceMatchLabels: map[string]string{"foo": "ba/r"},
-					PodMatchLabels:       map[string]string{"at$a": "bar"},
-				},
-				{
-					NamespaceMatchLabels: map[string]string{"label": "value"},
-				},
-				{
-					PodMatchLabels: map[string]string{"label": "value"},
-				},
-				{
-					NamespaceMatchLabels: map[string]string{},
-					PodMatchLabels:       map[string]string{"at_ta": "bar"},
-				},
-				{
-					NamespaceMatchLabels: map[string]string{"foo": "bar"},
-					PodMatchLabels:       map[string]string{},
-				},
-			}
-
-			var result field.ErrorList
-			for _, p := range podAttributes {
-				result = append(result, p.Validate(field.NewPath("foo"))...)
-			}
-
-			Expect(result).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.namespaceMatchLabels"),
-					"BadValue": Equal("_foo"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.podMatchLabels"),
-					"BadValue": Equal("bar."),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.namespaceMatchLabels"),
-					"BadValue": Equal("foo?baz"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.namespaceMatchLabels"),
-					"BadValue": Equal("ba/r"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.podMatchLabels"),
-					"BadValue": Equal("at$a"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("foo.namespaceMatchLabels"),
-					"Detail": Equal("must not be empty"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("foo.namespaceMatchLabels"),
-					"Detail": Equal("must not be empty"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("foo.podMatchLabels"),
-					"Detail": Equal("must not be empty"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("foo.podMatchLabels"),
-					"Detail": Equal("must not be empty"),
-				}))))
-		})
-	})
 	Describe("#ValidateOptions242414", func() {
 		It("should correctly validate options", func() {
-			options := option.Options242414{
-				AcceptedPods: []option.AcceptedPods242414{
+			options := disaoption.Options242414{
+				AcceptedPods: []disaoption.AcceptedPods242414{
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels: map[string]string{
-								"foo": "bar",
-							},
-							NamespaceMatchLabels: map[string]string{
-								"foo": "bar",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
 							},
 						},
 					},
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels: map[string]string{
-								"foo": "bar",
-							},
-							NamespaceMatchLabels: map[string]string{
-								"foo": "bar",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
 							},
 						},
 						Ports: []int32{0, 100},
 					},
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels: map[string]string{
-								"foo": "bar",
-							},
-							NamespaceMatchLabels: map[string]string{
-								"foo": "bar",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
 							},
 						},
 						Ports: []int32{-1},
@@ -185,26 +108,30 @@ var _ = Describe("options", func() {
 	})
 	Describe("#ValidateOptions242415", func() {
 		It("should correctly validate options", func() {
-			options := option.Options242415{
-				AcceptedPods: []option.AcceptedPods242415{
+			options := disaoption.Options242415{
+				AcceptedPods: []disaoption.AcceptedPods242415{
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels: map[string]string{
-								"foo": "bar",
-							},
-							NamespaceMatchLabels: map[string]string{
-								"foo": "bar",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
 							},
 						},
 						EnvironmentVariables: []string{"asd=dsa"},
 					},
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels: map[string]string{
-								"foo": "bar",
-							},
-							NamespaceMatchLabels: map[string]string{
-								"foo": "bar",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
 							},
 						},
 					},
@@ -230,7 +157,7 @@ var _ = Describe("options", func() {
 
 	Describe("#ValidateOptions242442", func() {
 		It("should deny empty expected images list", func() {
-			options := option.Options242442{}
+			options := disaoption.Options242442{}
 
 			result := options.Validate(field.NewPath("foo"))
 
@@ -244,8 +171,8 @@ var _ = Describe("options", func() {
 		})
 
 		It("should correctly validate options", func() {
-			options := option.Options242442{
-				ExpectedVersionedImages: []option.ExpectedVersionedImage{
+			options := disaoption.Options242442{
+				ExpectedVersionedImages: []disaoption.ExpectedVersionedImage{
 					{
 						Name: "foo",
 					},

--- a/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
@@ -19,6 +19,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -52,19 +53,35 @@ var _ = Describe("#242383", func() {
 		options = &rules.Options242383{
 			AcceptedResources: []rules.AcceptedResources242383{
 				{
-					ObjectSelector: rules.ObjectSelector{
-						APIVersion:           "v1",
-						Kind:                 "Pod",
-						MatchLabels:          map[string]string{},
-						NamespaceMatchLabels: map[string]string{"random_1": "value_1"},
+					AcceptedObjectSelector: rules.AcceptedObjectSelector{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"random_1": "value_1"},
+								},
+							},
+						},
 					},
 				},
 				{
-					ObjectSelector: rules.ObjectSelector{
-						APIVersion:           "v1",
-						Kind:                 "Pod",
-						MatchLabels:          map[string]string{},
-						NamespaceMatchLabels: map[string]string{"random_2": "value_2"},
+					AcceptedObjectSelector: rules.AcceptedObjectSelector{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"random_2": "value_2"},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -130,9 +147,9 @@ var _ = Describe("#242383", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedResources[0].MatchLabels["label"] = "value"
+		options.AcceptedResources[0].LabelSelector.MatchLabels["label"] = "value"
 		options.AcceptedResources[0].Status = "Passed"
-		options.AcceptedResources[1].MatchLabels["label"] = "value"
+		options.AcceptedResources[1].LabelSelector.MatchLabels["label"] = "value"
 		options.AcceptedResources[1].Status = "Passed"
 		r := &rules.Rule242383{
 			Client:  fakeClient,
@@ -356,30 +373,46 @@ var _ = Describe("#242383", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedResources[0].MatchLabels["foo"] = "bar"
-		options.AcceptedResources[0].MatchLabels["bar"] = "foo"
+		options.AcceptedResources[0].LabelSelector.MatchLabels["foo"] = "bar"
+		options.AcceptedResources[0].LabelSelector.MatchLabels["bar"] = "foo"
 		options.AcceptedResources[0].Status = "Accepted"
 		options.AcceptedResources[0].Justification = "Accept pod."
 
-		options.AcceptedResources[1].MatchLabels["foo"] = "bar"
-		options.AcceptedResources[1].MatchLabels["bar"] = "foo"
+		options.AcceptedResources[1].LabelSelector.MatchLabels["foo"] = "bar"
+		options.AcceptedResources[1].LabelSelector.MatchLabels["bar"] = "foo"
 		options.AcceptedResources[1].Status = "Accepted"
 		options.AcceptedResources[1].Justification = "Accept pod."
 
 		options.AcceptedResources = append(options.AcceptedResources, rules.AcceptedResources242383{
-			ObjectSelector: rules.ObjectSelector{
-				APIVersion:           "v1",
-				Kind:                 "*",
-				MatchLabels:          map[string]string{"foo": "bar"},
-				NamespaceMatchLabels: map[string]string{"random_2": "value_2"},
+			AcceptedObjectSelector: rules.AcceptedObjectSelector{
+				APIVersion: "v1",
+				Kind:       "*",
+				AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+					NamespacedObjectSelector: option.NamespacedObjectSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"foo": "bar"},
+						},
+						NamespaceLabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"random_2": "value_2"},
+						},
+					},
+				},
 			},
 		})
 		options.AcceptedResources = append(options.AcceptedResources, rules.AcceptedResources242383{
-			ObjectSelector: rules.ObjectSelector{
-				APIVersion:           "v1",
-				Kind:                 "*",
-				MatchLabels:          map[string]string{"foo-bar": "bar"},
-				NamespaceMatchLabels: map[string]string{"random_1": "value_1"},
+			AcceptedObjectSelector: rules.AcceptedObjectSelector{
+				APIVersion: "v1",
+				Kind:       "*",
+				AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+					NamespacedObjectSelector: option.NamespacedObjectSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"foo-bar": "bar"},
+						},
+						NamespaceLabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"random_1": "value_1"},
+						},
+					},
+				},
 			},
 			Status: "fake",
 		})
@@ -406,47 +439,87 @@ var _ = Describe("#242383", func() {
 			options = &rules.Options242383{
 				AcceptedResources: []rules.AcceptedResources242383{
 					{
-						ObjectSelector: rules.ObjectSelector{
-							APIVersion:           "v1",
-							Kind:                 "Pod",
-							MatchLabels:          map[string]string{"bar": "foo"},
-							NamespaceMatchLabels: map[string]string{"foo": "bar"},
+						AcceptedObjectSelector: rules.AcceptedObjectSelector{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+								NamespacedObjectSelector: option.NamespacedObjectSelector{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"bar": "foo"},
+									},
+									NamespaceLabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"foo": "bar"},
+									},
+								},
+							},
 						},
 						Status: "Passed",
 					},
 					{
-						ObjectSelector: rules.ObjectSelector{
-							APIVersion:           "apps/v1",
-							Kind:                 "Service",
-							MatchLabels:          map[string]string{"bar": "foo"},
-							NamespaceMatchLabels: map[string]string{"foo": "bar"},
+						AcceptedObjectSelector: rules.AcceptedObjectSelector{
+							APIVersion: "apps/v1",
+							Kind:       "Service",
+							AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+								NamespacedObjectSelector: option.NamespacedObjectSelector{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"bar": "foo"},
+									},
+									NamespaceLabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"foo": "bar"},
+									},
+								},
+							},
 						},
 						Status: "Passed",
 					},
 					{
-						ObjectSelector: rules.ObjectSelector{
-							APIVersion:           "v1",
-							Kind:                 "Deployment",
-							MatchLabels:          map[string]string{"-foo": "bar"},
-							NamespaceMatchLabels: map[string]string{},
+						AcceptedObjectSelector: rules.AcceptedObjectSelector{
+							APIVersion: "v1",
+							Kind:       "Deployment",
+							AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+								NamespacedObjectSelector: option.NamespacedObjectSelector{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"-foo": "bar"},
+									},
+									NamespaceLabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{},
+									},
+								},
+							},
 						},
 						Status: "Accepted",
 					},
 					{
-						ObjectSelector: rules.ObjectSelector{
-							APIVersion:           "v1",
-							Kind:                 "Service",
-							MatchLabels:          map[string]string{},
-							NamespaceMatchLabels: map[string]string{"foo": "bar"},
+						AcceptedObjectSelector: rules.AcceptedObjectSelector{
+							APIVersion: "v1",
+							Kind:       "Service",
+							AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+								NamespacedObjectSelector: option.NamespacedObjectSelector{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{},
+									},
+									NamespaceLabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"foo": "bar"},
+									},
+								},
+							},
 						},
 						Status: "Accepted",
 					},
 					{
-						ObjectSelector: rules.ObjectSelector{
-							APIVersion:           "fake",
-							Kind:                 "Service",
-							MatchLabels:          map[string]string{"foo": "?bar"},
-							NamespaceMatchLabels: map[string]string{"bar$baz": "_foo"},
+						AcceptedObjectSelector: rules.AcceptedObjectSelector{
+							APIVersion: "fake",
+							Kind:       "Service",
+							AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+								NamespacedObjectSelector: option.NamespacedObjectSelector{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"foo": "?bar"},
+									},
+									NamespaceLabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"bar$baz": "_foo"},
+									},
+								},
+							},
 						},
 						Status: "asd",
 					},
@@ -469,18 +542,8 @@ var _ = Describe("#242383", func() {
 					"Detail":   Equal("not checked kind for apiVersion apps/v1"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("foo.acceptedResources[2].namespaceMatchLabels"),
-					"Detail": Equal("must not be empty"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("foo.acceptedResources[3].matchLabels"),
-					"Detail": Equal("must not be empty"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.acceptedResources[2].matchLabels"),
+					"Field":    Equal("foo.acceptedResources[2].labelSelector.matchLabels"),
 					"BadValue": Equal("-foo"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -491,17 +554,17 @@ var _ = Describe("#242383", func() {
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.acceptedResources[4].matchLabels"),
+					"Field":    Equal("foo.acceptedResources[4].labelSelector.matchLabels"),
 					"BadValue": Equal("?bar"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.acceptedResources[4].namespaceMatchLabels"),
+					"Field":    Equal("foo.acceptedResources[4].namespaceLabelSelector.matchLabels"),
 					"BadValue": Equal("bar$baz"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("foo.acceptedResources[4].namespaceMatchLabels"),
+					"Field":    Equal("foo.acceptedResources[4].namespaceLabelSelector.matchLabels"),
 					"BadValue": Equal("_foo"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -18,7 +18,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/diki/pkg/rule"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -48,15 +48,27 @@ var _ = Describe("#242417", func() {
 		options = &rules.Options242417{
 			AcceptedPods: []rules.AcceptedPods242417{
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{},
-						NamespaceMatchLabels: map[string]string{"random1": "value1"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"random1": "value1"},
+							},
+						},
 					},
 				},
 				{
-					PodSelector: option.PodSelector{
-						PodMatchLabels:       map[string]string{},
-						NamespaceMatchLabels: map[string]string{"random2": "value2"},
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{},
+							},
+							NamespaceLabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"random2": "value2"},
+							},
+						},
 					},
 				},
 			},
@@ -119,9 +131,9 @@ var _ = Describe("#242417", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedPods[0].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[0].LabelSelector.MatchLabels["label"] = "value"
 		options.AcceptedPods[0].Status = "Passed"
-		options.AcceptedPods[1].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[1].LabelSelector.MatchLabels["label"] = "value"
 		options.AcceptedPods[1].Status = "Passed"
 
 		r := &rules.Rule242417{
@@ -222,9 +234,9 @@ var _ = Describe("#242417", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedPods[0].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[0].LabelSelector.MatchLabels["label"] = "value"
 		options.AcceptedPods[0].Status = "Passed"
-		options.AcceptedPods[1].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[1].LabelSelector.MatchLabels["label"] = "value"
 		options.AcceptedPods[1].Status = "Passed"
 
 		r := &rules.Rule242417{
@@ -260,8 +272,9 @@ var _ = Describe("#242417", func() {
 		pod3.Labels["label"] = "gardener"
 		Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
 
-		options.AcceptedPods[0].PodMatchLabels["label"] = "value"
+		options.AcceptedPods[0].LabelSelector.MatchLabels["label1"] = "value1"
 		options.AcceptedPods[0].Status = "Passed"
+		options.AcceptedPods[1].LabelSelector.MatchLabels["labe2"] = "value2"
 
 		r := &rules.Rule242417{Client: fakeClient,
 			Options: options}
@@ -304,22 +317,34 @@ var _ = Describe("#242417", func() {
 		pod4.Labels["compliance.gardener.cloud/role"] = "diki-privileged-pod"
 		Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
 
-		options.AcceptedPods[0].PodMatchLabels["foo"] = "bar"
-		options.AcceptedPods[0].PodMatchLabels["bar"] = "foo"
+		options.AcceptedPods[0].LabelSelector.MatchLabels["foo"] = "bar"
+		options.AcceptedPods[0].LabelSelector.MatchLabels["bar"] = "foo"
 		options.AcceptedPods[0].Status = "Accepted"
 		options.AcceptedPods[0].Justification = "Accept pod."
 
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodSelector: option.PodSelector{
-				PodMatchLabels:       map[string]string{"foo": "bar"},
-				NamespaceMatchLabels: map[string]string{"functionality": "system"},
+			AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+				NamespacedObjectSelector: option.NamespacedObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					NamespaceLabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"functionality": "system"},
+					},
+				},
 			},
 		})
 
 		options.AcceptedPods = append(options.AcceptedPods, rules.AcceptedPods242417{
-			PodSelector: option.PodSelector{
-				PodMatchLabels:       map[string]string{"foo-bar": "bar"},
-				NamespaceMatchLabels: map[string]string{"functionality": "system"},
+			AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+				NamespacedObjectSelector: option.NamespacedObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo-bar": "bar"},
+					},
+					NamespaceLabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"functionality": "system"},
+					},
+				},
 			},
 			Status: "fake",
 		})
@@ -346,30 +371,53 @@ var _ = Describe("#242417", func() {
 			options = &rules.Options242417{
 				AcceptedPods: []rules.AcceptedPods242417{
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
-							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"typeOfPod": "veryImportant"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"namespaceType": "system"},
+								},
+							},
 						},
-						Status: "Passed",
 					},
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
-							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"typeOfPod": "veryImportant"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"namespaceType": "system"},
+								},
+							},
 						},
 						Status: "Accepted",
 					},
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
-							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"typeOfPod": "veryImportant"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"namespaceType": "system"},
+								},
+							},
 						},
 						Status: "fake",
 					},
 					{
-						PodSelector: option.PodSelector{
-							PodMatchLabels:       map[string]string{"typeOfPod": "veryImportant"},
-							NamespaceMatchLabels: map[string]string{"namespaceType": "system"},
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"typeOfPod": "veryImportant"},
+								},
+								NamespaceLabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"namespaceType": "system"},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the `PodSelector` used by DISA STIG rules 242414, 242415 and 242417 with `NamespacedObject`.

It also refactors the custom `ObjectSelector` from DISA STIG rule 242383 to use `NamespacedObject`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/514

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
DISA Kubernetes STIG rules 242414, 242415 and 242417 have their options for selecting Pods changed from from `acceptedPods[].podMatchLabels` to `acceptedPods[].matchLabels`.
```
