### PR TITLE
GHA: target build stage name for images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,6 +100,7 @@ jobs:
       matrix:
         args:
           - name: diki # the image used to run diki
+            target: diki
             oci-repository: gardener/diki
             ocm-labels:
               name: gardener.cloud/cve-categorisation
@@ -112,6 +113,7 @@ jobs:
                 availability_requirement: none
           - name: diki-ops # used for the privileged pods created by diki on evaluated clusters.
                            # minimised image mainly used to run `chroot`, `nerdctl`
+            target: diki-ops
             oci-repository: gardener/diki-ops
             ocm-labels:
               name: gardener.cloud/cve-categorisation


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Target correct build name for diki images in GHA.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing GitHub Actions to incorrectly target `diki-ops` builder for `diki` images was fixed. Affected version with misnamed images are: `v0.19.x`, `v0.20.x`, `v0.21.x` and `v0.22.x`.
```
