### PR TITLE
Migrate to a maintained `yaml` package

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/version"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/spf13/cobra v1.10.1
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.2
 	k8s.io/api v0.33.5
 	k8s.io/apimachinery v0.33.5
 	k8s.io/apiserver v0.33.5
@@ -181,6 +181,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.18.6 // indirect
 	istio.io/api v1.27.3 // indirect
 	istio.io/client-go v1.27.2 // indirect

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -17,7 +17,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -13,7 +13,7 @@ import (
 	"slices"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/gardener/diki/pkg/rule"
 )

--- a/pkg/shared/ruleset/disak8sstig/rules/242379.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242379.go
@@ -7,7 +7,7 @@ package rules
 import (
 	"context"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/242380.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242380.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"slices"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/pkg/shared/ruleset/disak8sstig/rules/242403.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242403.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"

--- a/pkg/shared/ruleset/disak8sstig/rules/242423.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242423.go
@@ -7,7 +7,7 @@ package rules
 import (
 	"context"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/242426.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242426.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/242427.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242427.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/242428.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242428.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/242432.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242432.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/242433.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242433.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/shared/ruleset/disak8sstig/rules/274882.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/274882.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"slices"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The currently used yaml package `gopkg.in/yaml.v3` is [no longer maintained](https://github.com/go-yaml/yaml?tab=readme-ov-file#this-project-is-unmaintained).

This PR migrates to the [go/go-yaml](https://github.com/yaml/go-yaml) package which is a fork of [go-yaml/yaml](https://github.com/go-yaml/yaml/) and is [officially supported](https://github.com/yaml/go-yaml?tab=readme-ov-file#project-status) by the [YAML organization](https://github.com/yaml/) package.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Replace unmaintained `yaml` package `gopkg.in/yaml.v3` with `go.yaml.in/yaml/v4".
```
