### PR TITLE
Fix a bug regarding the unmarshalling of a Diki run configuration

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -557,23 +557,23 @@ type diffOptions struct {
 	title     string
 }
 
-func readConfig(filePath string) (config.DikiConfig, error) {
+func readConfig(filePath string) (*config.DikiConfig, error) {
 	data, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
-		return config.DikiConfig{}, err
+		return nil, err
 	}
 
-	c := config.DikiConfig{}
+	c := &config.DikiConfig{}
 	err = yaml.Unmarshal(data, c)
 
 	if err != nil {
-		return config.DikiConfig{}, err
+		return nil, err
 	}
 
 	return c, nil
 }
 
-func getProvidersFromConfig(c config.DikiConfig, providerCreateFuncs map[string]provider.ProviderFromConfigFunc) (map[string]provider.Provider, error) {
+func getProvidersFromConfig(c *config.DikiConfig, providerCreateFuncs map[string]provider.ProviderFromConfigFunc) (map[string]provider.Provider, error) {
 	providers := map[string]provider.Provider{}
 	rootPath := field.NewPath("providers")
 
@@ -595,23 +595,23 @@ func getProvidersFromConfig(c config.DikiConfig, providerCreateFuncs map[string]
 	return providers, nil
 }
 
-func getDikiConfig(opts runOptions, defaultConfigFuncs map[string]provider.DefaultDikiConfigFunc) (config.DikiConfig, error) {
+func getDikiConfig(opts runOptions, defaultConfigFuncs map[string]provider.DefaultDikiConfigFunc) (*config.DikiConfig, error) {
 	if len(opts.configFile) != 0 {
 		return readConfig(opts.configFile)
 	}
 
 	if len(opts.provider) == 0 {
-		return config.DikiConfig{}, fmt.Errorf("--provider must be set when --config is omitted")
+		return nil, fmt.Errorf("--provider must be set when --config is omitted")
 	}
 
 	if defaultFunc, ok := defaultConfigFuncs[opts.provider]; !ok {
-		return config.DikiConfig{}, fmt.Errorf("unknown provider: %s", opts.provider)
+		return nil, fmt.Errorf("unknown provider: %s", opts.provider)
 	} else {
 		if defaultFunc == nil {
-			return config.DikiConfig{}, fmt.Errorf("provider %s cannot resolve to a default configuration, it must be specified with the --config flag", opts.provider)
+			return nil, fmt.Errorf("provider %s cannot resolve to a default configuration, it must be specified with the --config flag", opts.provider)
 		}
 
 		dikiConfig := defaultFunc()
-		return dikiConfig, nil
+		return &dikiConfig, nil
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

With #620, functions using `config.DikiConfig` were converted to non-pointer values. However, this change has caused the umarshalling of a run configuration, read from a file to fail,
https://github.com/gardener/diki/blob/cac4b36debbbf53204e48bb90573a46f13b080d0/cmd/diki/app/app.go#L566-L567
since unmarshalling of non-pointer values returns the followng error message: 
```
reflect.Value.Set using unaddressable value [recovered, repanicked]
```

This PR fixes this bug.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
```
