### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,6 +59,15 @@
       "enabled": false
     },
     {
+      // Group gardener/gardener and gardener/gardener/pkg/apis since they come from the same repo.
+      "groupName": "github.com/gardener/gardener",
+      "matchDatasources": ["go"],
+      "matchPackageNames": [
+        "github.com/gardener/gardener",
+        "github.com/gardener/gardener/pkg/apis",
+      ],
+    },
+    {
       // Group github-actions minor updates in one PR
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,16 +46,16 @@
       // Minor and major upgrades most likely require manual adaptations of the code.
       "matchDatasources": ["go"],
       "matchUpdateTypes": ["major", "minor"],
-      "matchPackagePatterns": [
-        "k8s\\.io\/.+",
-        "sigs\\.k8s\\.io\/controller-runtime",
+      "matchPackageNames": [
+        "/k8s\\.io\/.+/",
+        "/sigs\\.k8s\\.io\/controller-runtime/",
       ],
       "enabled": false
     },
     {
       // Ignore dependency updates from k8s.io/kube-openapi because it depends on k8s.io/apiserver.
       "matchDatasources": ["go"],
-      "matchPackagePatterns": ["k8s\\.io\/kube-openapi"],
+      "matchPackageNames": ["/k8s\\.io\/kube-openapi/"],
       "enabled": false
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,15 @@
       ],
     },
     {
+      // Group ginkgo and gomega.
+      "groupName": "github.com/onsi (ginkgo + gomega)",
+      "matchDatasources": ["go"],
+      "matchPackageNames": [
+        "github.com/onsi/ginkgo/v2",
+        "github.com/onsi/gomega",
+      ],
+    },
+    {
       // Group github-actions minor updates in one PR
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR makes 3 improvements to the renovate configuration in diki:
- groups updates for `github.com/gardener/gardener` and `github.com/gardener/gardener/pkg/apis`
- groups updates for `github.com/onsi/ginkgo/v2` and `github.com/onsi/gomega`
- migrates away from the deprecated `matchPackageNames` field

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
