### PR TITLE
Use `labelSelector`s for kube-proxy rules

### DIFF
--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -30,7 +30,8 @@ providers:             # contains information about known providers
     #     - path: /livez
     # - ruleID: "242400"
     #   args:
-    #     kubeProxyDisabled: true # skip kube-proxy check
+    #     kubeProxy:
+    #       disabled: true # skip kube-proxy check
     - ruleID: "242414"
       args:
         acceptedPods:
@@ -83,7 +84,8 @@ providers:             # contains information about known providers
           groups: ["0", "65532"]
     - ruleID: "242451"
       args:
-        # kubeProxyDisabled: true
+        # kubeProxy:
+        #   disabled: true # skip kube-proxy check
         expectedFileOwner:
           # users and groups default to ["0"]
           #
@@ -93,10 +95,12 @@ providers:             # contains information about known providers
           groups: ["0", "65532"]
     # - ruleID: "242466"
     #   args:
-    #     kubeProxyDisabled: true # skip kube-proxy check
+    #     kubeProxy:
+    #       disabled: true # skip kube-proxy check
     # - ruleID: "242467"
     #   args:
-    #     kubeProxyDisabled: true # skip kube-proxy check
+    #     kubeProxy:
+    #       disabled: true # skip kube-proxy check
     - ruleID: "245543"
       args:
         acceptedTokens:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -55,9 +55,11 @@ providers:                   # contains information about known providers
     #     - foo
     # - ruleID: "242400"
     #   args:
-    #     kubeProxyDisabled: true
-    #     kubeProxyMatchLabels:
-    #       foo: bar
+    #     kubeProxy:
+    #       disabled: true # skip kube-proxy check
+    #       labelSelector:
+    #         matchLabels:
+    #           foo: bar
     # - ruleID: "242404"
     #   args:
     #     nodeGroupByLabels:
@@ -111,19 +113,23 @@ providers:                   # contains information about known providers
     #       status: Passed
     # - ruleID: "242442"
     #   args:
-    #     kubeProxyMatchLabels:
-    #       foo: bar
+    #     kubeProxy:
+    #       labelSelector:
+    #         matchLabels:
+    #           foo: bar
     #     expectedVersionedImages:
     #     - name: "eu.gcr.io/foo"
     #     - name: "eu.gcr.io/bar"
     # - ruleID: "242447"
     #   args:
-    #     kubeProxyMatchLabels:
-    #       foo: bar
+    #     labelSelector:
+    #       matchLabels:
+    #         foo: bar
     # - ruleID: "242448"
     #   args:
-    #     kubeProxyMatchLabels:
-    #       foo: bar
+    #     labelSelector:
+    #       matchLabels:
+    #         foo: bar
     #     expectedFileOwner:
     #       users: ["0"]
     #       groups: ["0"]
@@ -140,9 +146,11 @@ providers:                   # contains information about known providers
     #       groups: ["0"]
     # - ruleID: "242451"
     #   args:
-    #     kubeProxyDisabled: true
-    #     kubeProxyMatchLabels:
-    #       foo: bar
+    #     kubeProxy:
+    #       disabled: true # skip kube-proxy check
+    #       labelSelector:
+    #         matchLabels:
+    #           foo: bar
     #     nodeGroupByLabels:
     #     - foo
     #     expectedFileOwner:
@@ -161,16 +169,20 @@ providers:                   # contains information about known providers
     #       groups: ["0"]
     # - ruleID: "242466"
     #   args:
-    #     kubeProxyDisabled: true # skip kube-proxy check
-    #     kubeProxyMatchLabels:
-    #       foo: bar
+    #     kubeProxy:
+    #       disabled: true # skip kube-proxy check
+    #       labelSelector:
+    #         matchLabels:
+    #           foo: bar
     #     nodeGroupByLabels:
     #     - foo
     # - ruleID: "242467"
     #   args:
-    #     kubeProxyDisabled: true # skip kube-proxy check
-    #     kubeProxyMatchLabels:
-    #       foo: bar
+    #     kubeProxy:
+    #       disabled: true # skip kube-proxy check
+    #       labelSelector:
+    #         matchLabels:
+    #           foo: bar
     #     nodeGroupByLabels:
     #     - foo
   - id: security-hardened-k8s

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -386,8 +386,10 @@ var _ = Describe("#242400", func() {
 			ControlPlaneClient:    fakeControlPlaneClient,
 			ControlPlaneNamespace: controlPlaneNamespace,
 			ClusterV1RESTClient:   fakeRESTClient,
-			Options: &option.KubeProxyOptions{
-				KubeProxyDisabled: true,
+			Options: &rules.Options242400{
+				option.KubeProxyOptionsWithoutSelectors{
+					Disabled: true,
+				},
 			},
 		}
 		ruleResult, err := r.Run(ctx)

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -49,17 +49,18 @@ type Rule242451 struct {
 }
 
 type Options242451 struct {
-	disaoption.KubeProxyOptions
+	KubeProxy disaoption.KubeProxyOptionsWithoutSelectors `json:"kubeProxy" yaml:"kubeProxy"`
 	*disaoption.FileOwnerOptions
 }
 
 var _ option.Option = (*Options242451)(nil)
 
 func (o Options242451) Validate(fldPath *field.Path) field.ErrorList {
+	allErrors := o.KubeProxy.Validate(fldPath.Child("kubeProxy"))
 	if o.FileOwnerOptions != nil {
-		return o.FileOwnerOptions.Validate(fldPath)
+		allErrors = append(allErrors, o.FileOwnerOptions.Validate(fldPath)...)
 	}
-	return nil
+	return allErrors
 }
 
 func (r *Rule242451) ID() string {
@@ -198,7 +199,7 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	// kube-proxy check
-	if r.Options != nil && r.Options.KubeProxyDisabled {
+	if r.Options != nil && r.Options.KubeProxy.Disabled {
 		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", shootTarget))
 		return rule.Result(r, checkResults...), nil
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
@@ -476,8 +476,8 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should return accepted check result when kubeProxyDisabled option is set to true",
 			rules.Options242451{
-				KubeProxyOptions: option.KubeProxyOptions{
-					KubeProxyDisabled: true,
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{
+					Disabled: true,
 				},
 			},
 			[][]string{{mounts, compliantStats, compliantDirStats, mounts, compliantStats2, compliantDirStats, emptyMounts, emptyMounts, emptyMounts}},

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
@@ -387,7 +387,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 	})
 
 	DescribeTable("Run cases",
-		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, option *option.KubeProxyOptions, expectedCheckResults []rule.CheckResult) {
+		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, option *rules.Options242466, expectedCheckResults []rule.CheckResult) {
 			Expect(fakeControlPlaneClient.Create(ctx, etcdMainPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, etcdEventsPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, kubeAPIServerPod)).To(Succeed())
@@ -456,8 +456,10 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
 			[][]error{{nil, nil, nil, nil}},
-			&option.KubeProxyOptions{
-				KubeProxyDisabled: true,
+			&rules.Options242466{
+				option.KubeProxyOptionsWithoutSelectors{
+					Disabled: true,
+				},
 			},
 			[]rule.CheckResult{
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "etcd", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.crt, permissions: 664, expectedPermissionsMax: 644")),

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,8 +26,9 @@ import (
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/images"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 	"github.com/gardener/diki/pkg/shared/provider"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -42,8 +44,18 @@ type Rule242467 struct {
 	ControlPlaneNamespace  string
 	ControlPlanePodContext pod.PodContext
 	ClusterPodContext      pod.PodContext
-	Options                *option.KubeProxyOptions
+	Options                *Options242467
 	Logger                 provider.Logger
+}
+
+type Options242467 struct {
+	KubeProxy disaoption.KubeProxyOptionsWithoutSelectors `json:"kubeProxy" yaml:"kubeProxy"`
+}
+
+var _ option.Option = (*Options242467)(nil)
+
+func (o Options242467) Validate(fldPath *field.Path) field.ErrorList {
+	return o.KubeProxy.Validate(fldPath.Child("kubeProxy"))
 }
 
 func (r *Rule242467) ID() string {
@@ -173,7 +185,7 @@ func (r *Rule242467) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	// kube-proxy check
-	if r.Options != nil && r.Options.KubeProxyDisabled {
+	if r.Options != nil && r.Options.KubeProxy.Disabled {
 		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", shootTarget))
 		return rule.Result(r, checkResults...), nil
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
@@ -381,7 +381,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 	})
 
 	DescribeTable("Run cases",
-		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, option *option.KubeProxyOptions, expectedCheckResults []rule.CheckResult) {
+		func(seedExecuteReturnString, shootExecuteReturnString [][]string, seedExecuteReturnError, shootExecuteReturnError [][]error, option *rules.Options242467, expectedCheckResults []rule.CheckResult) {
 			Expect(fakeControlPlaneClient.Create(ctx, etcdMainPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, etcdEventsPod)).To(Succeed())
 			Expect(fakeControlPlaneClient.Create(ctx, kubeAPIServerPod)).To(Succeed())
@@ -450,8 +450,10 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			[][]string{{kubeletPID, kubeletCommand, "", nonCompliantStats}},
 			[][]error{{nil, nil, nil, nil, nil, nil}},
 			[][]error{{nil, nil, nil, nil}},
-			&option.KubeProxyOptions{
-				KubeProxyDisabled: true,
+			&rules.Options242467{
+				option.KubeProxyOptionsWithoutSelectors{
+					Disabled: true,
+				},
 			},
 			[]rule.CheckResult{
 				rule.FailedCheckResult("File has too wide permissions", rule.NewTarget("cluster", "seed", "name", "etcd-main", "namespace", "foo", "containerName", "test", "kind", "DaemonSet", "details", "fileName: /destination/file1.key, permissions: 644, expectedPermissionsMax: 640")),

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
@@ -11,12 +11,14 @@ import (
 
 type RuleOption interface {
 	sharedrules.Options242390 |
+		Options242400 |
 		option.Options242414 |
 		option.Options242415 |
 		option.Options242442 |
 		Options242451 |
+		Options242466 |
+		Options242467 |
 		sharedrules.Options245543 |
 		sharedrules.Options254800 |
-		option.FileOwnerOptions |
-		option.KubeProxyOptions
+		option.FileOwnerOptions
 }

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r2_ruleset.go
@@ -70,15 +70,15 @@ func (r *Ruleset) validateV2R2RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args, fldPath.Index(ruleOptions[sharedrules.ID242390].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R2Options[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args, fldPath.Index(ruleOptions[sharedrules.ID242400].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R2Options[rules.Options242400](ruleOptions[sharedrules.ID242400].Args, fldPath.Index(ruleOptions[sharedrules.ID242400].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[disaoption.Options242414](ruleOptions[sharedrules.ID242414].Args, fldPath.Index(ruleOptions[sharedrules.ID242414].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[disaoption.Options242415](ruleOptions[sharedrules.ID242415].Args, fldPath.Index(ruleOptions[sharedrules.ID242415].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[disaoption.Options242442](ruleOptions[sharedrules.ID242442].Args, fldPath.Index(ruleOptions[sharedrules.ID242442].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[disaoption.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args, fldPath.Index(ruleOptions[sharedrules.ID242445].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[disaoption.FileOwnerOptions](ruleOptions[sharedrules.ID242446].Args, fldPath.Index(ruleOptions[sharedrules.ID242446].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[rules.Options242451](ruleOptions[sharedrules.ID242451].Args, fldPath.Index(ruleOptions[sharedrules.ID242451].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R2Options[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242466].Args, fldPath.Index(ruleOptions[sharedrules.ID242466].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R2Options[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242467].Args, fldPath.Index(ruleOptions[sharedrules.ID242467].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R2Options[rules.Options242466](ruleOptions[sharedrules.ID242466].Args, fldPath.Index(ruleOptions[sharedrules.ID242466].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R2Options[rules.Options242467](ruleOptions[sharedrules.ID242467].Args, fldPath.Index(ruleOptions[sharedrules.ID242467].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args, fldPath.Index(ruleOptions[sharedrules.ID245543].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options254800](ruleOptions[sharedrules.ID254800].Args, fldPath.Index(ruleOptions[sharedrules.ID254800].Index).Child("args"))...)
 
@@ -115,7 +115,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return fmt.Errorf("rule option 242390 error: %s", err.Error())
 	}
-	opts242400, err := getV2R2OptionOrNil[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
+	opts242400, err := getV2R2OptionOrNil[rules.Options242400](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242400 error: %s", err.Error())
 	}
@@ -143,11 +143,11 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return fmt.Errorf("rule option 242451 error: %s", err.Error())
 	}
-	opts242466, err := getV2R2OptionOrNil[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242466].Args)
+	opts242466, err := getV2R2OptionOrNil[rules.Options242466](ruleOptions[sharedrules.ID242466].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242466 error: %s", err.Error())
 	}
-	opts242467, err := getV2R2OptionOrNil[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242467].Args)
+	opts242467, err := getV2R2OptionOrNil[rules.Options242467](ruleOptions[sharedrules.ID242467].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242467 error: %s", err.Error())
 	}

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r3_ruleset.go
@@ -70,15 +70,15 @@ func (r *Ruleset) validateV2R3RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args, fldPath.Index(ruleOptions[sharedrules.ID242390].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R3Options[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args, fldPath.Index(ruleOptions[sharedrules.ID242400].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R3Options[rules.Options242400](ruleOptions[sharedrules.ID242400].Args, fldPath.Index(ruleOptions[sharedrules.ID242400].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[disaoption.Options242414](ruleOptions[sharedrules.ID242414].Args, fldPath.Index(ruleOptions[sharedrules.ID242414].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[disaoption.Options242415](ruleOptions[sharedrules.ID242415].Args, fldPath.Index(ruleOptions[sharedrules.ID242415].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[disaoption.Options242442](ruleOptions[sharedrules.ID242442].Args, fldPath.Index(ruleOptions[sharedrules.ID242442].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[disaoption.FileOwnerOptions](ruleOptions[sharedrules.ID242445].Args, fldPath.Index(ruleOptions[sharedrules.ID242445].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[disaoption.FileOwnerOptions](ruleOptions[sharedrules.ID242446].Args, fldPath.Index(ruleOptions[sharedrules.ID242446].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[rules.Options242451](ruleOptions[sharedrules.ID242451].Args, fldPath.Index(ruleOptions[sharedrules.ID242451].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R3Options[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242466].Args, fldPath.Index(ruleOptions[sharedrules.ID242466].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R3Options[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242467].Args, fldPath.Index(ruleOptions[sharedrules.ID242467].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R3Options[rules.Options242466](ruleOptions[sharedrules.ID242466].Args, fldPath.Index(ruleOptions[sharedrules.ID242466].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R3Options[rules.Options242467](ruleOptions[sharedrules.ID242467].Args, fldPath.Index(ruleOptions[sharedrules.ID242467].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args, fldPath.Index(ruleOptions[sharedrules.ID245543].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options254800](ruleOptions[sharedrules.ID254800].Args, fldPath.Index(ruleOptions[sharedrules.ID254800].Index).Child("args"))...)
 
@@ -115,7 +115,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return fmt.Errorf("rule option 242390 error: %s", err.Error())
 	}
-	opts242400, err := getV2R3OptionOrNil[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242400].Args)
+	opts242400, err := getV2R3OptionOrNil[rules.Options242400](ruleOptions[sharedrules.ID242400].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242400 error: %s", err.Error())
 	}
@@ -143,11 +143,11 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return fmt.Errorf("rule option 242451 error: %s", err.Error())
 	}
-	opts242466, err := getV2R3OptionOrNil[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242466].Args)
+	opts242466, err := getV2R3OptionOrNil[rules.Options242466](ruleOptions[sharedrules.ID242466].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242466 error: %s", err.Error())
 	}
-	opts242467, err := getV2R3OptionOrNil[disaoption.KubeProxyOptions](ruleOptions[sharedrules.ID242467].Args)
+	opts242467, err := getV2R3OptionOrNil[rules.Options242467](ruleOptions[sharedrules.ID242467].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242467 error: %s", err.Error())
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -28,7 +28,8 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -270,8 +271,14 @@ var _ = Describe("#242400", func() {
 		Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
 
 		options := rules.Options242400{
-			KubeProxyMatchLabels: map[string]string{
-				"foo": "bar",
+			KubeProxy: disaoption.KubeProxyOptions{
+				ClusterObjectSelector: &option.ClusterObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
 			},
 		}
 
@@ -387,7 +394,7 @@ var _ = Describe("#242400", func() {
 		ruleResult, err := r.Run(ctx)
 
 		expectedCheckResults := []rule.CheckResult{
-			rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget("selector", "role=proxy")),
+			rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget()),
 			rule.PassedCheckResult("Option featureGates.AllAlpha not set.", rule.NewTarget("kind", "Node", "name", "node1")),
 		}
 
@@ -413,8 +420,8 @@ var _ = Describe("#242400", func() {
 			PodContext:   fakePodContext,
 			V1RESTClient: fakeRESTClient,
 			Options: &rules.Options242400{
-				KubeProxyOptions: option.KubeProxyOptions{
-					KubeProxyDisabled: true,
+				KubeProxy: disaoption.KubeProxyOptions{
+					Disabled: true,
 				},
 			},
 		}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
@@ -15,7 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/version"
@@ -47,16 +46,15 @@ type Rule242451 struct {
 }
 
 type Options242451 struct {
-	disaoption.KubeProxyOptions
-	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
-	NodeGroupByLabels    []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
+	KubeProxy         disaoption.KubeProxyOptions `json:"kubeProxy" yaml:"kubeProxy"`
+	NodeGroupByLabels []string                    `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 	*disaoption.FileOwnerOptions
 }
 
 var _ option.Option = (*Options242451)(nil)
 
 func (o Options242451) Validate(fldPath *field.Path) field.ErrorList {
-	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, fldPath.Child("kubeProxyMatchLabels"))
+	allErrs := o.KubeProxy.Validate(fldPath.Child("kubeProxy"))
 	allErrs = append(allErrs, disaoption.ValidateLabelNames(o.NodeGroupByLabels, fldPath.Child("nodeGroupByLabels"))...)
 	if o.FileOwnerOptions != nil {
 		return append(allErrs, o.FileOwnerOptions.Validate(fldPath)...)
@@ -78,22 +76,27 @@ func (r *Rule242451) Severity() rule.SeverityLevel {
 
 func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 	var (
-		checkResults      []rule.CheckResult
-		nodeLabels        []string
-		pods              []corev1.Pod
-		options           disaoption.FileOwnerOptions
-		kubeProxySelector = labels.SelectorFromSet(labels.Set{"role": "proxy"})
+		checkResults []rule.CheckResult
+		nodeLabels   []string
+		pods         []corev1.Pod
+		options      disaoption.FileOwnerOptions
 	)
 
 	if r.Options != nil {
 		if r.Options.FileOwnerOptions != nil {
 			options = *r.Options.FileOwnerOptions
 		}
-		if len(r.Options.KubeProxyMatchLabels) > 0 {
-			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
-		}
 		if r.Options.NodeGroupByLabels != nil {
 			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
+		}
+	} else {
+		r.Options = &Options242451{}
+	}
+	if r.Options.KubeProxy.ClusterObjectSelector == nil {
+		r.Options.KubeProxy.ClusterObjectSelector = &option.ClusterObjectSelector{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "proxy"},
+			},
 		}
 	}
 	if len(options.ExpectedFileOwner.Users) == 0 {
@@ -139,19 +142,22 @@ func (r *Rule242451) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	// kube-proxy check
-	if r.Options != nil && r.Options.KubeProxyDisabled {
+	if r.Options.KubeProxy.Disabled {
 		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()))
 		return rule.Result(r, checkResults...), nil
 	}
 
 	for _, p := range allPods {
-		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
+		if matches, err := r.Options.KubeProxy.Matches(p.Labels); err != nil {
+			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget()))
+			return rule.Result(r, checkResults...), nil
+		} else if matches {
 			pods = append(pods, p)
 		}
 	}
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget()))
 		return rule.Result(r, checkResults...), nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
@@ -15,7 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/version"
@@ -47,15 +46,14 @@ type Rule242466 struct {
 }
 
 type Options242466 struct {
-	disaoption.KubeProxyOptions
-	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
-	NodeGroupByLabels    []string          `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
+	KubeProxy         disaoption.KubeProxyOptions `json:"kubeProxy" yaml:"kubeProxy"`
+	NodeGroupByLabels []string                    `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
 var _ option.Option = (*Options242466)(nil)
 
 func (o Options242466) Validate(fldPath *field.Path) field.ErrorList {
-	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, fldPath.Child("kubeProxyMatchLabels"))
+	allErrs := o.KubeProxy.Validate(fldPath.Child("kubeProxy"))
 	return append(allErrs, disaoption.ValidateLabelNames(o.NodeGroupByLabels, fldPath.Child("nodeGroupByLabels"))...)
 }
 
@@ -77,15 +75,20 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 		nodeLabels                 []string
 		pods                       []corev1.Pod
 		expectedFilePermissionsMax = "644"
-		kubeProxySelector          = labels.SelectorFromSet(labels.Set{"role": "proxy"})
 	)
 
 	if r.Options != nil {
-		if len(r.Options.KubeProxyMatchLabels) > 0 {
-			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
-		}
 		if r.Options.NodeGroupByLabels != nil {
 			nodeLabels = slices.Clone(r.Options.NodeGroupByLabels)
+		}
+	} else {
+		r.Options = &Options242466{}
+	}
+	if r.Options.KubeProxy.ClusterObjectSelector == nil {
+		r.Options.KubeProxy.ClusterObjectSelector = &option.ClusterObjectSelector{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "proxy"},
+			},
 		}
 	}
 
@@ -125,19 +128,22 @@ func (r *Rule242466) Run(ctx context.Context) (rule.RuleResult, error) {
 	}
 
 	// kube-proxy check
-	if r.Options != nil && r.Options.KubeProxyDisabled {
+	if r.Options.KubeProxy.Disabled {
 		checkResults = append(checkResults, rule.AcceptedCheckResult("kube-proxy check is skipped.", rule.NewTarget()))
 		return rule.Result(r, checkResults...), nil
 	}
 
 	for _, p := range allPods {
-		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
+		if matches, err := r.Options.KubeProxy.Matches(p.Labels); err != nil {
+			checkResults = append(checkResults, rule.ErroredCheckResult(err.Error(), rule.NewTarget()))
+			return rule.Result(r, checkResults...), nil
+		} else if matches {
 			pods = append(pods, p)
 		}
 	}
 
 	if len(pods) == 0 {
-		checkResults = append(checkResults, rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())))
+		checkResults = append(checkResults, rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget()))
 		return rule.Result(r, checkResults...), nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -23,7 +22,8 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -171,8 +171,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		dikiPod2.Labels = map[string]string{}
 	})
 
-	It("should fail when etcd pods cannot be found", func() {
-		kubeProxySelector := labels.SelectorFromSet(labels.Set{"role": "proxy"})
+	It("should fail when kube-proxy pods cannot be found", func() {
 		fakePodContext = fakepod.NewFakeSimplePodContext([][]string{}, [][]error{})
 		r := &rules.Rule242467{
 			Logger:     testLogger,
@@ -184,7 +183,7 @@ tlsCertFile: /var/lib/certs/tls.crt`
 		ruleResult, err := r.Run(ctx)
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(ConsistOf([]rule.CheckResult{
-			rule.ErroredCheckResult("pods not found", rule.NewTarget("selector", kubeProxySelector.String())),
+			rule.ErroredCheckResult("kube-proxy pods not found", rule.NewTarget()),
 			rule.ErroredCheckResult("no allocatable nodes could be selected", rule.NewTarget()),
 		}))
 	})
@@ -238,8 +237,12 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should check only pod with matched labels",
 			rules.Options242467{
-				KubeProxyMatchLabels: map[string]string{
-					"component": "kube-proxy",
+				KubeProxy: disaoption.KubeProxyOptions{
+					ClusterObjectSelector: &option.ClusterObjectSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"component": "kube-proxy"},
+						},
+					},
 				},
 			},
 			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}, {mounts, compliantStats}},
@@ -251,8 +254,8 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			}),
 		Entry("should return accepted check result when kubeProxyDisabled option is set to true",
 			rules.Options242467{
-				KubeProxyOptions: option.KubeProxyOptions{
-					KubeProxyDisabled: true,
+				KubeProxy: disaoption.KubeProxyOptions{
+					Disabled: true,
 				},
 			},
 			[][]string{{kubeletPID, kubeletCommand, tlsKubeletConfig, compliantKeyStats}},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/options.go
@@ -5,7 +5,8 @@
 package rules
 
 import (
-	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -18,11 +19,10 @@ type RuleOption interface {
 		sharedrules.Options242404 |
 		sharedrules.Options242406 |
 		sharedrules.Options242407 |
-		option.Options242414 |
-		option.Options242415 |
+		disaoption.Options242414 |
+		disaoption.Options242415 |
 		sharedrules.Options242417 |
 		Options242442 |
-		sharedrules.Options242447 |
 		sharedrules.Options242448 |
 		sharedrules.Options242449 |
 		sharedrules.Options242450 |
@@ -30,5 +30,6 @@ type RuleOption interface {
 		sharedrules.Options242452 |
 		sharedrules.Options242453 |
 		Options242466 |
-		Options242467
+		Options242467 |
+		option.ClusterObjectSelector
 }

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -61,7 +61,7 @@ func (r *Ruleset) validateV2R2RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R2Options[disaoption.Options242415](ruleOptions[sharedrules.ID242415].Args, fldPath.Index(ruleOptions[sharedrules.ID242415].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options242417](ruleOptions[sharedrules.ID242417].Args, fldPath.Index(ruleOptions[sharedrules.ID242417].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[rules.Options242442](ruleOptions[sharedrules.ID242442].Args, fldPath.Index(ruleOptions[sharedrules.ID242442].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options242447](ruleOptions[sharedrules.ID242447].Args, fldPath.Index(ruleOptions[sharedrules.ID242447].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R2Options[option.ClusterObjectSelector](ruleOptions[sharedrules.ID242447].Args, fldPath.Index(ruleOptions[sharedrules.ID242447].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options242448](ruleOptions[sharedrules.ID242448].Args, fldPath.Index(ruleOptions[sharedrules.ID242448].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options242449](ruleOptions[sharedrules.ID242449].Args, fldPath.Index(ruleOptions[sharedrules.ID242449].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R2Options[sharedrules.Options242450](ruleOptions[sharedrules.ID242450].Args, fldPath.Index(ruleOptions[sharedrules.ID242450].Index).Child("args"))...)
@@ -144,7 +144,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return fmt.Errorf("rule option 242442 error: %s", err.Error())
 	}
-	opts242447, err := getV2R2OptionOrNil[sharedrules.Options242447](ruleOptions[sharedrules.ID242447].Args)
+	opts242447, err := getV2R2OptionOrNil[option.ClusterObjectSelector](ruleOptions[sharedrules.ID242447].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242447 error: %s", err.Error())
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -61,7 +61,7 @@ func (r *Ruleset) validateV2R3RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R3Options[disaoption.Options242415](ruleOptions[sharedrules.ID242415].Args, fldPath.Index(ruleOptions[sharedrules.ID242415].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options242417](ruleOptions[sharedrules.ID242417].Args, fldPath.Index(ruleOptions[sharedrules.ID242417].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[rules.Options242442](ruleOptions[sharedrules.ID242442].Args, fldPath.Index(ruleOptions[sharedrules.ID242442].Index).Child("args"))...)
-	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options242447](ruleOptions[sharedrules.ID242447].Args, fldPath.Index(ruleOptions[sharedrules.ID242447].Index).Child("args"))...)
+	allErrs = append(allErrs, validateV2R3Options[option.ClusterObjectSelector](ruleOptions[sharedrules.ID242447].Args, fldPath.Index(ruleOptions[sharedrules.ID242447].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options242448](ruleOptions[sharedrules.ID242448].Args, fldPath.Index(ruleOptions[sharedrules.ID242448].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options242449](ruleOptions[sharedrules.ID242449].Args, fldPath.Index(ruleOptions[sharedrules.ID242449].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R3Options[sharedrules.Options242450](ruleOptions[sharedrules.ID242450].Args, fldPath.Index(ruleOptions[sharedrules.ID242450].Index).Child("args"))...)
@@ -144,7 +144,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 	if err != nil {
 		return fmt.Errorf("rule option 242442 error: %s", err.Error())
 	}
-	opts242447, err := getV2R3OptionOrNil[sharedrules.Options242447](ruleOptions[sharedrules.ID242447].Args)
+	opts242447, err := getV2R3OptionOrNil[option.ClusterObjectSelector](ruleOptions[sharedrules.ID242447].Args)
 	if err != nil {
 		return fmt.Errorf("rule option 242447 error: %s", err.Error())
 	}

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -193,7 +193,30 @@ func ValidateLabelNames(labelNames []string, fldPath *field.Path) field.ErrorLis
 	return allErrs
 }
 
+// KubeProxyOptionsWithoutSelectors contains options for kube-proxy rules
+type KubeProxyOptionsWithoutSelectors struct {
+	Disabled bool `json:"disabled" yaml:"disabled"`
+}
+
+var _ option.Option = (*KubeProxyOptionsWithoutSelectors)(nil)
+
+// Validate validates that option configurations are correctly defined.
+func (o KubeProxyOptionsWithoutSelectors) Validate(_ *field.Path) field.ErrorList {
+	return nil
+}
+
 // KubeProxyOptions contains options for kube-proxy rules
 type KubeProxyOptions struct {
-	KubeProxyDisabled bool `json:"kubeProxyDisabled" yaml:"kubeProxyDisabled"`
+	*option.ClusterObjectSelector
+	Disabled bool `json:"disabled" yaml:"disabled"`
+}
+
+var _ option.Option = (*KubeProxyOptions)(nil)
+
+// Validate validates that option configurations are correctly defined.
+func (o KubeProxyOptions) Validate(fldPath *field.Path) field.ErrorList {
+	if o.ClusterObjectSelector != nil {
+		return o.ClusterObjectSelector.Validate(fldPath)
+	}
+	return nil
 }

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -8,8 +8,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	k8soption "github.com/gardener/diki/pkg/shared/kubernetes/option"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
@@ -267,6 +269,55 @@ var _ = Describe("options", func() {
 					"Detail": Equal("must not be empty"),
 				})),
 			))
+		})
+	})
+	Describe("#ValidateKubeProxyOptions", func() {
+		It("should validate correctly when ClusterObjectSelector is nil", func() {
+			options := option.KubeProxyOptions{}
+
+			result := options.Validate(field.NewPath("foo"))
+
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should fail when ClusterObjectSelector is not valid", func() {
+			options := option.KubeProxyOptions{
+				ClusterObjectSelector: &k8soption.ClusterObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+						},
+					},
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			}
+
+			result := options.Validate(field.NewPath("foo"))
+
+			Expect(result).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("foo.matchLabels"),
+					"Detail": Equal("cannot be set when labelSelector is defined"),
+				})),
+			))
+		})
+		It("should succeed when ClusterObjectSelector is valid", func() {
+			options := option.KubeProxyOptions{
+				ClusterObjectSelector: &k8soption.ClusterObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			}
+
+			result := options.Validate(field.NewPath("foo"))
+
+			Expect(result).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -14,7 +14,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/version"
@@ -45,14 +44,18 @@ type Rule242448 struct {
 }
 
 type Options242448 struct {
-	KubeProxyMatchLabels map[string]string `json:"kubeProxyMatchLabels" yaml:"kubeProxyMatchLabels"`
+	*option.ClusterObjectSelector
 	*disaoption.FileOwnerOptions
 }
 
 var _ option.Option = (*Options242448)(nil)
 
 func (o Options242448) Validate(fldPath *field.Path) field.ErrorList {
-	allErrs := validation.ValidateLabels(o.KubeProxyMatchLabels, fldPath.Child("kubeProxyMatchLabels"))
+	var allErrs field.ErrorList
+
+	if o.ClusterObjectSelector != nil {
+		allErrs = append(allErrs, o.ClusterObjectSelector.Validate(fldPath)...)
+	}
 	if o.FileOwnerOptions != nil {
 		return append(allErrs, o.FileOwnerOptions.Validate(fldPath)...)
 	}
@@ -75,7 +78,6 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 	var (
 		checkResults            []rule.CheckResult
 		options                 = disaoption.FileOwnerOptions{}
-		kubeProxySelector       = labels.SelectorFromSet(labels.Set{"role": "proxy"})
 		kubeProxyContainerNames = []string{"kube-proxy", "proxy"}
 	)
 
@@ -83,8 +85,14 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 		if r.Options.FileOwnerOptions != nil {
 			options = *r.Options.FileOwnerOptions
 		}
-		if len(r.Options.KubeProxyMatchLabels) > 0 {
-			kubeProxySelector = labels.SelectorFromSet(labels.Set(r.Options.KubeProxyMatchLabels))
+	} else {
+		r.Options = &Options242448{}
+	}
+	if r.Options.ClusterObjectSelector == nil {
+		r.Options.ClusterObjectSelector = &option.ClusterObjectSelector{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "proxy"},
+			},
 		}
 	}
 	if len(options.ExpectedFileOwner.Users) == 0 {
@@ -102,13 +110,15 @@ func (r *Rule242448) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	var pods []corev1.Pod
 	for _, p := range allPods {
-		if kubeProxySelector.Matches(labels.Set(p.Labels)) {
+		if matches, err := r.Options.Matches(p.Labels); err != nil {
+			return rule.Result(r, rule.ErroredCheckResult(err.Error(), target)), nil
+		} else if matches {
 			pods = append(pods, p)
 		}
 	}
 
 	if len(pods) == 0 {
-		return rule.Result(r, rule.ErroredCheckResult("kube-proxy pods not found", target.With("selector", kubeProxySelector.String()))), nil
+		return rule.Result(r, rule.ErroredCheckResult("kube-proxy pods not found", target)), nil
 	}
 
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind api-change
/kind enhancement

**What this PR does / why we need it**:
This PR changes the API of all DISA Kubernetes STIG rules regarding `kube-proxy` options. An example old kube-proxy options can be:
``` yaml
  - ruleID: "XXX"
    args:
      kubeProxyDisabled: true
      kubeProxyMatchLabels:
        foo: bar
```

The new options would look like:
``` yaml
  - ruleID: "XXX"
    args:
      kubeProxy:
        disabled: true
        labelSelector:
          matchLabels:
            foo: bar
```

Note: For rule `242447` and `242448` the `kube-proxy` options are directly composed into the options struct, since they rules are specifically regarding `kube-proxy`.
``` yaml
    - ruleID: "242447"
      args:
        labelSelector:
          matchLabels:
            foo: bar
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/514

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
DISA Kubernetes STIG rules 242400, 242442, 242447, 242448, 242451, 242466 and 242467 have their kube-proxy options changed and enhanced to use `labelSelectors`. Please check `example/config/gardener.yaml` and `example/config/managedk8s.yaml`.
```
