### PR TITLE
Update Diki's documentation to include support for DISA STIG's version V2R5

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ diki run \
     --config=config.yaml \
     --provider=gardener \
     --ruleset-id=disa-kubernetes-stig \
-    --ruleset-version=v2r4
+    --ruleset-version=v2r5
 ```
 
 - Run a specific rule defined in a ruleset for a known provider
@@ -106,7 +106,7 @@ diki run \
     --config=config.yaml \
     --provider=gardener \
     --ruleset-id=disa-kubernetes-stig \
-    --ruleset-version=v2r4 \
+    --ruleset-version=v2r5 \
     --rule-id=242414
 ```
 

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -15,7 +15,7 @@ providers:             # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r4
+    version: v2r5
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -11,7 +11,7 @@ providers:                   # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r4
+    version: v2r5
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1
     ruleOptions:

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -10,7 +10,7 @@ providers:               # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r4
+    version: v2r5
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:

--- a/example/guides/disa-k8s-stig-shoot.yaml
+++ b/example/guides/disa-k8s-stig-shoot.yaml
@@ -9,7 +9,7 @@ providers:
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r4
+    version: v2r5
     ruleOptions:
     - ruleID: "242393"
       args:

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -9,7 +9,7 @@ set -e
 rule_id=""
 provider="gardener"
 ruleset_id="disa-kubernetes-stig"
-ruleset_version="v2r4"
+ruleset_version="v2r5"
 run_all="false"
 
 
@@ -29,7 +29,7 @@ This command runs diki with a specified config file.
                       specified ruleset are executed.
     --provider        Ruleset provider. Defaults to "gardener".
     --ruleset-id      ID of ruleset that will be ran. Defaults to "disa-kubernetes-stig".
-    --ruleset-version Version of ruleset that will be ran. Defaults to "v2r4".
+    --ruleset-version Version of ruleset that will be ran. Defaults to "v2r5".
     
   environment variables:
     IMAGEVECTOR_OVERWRITE Overwrites diki/imagesvector/images.yaml file with specified file path.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates Diki's documentation and configuration files to use version V2R5 of the DISA STIG ruleset.

**Which issue(s) this PR fixes**:
Part of #680

**Special notes for your reviewer**:
This PR should be merged after #681 is merged and [version 0.25.0 of Diki has been released](https://github.com/gardener/diki/releases).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Diki's documentation and configuration files now use version V2R5 of the DISA STIG ruleset.
```
