### PR TITLE
ci: use valid dummy SHA256 for manual workflow runs

### DIFF
--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -81,7 +81,7 @@ jobs:
         if: ${{ inputs.component-descriptor == '' }}
         run: |
           set -euo pipefail
-          dummy=dummySHA256sum
+          dummy=0000000000000000000000000000000000000000000000000000000000000000
           printf '%s\n' \
             "DARWIN_SHA_AMD64=$dummy" \
             "DARWIN_SHA_ARM64=$dummy" \


### PR DESCRIPTION
/area quality
/kind enhancement

**What this PR does / why we need it**:

Replace `dummySHA256sum` placeholder with 64 hex zeros (`0{64}`) in the dummy-hashes step.

The downstream package repositories (homebrew-tap, chocolatey-packages) validate SHA256 hashes
against `^[0-9a-f]{64}$`. The old placeholder fails this check when running `workflow_dispatch`
without a component-descriptor.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/hold until https://github.com/gardener/homebrew-tap/pull/104 and https://github.com/gardener/chocolatey-packages/pull/85 is merged

**Release note**:
```other developer
NONE
```