### PR TITLE
Refactor the Renovate bot's configuration to reflect current pipeline defintions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,8 @@
         "^\.github\/actions\/prepare-release\/action\.yaml$",
       ],
       "matchStrings": [
-        "go-version: '(?<currentValue>.*?)'\\s",],
+        "go-version: '(?<currentValue>.*?)'\\s",
+      ],
       "depNameTemplate": "golang",
       "datasourceTemplate": "docker"
     },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The Renovate bot currently is detecting non-existent files, which were previously used in Diki's building and publishing pipelines. The files in question were removed with the following PRs: #524 and #563.

This PR updates the `renovate.json5` configuration to detect the new pipeline definitions.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The Renovate bot's configuration file has been updated to match the current pipeline definitions.
```
