### PR TITLE
[Security Hardened Kubernetes] Add retry period to Rule 2000

### DIFF
--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -27,14 +27,20 @@ var (
 	_ option.Option = &Options2000{}
 )
 
-// TimeNow and TimeSleep are package-level variables to allow overriding in tests.
 var (
-	TimeNow   = time.Now
-	TimeSleep = time.Sleep
+	timeNow   = time.Now
+	timeSleep = func(ctx context.Context, d time.Duration) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(d):
+			return nil
+		}
+	}
 )
 
 const (
-	youngNamespaceThreshold = 5 * time.Minute
+	youngNamespaceThreshold = 1 * time.Minute
 	maxRetries              = 3
 	retryBaseInterval       = 10 * time.Second
 )
@@ -104,7 +110,9 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 
 	for retry := range maxRetries {
 		// Sleep for an incremented interval
-		TimeSleep(retryBaseInterval * time.Duration(retry+1))
+		if err := timeSleep(ctx, retryBaseInterval*time.Duration(retry+1)); err != nil {
+			return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), nil
+		}
 
 		groupedNetworkPolicies, err = r.getGroupedNetworkPolicies(ctx)
 		if err != nil {
@@ -128,7 +136,7 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 }
 
 // checkNamespaces evaluates network policies for the given namespaces. When retryYoung is true,
-// namespaces created within the last 5 minutes that fail checks are excluded from checkResults
+// namespaces created within the last 1 minute that fail checks are excluded from checkResults
 // and returned separately for a retry. When retryYoung is false, all results are included.
 func (r *Rule2000) checkNamespaces(ctx context.Context, namespaces []corev1.Namespace, groupedNetworkPolicies map[string][]networkingv1.NetworkPolicy, retryYoung bool) ([]rule.CheckResult, []corev1.Namespace) {
 	const (
@@ -141,7 +149,7 @@ func (r *Rule2000) checkNamespaces(ctx context.Context, namespaces []corev1.Name
 	var (
 		checkResults          []rule.CheckResult
 		youngFailedNamespaces []corev1.Namespace
-		now                   = TimeNow()
+		now                   = timeNow()
 	)
 
 	for _, namespace := range namespaces {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -7,10 +7,13 @@ package rules
 import (
 	"context"
 	"slices"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
@@ -21,6 +24,18 @@ import (
 var (
 	_ rule.Rule     = &Rule2000{}
 	_ rule.Severity = &Rule2000{}
+	_ option.Option = &Options2000{}
+)
+
+// TimeNow and TimeSleep are package-level variables to allow overriding in tests.
+var (
+	TimeNow   = time.Now
+	TimeSleep = time.Sleep
+)
+
+const (
+	youngNamespaceThreshold = 5 * time.Minute
+	retryBackoff            = 1 * time.Minute
 )
 
 type Rule2000 struct {
@@ -35,6 +50,18 @@ type Options2000 struct {
 type AcceptedNamespaces2000 struct {
 	option.AcceptedClusterObject
 	AcceptedTraffic AcceptedTraffic `json:"acceptedTraffic" yaml:"acceptedTraffic"`
+}
+
+// Validate validates that option configurations are correctly defined.
+func (o Options2000) Validate(fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	acceptedNamespacesPath := fldPath.Child("acceptedNamespaces")
+	for nIdx, n := range o.AcceptedNamespaces {
+		allErrs = append(allErrs, n.Validate(acceptedNamespacesPath.Index(nIdx))...)
+	}
+
+	return allErrs
 }
 
 type AcceptedTraffic struct {
@@ -55,6 +82,43 @@ func (r *Rule2000) Severity() rule.SeverityLevel {
 }
 
 func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
+	namespacesMap, err := kubeutils.GetNamespaces(ctx, r.Client)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NamespaceList"))), nil
+	}
+	namespaces := make([]corev1.Namespace, 0, len(namespacesMap))
+	for _, ns := range namespacesMap {
+		namespaces = append(namespaces, ns)
+	}
+
+	groupedNetworkPolicies, err := r.getGroupedNetworkPolicies(ctx)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NetworkPolicyList"))), nil
+	}
+
+	checkResults, youngFailedNamespaces := r.checkNamespaces(ctx, namespaces, groupedNetworkPolicies, true)
+	if len(youngFailedNamespaces) == 0 {
+		return rule.Result(r, checkResults...), nil
+	}
+
+	// Backoff and retry for recently created namespaces that failed.
+	TimeSleep(retryBackoff)
+
+	groupedNetworkPolicies, err = r.getGroupedNetworkPolicies(ctx)
+	if err != nil {
+		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NetworkPolicyList"))), nil
+	}
+
+	retryResults, _ := r.checkNamespaces(ctx, youngFailedNamespaces, groupedNetworkPolicies, false)
+	checkResults = append(checkResults, retryResults...)
+
+	return rule.Result(r, checkResults...), nil
+}
+
+// checkNamespaces evaluates network policies for the given namespaces. When retryYoung is true,
+// namespaces created within the last 5 minutes that fail checks are excluded from checkResults
+// and returned separately for a retry. When retryYoung is false, all results are included.
+func (r *Rule2000) checkNamespaces(ctx context.Context, namespaces []corev1.Namespace, groupedNetworkPolicies map[string][]networkingv1.NetworkPolicy, retryYoung bool) ([]rule.CheckResult, []corev1.Namespace) {
 	const (
 		namespaceDeletionWithoutPodsDetails = "namespace is marked for deletion without any present pods"
 		namespaceDeletionWithPodsDetails    = "namespace is marked for deletion with present pods"
@@ -62,26 +126,13 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 		egressTrafficNotDeniedMessage       = "Egress traffic is not denied by default."
 	)
 
-	networkPolicies, err := kubeutils.GetNetworkPolicies(ctx, r.Client, "", labels.NewSelector(), 300)
-	if err != nil {
-		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "ServiceList"))), nil
-	}
-
-	namespaces, err := kubeutils.GetNamespaces(ctx, r.Client)
-	if err != nil {
-		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NamespaceList"))), nil
-	}
-
-	groupedNetworkPolicies := map[string][]networkingv1.NetworkPolicy{}
-
-	for _, np := range networkPolicies {
-		groupedNetworkPolicies[np.Namespace] = append(groupedNetworkPolicies[np.Namespace], np)
-	}
-
-	var checkResults []rule.CheckResult
+	var (
+		checkResults          []rule.CheckResult
+		youngFailedNamespaces []corev1.Namespace
+		now                   = TimeNow()
+	)
 
 	for _, namespace := range namespaces {
-
 		var (
 			deniesAllIngress, deniesAllEgress bool
 			allowsAllIngress, allowsAllEgress bool
@@ -90,6 +141,8 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 			deniesAllEgressTarget             = target
 			allowsAllIngressTarget            = target
 			allowsAllEgressTarget             = target
+			nsCheckResults                    []rule.CheckResult
+			nsFailed                          bool
 		)
 
 		for _, networkPolicy := range groupedNetworkPolicies[namespace.Name] {
@@ -130,11 +183,11 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 		}
 
 		if deniesAllIngress && !allowsAllIngress {
-			checkResults = append(checkResults, rule.PassedCheckResult("Ingress traffic is denied by default.", deniesAllIngressTarget))
+			nsCheckResults = append(nsCheckResults, rule.PassedCheckResult("Ingress traffic is denied by default.", deniesAllIngressTarget))
 		} else {
 			accepted, justification, err := r.acceptedIngress(namespace.Labels)
 			if err != nil {
-				return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), nil
+				return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), rule.NewTarget())}, nil
 			}
 
 			acceptedTarget := target
@@ -149,31 +202,32 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 
 			switch {
 			case accepted:
-				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, acceptedTarget))
+				nsCheckResults = append(nsCheckResults, rule.AcceptedCheckResult(msg, acceptedTarget))
 			case allowsAllIngress:
-				checkResults = append(checkResults, rule.FailedCheckResult("All Ingress traffic is allowed by default.", allowsAllIngressTarget))
+				nsCheckResults = append(nsCheckResults, rule.FailedCheckResult("All Ingress traffic is allowed by default.", allowsAllIngressTarget))
 			case namespace.DeletionTimestamp == nil:
-				checkResults = append(checkResults, rule.FailedCheckResult(ingressTrafficNotDeniedMessage, target))
+				nsCheckResults = append(nsCheckResults, rule.FailedCheckResult(ingressTrafficNotDeniedMessage, target))
+				nsFailed = true
 			default:
 				pods, err := kubeutils.GetPods(ctx, r.Client, namespace.Name, labels.NewSelector(), 300)
 				if err != nil {
-					return rule.Result(r, rule.ErroredCheckResult(err.Error(), target)), nil
+					return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), target)}, nil
 				}
 
 				if len(pods) > 0 {
-					checkResults = append(checkResults, rule.FailedCheckResult(ingressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithPodsDetails)))
+					nsCheckResults = append(nsCheckResults, rule.FailedCheckResult(ingressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithPodsDetails)))
 				} else {
-					checkResults = append(checkResults, rule.WarningCheckResult(ingressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithoutPodsDetails)))
+					nsCheckResults = append(nsCheckResults, rule.WarningCheckResult(ingressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithoutPodsDetails)))
 				}
 			}
 		}
 
 		if deniesAllEgress && !allowsAllEgress {
-			checkResults = append(checkResults, rule.PassedCheckResult("Egress traffic is denied by default.", deniesAllEgressTarget))
+			nsCheckResults = append(nsCheckResults, rule.PassedCheckResult("Egress traffic is denied by default.", deniesAllEgressTarget))
 		} else {
 			accepted, justification, err := r.acceptedEgress(namespace.Labels)
 			if err != nil {
-				return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget())), nil
+				return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), rule.NewTarget())}, nil
 			}
 
 			acceptedTarget := target
@@ -188,27 +242,34 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 
 			switch {
 			case accepted:
-				checkResults = append(checkResults, rule.AcceptedCheckResult(msg, acceptedTarget))
+				nsCheckResults = append(nsCheckResults, rule.AcceptedCheckResult(msg, acceptedTarget))
 			case allowsAllEgress:
-				checkResults = append(checkResults, rule.FailedCheckResult("All Egress traffic is allowed by default.", allowsAllEgressTarget))
+				nsCheckResults = append(nsCheckResults, rule.FailedCheckResult("All Egress traffic is allowed by default.", allowsAllEgressTarget))
 			case namespace.DeletionTimestamp == nil:
-				checkResults = append(checkResults, rule.FailedCheckResult(egressTrafficNotDeniedMessage, target))
+				nsCheckResults = append(nsCheckResults, rule.FailedCheckResult(egressTrafficNotDeniedMessage, target))
+				nsFailed = true
 			default:
 				pods, err := kubeutils.GetPods(ctx, r.Client, namespace.Name, labels.NewSelector(), 300)
 				if err != nil {
-					return rule.Result(r, rule.ErroredCheckResult(err.Error(), target)), nil
+					return []rule.CheckResult{rule.ErroredCheckResult(err.Error(), target)}, nil
 				}
 
 				if len(pods) > 0 {
-					checkResults = append(checkResults, rule.FailedCheckResult(egressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithPodsDetails)))
+					nsCheckResults = append(nsCheckResults, rule.FailedCheckResult(egressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithPodsDetails)))
 				} else {
-					checkResults = append(checkResults, rule.WarningCheckResult(egressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithoutPodsDetails)))
+					nsCheckResults = append(nsCheckResults, rule.WarningCheckResult(egressTrafficNotDeniedMessage, target.With("details", namespaceDeletionWithoutPodsDetails)))
 				}
 			}
 		}
+
+		if retryYoung && nsFailed && now.Sub(namespace.CreationTimestamp.Time) < youngNamespaceThreshold {
+			youngFailedNamespaces = append(youngFailedNamespaces, namespace)
+		} else {
+			checkResults = append(checkResults, nsCheckResults...)
+		}
 	}
 
-	return rule.Result(r, checkResults...), nil
+	return checkResults, youngFailedNamespaces
 }
 
 func (r *Rule2000) acceptedIngress(namespaceLabels map[string]string) (bool, string, error) {
@@ -241,4 +302,18 @@ func (r *Rule2000) acceptedEgress(namespaceLabels map[string]string) (bool, stri
 	}
 
 	return false, "", nil
+}
+
+func (r *Rule2000) getGroupedNetworkPolicies(ctx context.Context) (map[string][]networkingv1.NetworkPolicy, error) {
+	networkPolicies, err := kubeutils.GetNetworkPolicies(ctx, r.Client, "", labels.NewSelector(), 300)
+	if err != nil {
+		return nil, err
+	}
+
+	groupedNetworkPolicies := map[string][]networkingv1.NetworkPolicy{}
+	for _, np := range networkPolicies {
+		groupedNetworkPolicies[np.Namespace] = append(groupedNetworkPolicies[np.Namespace], np)
+	}
+
+	return groupedNetworkPolicies, nil
 }

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -35,7 +35,8 @@ var (
 
 const (
 	youngNamespaceThreshold = 5 * time.Minute
-	retryBackoff            = 1 * time.Minute
+	maxRetries              = 3
+	retryBaseInterval       = 10 * time.Second
 )
 
 type Rule2000 struct {
@@ -101,16 +102,27 @@ func (r *Rule2000) Run(ctx context.Context) (rule.RuleResult, error) {
 		return rule.Result(r, checkResults...), nil
 	}
 
-	// Backoff and retry for recently created namespaces that failed.
-	TimeSleep(retryBackoff)
+	for retry := range maxRetries {
+		// Sleep for an incremented interval
+		TimeSleep(retryBaseInterval * time.Duration(retry+1))
 
-	groupedNetworkPolicies, err = r.getGroupedNetworkPolicies(ctx)
-	if err != nil {
-		return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NetworkPolicyList"))), nil
+		groupedNetworkPolicies, err = r.getGroupedNetworkPolicies(ctx)
+		if err != nil {
+			return rule.Result(r, rule.ErroredCheckResult(err.Error(), rule.NewTarget("kind", "NetworkPolicyList"))), nil
+		}
+
+		if retry < maxRetries-1 {
+			var retryResults []rule.CheckResult
+			retryResults, youngFailedNamespaces = r.checkNamespaces(ctx, youngFailedNamespaces, groupedNetworkPolicies, true)
+			checkResults = append(checkResults, retryResults...)
+			if len(youngFailedNamespaces) == 0 {
+				break
+			}
+		} else {
+			retryResults, _ := r.checkNamespaces(ctx, youngFailedNamespaces, groupedNetworkPolicies, false)
+			checkResults = append(checkResults, retryResults...)
+		}
 	}
-
-	retryResults, _ := r.checkNamespaces(ctx, youngFailedNamespaces, groupedNetworkPolicies, false)
-	checkResults = append(checkResults, retryResults...)
 
 	return rule.Result(r, checkResults...), nil
 }

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -883,4 +883,190 @@ var _ = Describe("#2000", func() {
 			}))
 		})
 	})
+
+	Context("test backoff retry for recently created namespaces", func() {
+		var (
+			originalTimeSleep func(time.Duration)
+			originalTimeNow   func() time.Time
+			fakeNow           time.Time
+		)
+
+		BeforeEach(func() {
+			originalTimeSleep = rules.TimeSleep
+			originalTimeNow = rules.TimeNow
+			fakeNow = time.Now()
+			rules.TimeNow = func() time.Time { return fakeNow }
+			rules.TimeSleep = func(_ time.Duration) {}
+			client = fakeclient.NewClientBuilder().Build()
+		})
+
+		AfterEach(func() {
+			rules.TimeSleep = originalTimeSleep
+			rules.TimeNow = originalTimeNow
+		})
+
+		It("should retry and pass when network policy is added before retry", func() {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "young-ns",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Minute)},
+				},
+			}
+			Expect(client.Create(ctx, namespace)).To(Succeed())
+
+			// Override TimeSleep to create the policy during the backoff.
+			rules.TimeSleep = func(_ time.Duration) {
+				denyAll := &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deny-all",
+						Namespace: "young-ns",
+					},
+					Spec: networkingv1.NetworkPolicySpec{
+						PolicyTypes: []networkingv1.PolicyType{
+							networkingv1.PolicyTypeIngress,
+							networkingv1.PolicyTypeEgress,
+						},
+					},
+				}
+				Expect(client.Create(ctx, denyAll)).To(Succeed())
+			}
+
+			r := &rules.Rule2000{Client: client}
+			ruleResult, err := r.Run(ctx)
+			Expect(err).To(BeNil())
+
+			Expect(ruleResult.CheckResults).To(ConsistOf(
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Ingress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns", "kind", "NetworkPolicy", "name", "deny-all"),
+				},
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Egress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns", "kind", "NetworkPolicy", "name", "deny-all"),
+				},
+			))
+		})
+
+		It("should retry and still fail when no network policy is added", func() {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "young-ns",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Minute)},
+				},
+			}
+			Expect(client.Create(ctx, namespace)).To(Succeed())
+
+			r := &rules.Rule2000{Client: client}
+			ruleResult, err := r.Run(ctx)
+			Expect(err).To(BeNil())
+
+			Expect(ruleResult.CheckResults).To(ConsistOf(
+				rule.CheckResult{
+					Status:  rule.Failed,
+					Message: "Ingress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns"),
+				},
+				rule.CheckResult{
+					Status:  rule.Failed,
+					Message: "Egress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns"),
+				},
+			))
+		})
+
+		It("should not retry old namespaces", func() {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-ns",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Hour)},
+				},
+			}
+			Expect(client.Create(ctx, namespace)).To(Succeed())
+
+			sleepCalled := false
+			rules.TimeSleep = func(_ time.Duration) {
+				sleepCalled = true
+			}
+
+			r := &rules.Rule2000{Client: client}
+			ruleResult, err := r.Run(ctx)
+			Expect(err).To(BeNil())
+			Expect(sleepCalled).To(BeFalse())
+
+			Expect(ruleResult.CheckResults).To(Equal([]rule.CheckResult{
+				{
+					Status:  rule.Failed,
+					Message: "Ingress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "old-ns"),
+				},
+				{
+					Status:  rule.Failed,
+					Message: "Egress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "old-ns"),
+				},
+			}))
+		})
+
+		It("should only retry young namespaces and keep results for old namespaces", func() {
+			oldNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-ns",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Hour)},
+				},
+			}
+			youngNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "young-ns",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Minute)},
+				},
+			}
+			Expect(client.Create(ctx, oldNs)).To(Succeed())
+			Expect(client.Create(ctx, youngNs)).To(Succeed())
+
+			rules.TimeSleep = func(_ time.Duration) {
+				denyAll := &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deny-all",
+						Namespace: "young-ns",
+					},
+					Spec: networkingv1.NetworkPolicySpec{
+						PolicyTypes: []networkingv1.PolicyType{
+							networkingv1.PolicyTypeIngress,
+							networkingv1.PolicyTypeEgress,
+						},
+					},
+				}
+				Expect(client.Create(ctx, denyAll)).To(Succeed())
+			}
+
+			r := &rules.Rule2000{Client: client}
+			ruleResult, err := r.Run(ctx)
+			Expect(err).To(BeNil())
+
+			Expect(ruleResult.CheckResults).To(ConsistOf(
+				rule.CheckResult{
+					Status:  rule.Failed,
+					Message: "Ingress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "old-ns"),
+				},
+				rule.CheckResult{
+					Status:  rule.Failed,
+					Message: "Egress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "old-ns"),
+				},
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Ingress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns", "kind", "NetworkPolicy", "name", "deny-all"),
+				},
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Egress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns", "kind", "NetworkPolicy", "name", "deny-all"),
+				},
+			))
+		})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -909,7 +909,7 @@ var _ = Describe("#2000", func() {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "young-ns",
-					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Minute)},
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-30 * time.Second)},
 				},
 			}
 			Expect(client.Create(ctx, namespace)).To(Succeed())
@@ -954,7 +954,7 @@ var _ = Describe("#2000", func() {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "young-ns",
-					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Minute)},
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-30 * time.Second)},
 				},
 			}
 			Expect(client.Create(ctx, namespace)).To(Succeed())
@@ -1021,7 +1021,7 @@ var _ = Describe("#2000", func() {
 			youngNs := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "young-ns",
-					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Minute)},
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-30 * time.Second)},
 				},
 			}
 			Expect(client.Create(ctx, oldNs)).To(Succeed())

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -1041,6 +1041,19 @@ var _ = Describe("#2000", func() {
 					},
 				}
 				Expect(client.Create(ctx, denyAll)).To(Succeed())
+				oldDenyAll := &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deny-all",
+						Namespace: "old-ns",
+					},
+					Spec: networkingv1.NetworkPolicySpec{
+						PolicyTypes: []networkingv1.PolicyType{
+							networkingv1.PolicyTypeIngress,
+							networkingv1.PolicyTypeEgress,
+						},
+					},
+				}
+				Expect(client.Create(ctx, oldDenyAll)).To(Succeed())
 				return nil
 			})
 
@@ -1070,6 +1083,105 @@ var _ = Describe("#2000", func() {
 					Target:  rule.NewTarget("namespace", "young-ns", "kind", "NetworkPolicy", "name", "deny-all"),
 				},
 			))
+		})
+
+		It("should retry only until all namespaces pass", func() {
+			oldNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-ns",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-time.Hour)},
+				},
+			}
+			youngNs1 := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "young-ns-1",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-30 * time.Second)},
+				},
+			}
+			youngNs2 := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "young-ns-2",
+					CreationTimestamp: metav1.Time{Time: fakeNow.Add(-15 * time.Second)},
+				},
+			}
+			Expect(client.Create(ctx, oldNs)).To(Succeed())
+			Expect(client.Create(ctx, youngNs1)).To(Succeed())
+			Expect(client.Create(ctx, youngNs2)).To(Succeed())
+
+			retryCounter := 0
+
+			rules.SetTimeSleep(func(_ context.Context, _ time.Duration) error {
+				retryCounter++
+				switch retryCounter {
+				case 1:
+					denyAll := &networkingv1.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "deny-all-1",
+							Namespace: "young-ns-1",
+						},
+						Spec: networkingv1.NetworkPolicySpec{
+							PolicyTypes: []networkingv1.PolicyType{
+								networkingv1.PolicyTypeIngress,
+								networkingv1.PolicyTypeEgress,
+							},
+						},
+					}
+					Expect(client.Create(ctx, denyAll)).To(Succeed())
+				case 2:
+					denyAll := &networkingv1.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "deny-all-2",
+							Namespace: "young-ns-2",
+						},
+						Spec: networkingv1.NetworkPolicySpec{
+							PolicyTypes: []networkingv1.PolicyType{
+								networkingv1.PolicyTypeIngress,
+								networkingv1.PolicyTypeEgress,
+							},
+						},
+					}
+					Expect(client.Create(ctx, denyAll)).To(Succeed())
+				}
+				return nil
+			})
+
+			r := &rules.Rule2000{Client: client}
+			ruleResult, err := r.Run(ctx)
+
+			Expect(err).To(BeNil())
+			Expect(ruleResult.CheckResults).To(ConsistOf(
+				rule.CheckResult{
+					Status:  rule.Failed,
+					Message: "Ingress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "old-ns"),
+				},
+				rule.CheckResult{
+					Status:  rule.Failed,
+					Message: "Egress traffic is not denied by default.",
+					Target:  rule.NewTarget("namespace", "old-ns"),
+				},
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Ingress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns-1", "kind", "NetworkPolicy", "name", "deny-all-1"),
+				},
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Egress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns-1", "kind", "NetworkPolicy", "name", "deny-all-1"),
+				},
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Ingress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns-2", "kind", "NetworkPolicy", "name", "deny-all-2"),
+				},
+				rule.CheckResult{
+					Status:  rule.Passed,
+					Message: "Egress traffic is denied by default.",
+					Target:  rule.NewTarget("namespace", "young-ns-2", "kind", "NetworkPolicy", "name", "deny-all-2"),
+				},
+			))
+			Expect(retryCounter).To(Equal(2))
 		})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -886,23 +886,23 @@ var _ = Describe("#2000", func() {
 
 	Context("test backoff retry for recently created namespaces", func() {
 		var (
-			originalTimeSleep func(time.Duration)
+			originalTimeSleep func(context.Context, time.Duration) error
 			originalTimeNow   func() time.Time
 			fakeNow           time.Time
 		)
 
 		BeforeEach(func() {
-			originalTimeSleep = rules.TimeSleep
-			originalTimeNow = rules.TimeNow
+			originalTimeSleep = rules.GetTimeSleep()
+			originalTimeNow = rules.GetTimeNow()
 			fakeNow = time.Now()
-			rules.TimeNow = func() time.Time { return fakeNow }
-			rules.TimeSleep = func(_ time.Duration) {}
+			rules.SetTimeNow(func() time.Time { return fakeNow })
+			rules.SetTimeSleep(func(_ context.Context, _ time.Duration) error { return nil })
 			client = fakeclient.NewClientBuilder().Build()
 		})
 
 		AfterEach(func() {
-			rules.TimeSleep = originalTimeSleep
-			rules.TimeNow = originalTimeNow
+			rules.SetTimeSleep(originalTimeSleep)
+			rules.SetTimeNow(originalTimeNow)
 		})
 
 		It("should retry and pass when network policy is added before retry", func() {
@@ -915,7 +915,7 @@ var _ = Describe("#2000", func() {
 			Expect(client.Create(ctx, namespace)).To(Succeed())
 
 			// Override TimeSleep to create the policy during the backoff.
-			rules.TimeSleep = func(_ time.Duration) {
+			rules.SetTimeSleep(func(_ context.Context, _ time.Duration) error {
 				denyAll := &networkingv1.NetworkPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "deny-all",
@@ -929,7 +929,8 @@ var _ = Describe("#2000", func() {
 					},
 				}
 				Expect(client.Create(ctx, denyAll)).To(Succeed())
-			}
+				return nil
+			})
 
 			r := &rules.Rule2000{Client: client}
 			ruleResult, err := r.Run(ctx)
@@ -986,9 +987,10 @@ var _ = Describe("#2000", func() {
 			Expect(client.Create(ctx, namespace)).To(Succeed())
 
 			sleepCalled := false
-			rules.TimeSleep = func(_ time.Duration) {
+			rules.SetTimeSleep(func(_ context.Context, _ time.Duration) error {
 				sleepCalled = true
-			}
+				return nil
+			})
 
 			r := &rules.Rule2000{Client: client}
 			ruleResult, err := r.Run(ctx)
@@ -1025,7 +1027,7 @@ var _ = Describe("#2000", func() {
 			Expect(client.Create(ctx, oldNs)).To(Succeed())
 			Expect(client.Create(ctx, youngNs)).To(Succeed())
 
-			rules.TimeSleep = func(_ time.Duration) {
+			rules.SetTimeSleep(func(_ context.Context, _ time.Duration) error {
 				denyAll := &networkingv1.NetworkPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "deny-all",
@@ -1039,7 +1041,8 @@ var _ = Describe("#2000", func() {
 					},
 				}
 				Expect(client.Create(ctx, denyAll)).To(Succeed())
-			}
+				return nil
+			})
 
 			r := &rules.Rule2000{Client: client}
 			ruleResult, err := r.Run(ctx)

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/export_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/export_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+	"time"
+)
+
+func SetTimeNow(f func() time.Time) {
+	timeNow = f
+}
+
+func GetTimeNow() func() time.Time {
+	return timeNow
+}
+
+func SetTimeSleep(f func(context.Context, time.Duration) error) {
+	timeSleep = f
+}
+
+func GetTimeSleep() func(context.Context, time.Duration) error {
+	return timeSleep
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds a retry period of 1 minutes to rule 2000 of the Security Hardened Kubernetes Cluster to retry checks for namespaces created in the last 5 minutes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Rule 2000 of the Security Hardened Kubernetes Cluster now has a retry period of 1 minute where it retries checks for namespaces created in the last 5 minutes.
```
