### PR TITLE
Do not error when CA files are missing

### DIFF
--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -93,10 +93,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
-	var (
-		insecureSkipTLSVerify bool
-		authorityCertPool     = x509.NewCertPool()
-	)
+	authorityCertPool := x509.NewCertPool()
 
 	switch {
 	case len(r.Config.CAData) > 0:
@@ -113,9 +110,6 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		if !ok {
 			return errors.New("failed to parse kube-apiserver CA data from config")
 		}
-	case r.Config.Insecure:
-		insecureSkipTLSVerify = true
-		authorityCertPool = nil
 	default:
 		authorityCertPool = nil
 	}
@@ -319,7 +313,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 					// the TLS MinVersion warnings are ignored in order to avoid version conflicts
 					TLSClientConfig: &tls.Config{ // #nosec: G402
 						RootCAs:            authorityCertPool,
-						InsecureSkipVerify: insecureSkipTLSVerify, // #nosec: G402
+						InsecureSkipVerify: r.Config.Insecure, // #nosec: G402
 					},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
@@ -90,8 +91,24 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
-	authorityCertPool := x509.NewCertPool()
-	authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
+	var (
+		insecureSkipTLSVerify bool
+		authorityCertPool     = x509.NewCertPool()
+	)
+
+	switch {
+	case len(r.Config.CAData) > 0:
+		authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
+	case len(r.Config.CAFile) > 0:
+		caFileData, err := os.ReadFile(r.Config.CAFile)
+		if err != nil {
+			return fmt.Errorf("failed to read CA file: %w", err)
+		}
+		authorityCertPool.AppendCertsFromPEM(caFileData)
+	default:
+		insecureSkipTLSVerify = true
+		authorityCertPool = nil
+	}
 
 	opts242383, err := getV2R2OptionOrNil[sharedrules.Options242383](ruleOptions[sharedrules.ID242383].Args)
 	if err != nil {
@@ -291,7 +308,8 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 				Transport: &http.Transport{
 					// the TLS MinVersion warnings are ignored in order to avoid version conflicts
 					TLSClientConfig: &tls.Config{ // #nosec: G402
-						RootCAs: authorityCertPool,
+						RootCAs:            authorityCertPool,
+						InsecureSkipVerify: insecureSkipTLSVerify,
 					},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
@@ -91,22 +92,21 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
-	var (
-		insecureSkipTLSVerify bool
-		authorityCertPool     = x509.NewCertPool()
-	)
+	var authorityCertPool = x509.NewCertPool()
 
 	switch {
 	case len(r.Config.CAData) > 0:
-		authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
+		ok := authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
+		if !ok {
+			return fmt.Errorf("failed to parse kube-apiserver CA data from config")
+		}
 	case len(r.Config.CAFile) > 0:
-		caFileData, err := os.ReadFile(r.Config.CAFile)
+		caFileData, err := os.ReadFile(filepath.Clean(r.Config.CAFile))
 		if err != nil {
 			return fmt.Errorf("failed to read CA file: %w", err)
 		}
 		authorityCertPool.AppendCertsFromPEM(caFileData)
 	default:
-		insecureSkipTLSVerify = true
 		authorityCertPool = nil
 	}
 
@@ -308,8 +308,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 				Transport: &http.Transport{
 					// the TLS MinVersion warnings are ignored in order to avoid version conflicts
 					TLSClientConfig: &tls.Config{ // #nosec: G402
-						RootCAs:            authorityCertPool,
-						InsecureSkipVerify: insecureSkipTLSVerify,
+						RootCAs: authorityCertPool,
 					},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -105,7 +105,10 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 		if err != nil {
 			return fmt.Errorf("failed to read CA file: %w", err)
 		}
-		authorityCertPool.AppendCertsFromPEM(caFileData)
+		ok := authorityCertPool.AppendCertsFromPEM(caFileData)
+		if !ok {
+			return fmt.Errorf("failed to parse kube-apiserver CA data from config")
+		}
 	default:
 		authorityCertPool = nil
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r2_ruleset.go
@@ -91,10 +91,7 @@ func (r *Ruleset) registerV2R2Rules(ruleOptions map[string]config.RuleOptionsCon
 	}
 
 	authorityCertPool := x509.NewCertPool()
-	ok := authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
-	if !ok {
-		return fmt.Errorf("failed to parse kube-apiserver CA data from config")
-	}
+	authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
 
 	opts242383, err := getV2R2OptionOrNil[sharedrules.Options242383](ruleOptions[sharedrules.ID242383].Args)
 	if err != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -93,10 +93,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
-	var (
-		insecureSkipTLSVerify bool
-		authorityCertPool     = x509.NewCertPool()
-	)
+	authorityCertPool := x509.NewCertPool()
 
 	switch {
 	case len(r.Config.CAData) > 0:
@@ -113,9 +110,6 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		if !ok {
 			return errors.New("failed to parse kube-apiserver CA data from config")
 		}
-	case r.Config.Insecure:
-		insecureSkipTLSVerify = true
-		authorityCertPool = nil
 	default:
 		authorityCertPool = nil
 	}
@@ -319,7 +313,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 					// the TLS MinVersion warnings are ignored in order to avoid version conflicts
 					TLSClientConfig: &tls.Config{ // #nosec: G402
 						RootCAs:            authorityCertPool,
-						InsecureSkipVerify: insecureSkipTLSVerify, // #nosec: G402
+						InsecureSkipVerify: r.Config.Insecure, // #nosec: G402
 					},
 				},
 			},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -105,7 +105,10 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		if err != nil {
 			return fmt.Errorf("failed to read CA file: %w", err)
 		}
-		authorityCertPool.AppendCertsFromPEM(caFileData)
+		ok := authorityCertPool.AppendCertsFromPEM(caFileData)
+		if !ok {
+			return fmt.Errorf("failed to parse kube-apiserver CA data from config")
+		}
 	default:
 		authorityCertPool = nil
 	}

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -91,10 +91,7 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 	}
 
 	authorityCertPool := x509.NewCertPool()
-	ok := authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
-	if !ok {
-		return fmt.Errorf("failed to parse kube-apiserver CA data from config")
-	}
+	authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
 
 	opts242383, err := getV2R3OptionOrNil[sharedrules.Options242383](ruleOptions[sharedrules.ID242383].Args)
 	if err != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r3_ruleset.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -92,13 +93,16 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		return err
 	}
 
-	var authorityCertPool = x509.NewCertPool()
+	var (
+		insecureSkipTLSVerify bool
+		authorityCertPool     = x509.NewCertPool()
+	)
 
 	switch {
 	case len(r.Config.CAData) > 0:
 		ok := authorityCertPool.AppendCertsFromPEM(r.Config.CAData)
 		if !ok {
-			return fmt.Errorf("failed to parse kube-apiserver CA data from config")
+			return errors.New("failed to parse kube-apiserver CA data from config")
 		}
 	case len(r.Config.CAFile) > 0:
 		caFileData, err := os.ReadFile(filepath.Clean(r.Config.CAFile))
@@ -107,8 +111,11 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 		}
 		ok := authorityCertPool.AppendCertsFromPEM(caFileData)
 		if !ok {
-			return fmt.Errorf("failed to parse kube-apiserver CA data from config")
+			return errors.New("failed to parse kube-apiserver CA data from config")
 		}
+	case r.Config.Insecure:
+		insecureSkipTLSVerify = true
+		authorityCertPool = nil
 	default:
 		authorityCertPool = nil
 	}
@@ -311,7 +318,8 @@ func (r *Ruleset) registerV2R3Rules(ruleOptions map[string]config.RuleOptionsCon
 				Transport: &http.Transport{
 					// the TLS MinVersion warnings are ignored in order to avoid version conflicts
 					TLSClientConfig: &tls.Config{ // #nosec: G402
-						RootCAs: authorityCertPool,
+						RootCAs:            authorityCertPool,
+						InsecureSkipVerify: insecureSkipTLSVerify, // #nosec: G402
 					},
 				},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This PR improves the DISA K8s STIG ruleset for the `managedk8s` provider to no longer error when CA cannot be found from the provided kubeconfig. Now if a CA is not provided the rules will run.

**Which issue(s) this PR fixes**:
Fixes #599

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing the DISA K8s STIG ruleset for the `managedk8s` provider to error when the provided kubeconfig does not contain CA Data has been fixed.
```

```bugfix user
A bug causing the DISA K8s STIG rule 242390 for the `managedk8s` provider to error when the provided kubeconfig uses a CA file or has insecure skip tls verify has been fixed.
```