### PR TITLE
Fix `nil` pointer error for rule 1001 from Security Hardened Shoot Cluster guide 

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -113,8 +113,10 @@ func (r *Rule1001) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.Result(r, rule.ErroredCheckResult("kubernetes version not found in cloudProfile", target)), nil
 	}
 
-	if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Spec.Kubernetes.Versions, target); found {
-		return rule.Result(r, checkResult), nil
+	if namespacedCloudProfile.Spec.Kubernetes != nil {
+		if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Spec.Kubernetes.Versions, target); found {
+			return rule.Result(r, checkResult), nil
+		}
 	}
 	if checkResult, found := r.checkShootVersion(shoot.Spec.Kubernetes.Version, namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions, target); found {
 		return rule.Result(r, checkResult), nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #624

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing Rule 1001 from Security Hardened Shoot Cluster guide to panic when target `NamespacedCloudProfile` has `.spec.kubernetes` field equal to `nil` was fixed.
```
