### PR TITLE
Config validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ diki report generate diff \
     difference1.json difference2.json
 ```
 
+### Config Validate
+
+Diki can validate the structure and content of a configuration file.
+
+```bash
+diki config validate config.yaml
+```
+
 ### Unit Tests
 
 You can manually run the tests via `make test`.

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -24,6 +24,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/config/validate"
 	"github.com/gardener/diki/pkg/metadata"
 	"github.com/gardener/diki/pkg/provider"
 	"github.com/gardener/diki/pkg/report"
@@ -169,6 +170,38 @@ e.g. to check compliance of your hyperscaler accounts.`,
 	}
 
 	showCmd.AddCommand(showProviderCmd)
+
+	validateConfigFuncs := map[string]provider.ValidateConfigFunc{}
+	for providerID, providerOption := range providerOptions {
+		if providerOption.ValidateConfigFunc != nil {
+			validateConfigFuncs[providerID] = providerOption.ValidateConfigFunc
+		}
+	}
+
+	configCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Config is the root command for configuration operations.",
+		Long:  "Config is the root command for configuration operations.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return errors.New("config subcommand not selected")
+		},
+	}
+
+	rootCmd.AddCommand(configCmd)
+
+	configValidateCmd := &cobra.Command{
+		Use:           "validate",
+		Short:         "Validate checks the structure and content of a diki configuration.",
+		Long:          "Validate checks the structure and content of a diki configuration.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return configValidateCmd(args[0], validateConfigFuncs, logger)
+		},
+	}
+
+	configCmd.AddCommand(configValidateCmd)
 
 	return rootCmd
 }
@@ -614,4 +647,21 @@ func getDikiConfig(opts runOptions, defaultConfigFuncs map[string]provider.Defau
 		dikiConfig := defaultFunc()
 		return &dikiConfig, nil
 	}
+}
+
+func configValidateCmd(configPath string, validateFuncs map[string]provider.ValidateConfigFunc, logger *slog.Logger) error {
+	cfg, err := readConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config: %w", err)
+	}
+
+	if errs := validate.ValidateConfig(cfg, validateFuncs); len(errs) > 0 {
+		for _, e := range errs {
+			logger.Error(e.Error())
+		}
+		return errors.New("configuration is not valid")
+	}
+
+	logger.Info("configuration is valid")
+	return nil
 }

--- a/cmd/diki/main.go
+++ b/cmd/diki/main.go
@@ -21,10 +21,10 @@ import (
 func main() {
 	cmd := app.NewDikiCommand(
 		map[string]provider.ProviderOption{
-			garden.ProviderID:        {ProviderFromConfigFunc: builder.GardenProviderFromConfig, MetadataFunc: builder.GardenProviderMetadata},
-			gardener.ProviderID:      {ProviderFromConfigFunc: builder.GardenerProviderFromConfig, MetadataFunc: builder.GardenerProviderMetadata},
-			managedk8s.ProviderID:    {ProviderFromConfigFunc: builder.ManagedK8SProviderFromConfig, MetadataFunc: builder.ManagedK8SProviderMetadata, DefaultDikiConfigFunc: managedk8s.ManagedK8sDefaultDikiConfigFunc},
-			virtualgarden.ProviderID: {ProviderFromConfigFunc: builder.VirtualGardenProviderFromConfig, MetadataFunc: builder.VirtualGardenProviderMetadata},
+			garden.ProviderID:        {ProviderFromConfigFunc: builder.GardenProviderFromConfig, MetadataFunc: builder.GardenProviderMetadata, ValidateConfigFunc: garden.ValidateProviderConfig},
+			gardener.ProviderID:      {ProviderFromConfigFunc: builder.GardenerProviderFromConfig, MetadataFunc: builder.GardenerProviderMetadata, ValidateConfigFunc: gardener.ValidateProviderConfig},
+			managedk8s.ProviderID:    {ProviderFromConfigFunc: builder.ManagedK8SProviderFromConfig, MetadataFunc: builder.ManagedK8SProviderMetadata, DefaultDikiConfigFunc: managedk8s.ManagedK8sDefaultDikiConfigFunc, ValidateConfigFunc: managedk8s.ValidateProviderConfig},
+			virtualgarden.ProviderID: {ProviderFromConfigFunc: builder.VirtualGardenProviderFromConfig, MetadataFunc: builder.VirtualGardenProviderMetadata, ValidateConfigFunc: virtualgarden.ValidateProviderConfig},
 		},
 	)
 

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider"
+)
+
+// ValidateConfig validates a [config.DikiConfig] structurally using registered provider validation functions.
+func ValidateConfig(c *config.DikiConfig, validateFuncs map[string]provider.ValidateConfigFunc) field.ErrorList {
+	allErrs := field.ErrorList{}
+	rootPath := field.NewPath("providers")
+
+	seenProviderIDs := make(map[string]struct{})
+	for providerIdx, providerConfig := range c.Providers {
+		fldPath := rootPath.Index(providerIdx)
+
+		if _, seen := seenProviderIDs[providerConfig.ID]; seen {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Child("id"), providerConfig.ID))
+			continue
+		}
+		seenProviderIDs[providerConfig.ID] = struct{}{}
+
+		validateFunc, ok := validateFuncs[providerConfig.ID]
+		if !ok {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("id"), providerConfig.ID, knownProviderIDs(validateFuncs)))
+			continue
+		}
+
+		allErrs = append(allErrs, validateFunc(providerConfig, fldPath)...)
+	}
+
+	return allErrs
+}
+
+func knownProviderIDs(funcs map[string]provider.ValidateConfigFunc) []string {
+	ids := make([]string, 0, len(funcs))
+	for id := range funcs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -5,19 +5,24 @@
 package validate
 
 import (
+	"slices"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/provider"
+	"github.com/gardener/diki/pkg/rule"
 )
 
 // ValidateConfig validates a [config.DikiConfig] structurally using registered provider validation functions.
 func ValidateConfig(c *config.DikiConfig, validateFuncs map[string]provider.ValidateConfigFunc) field.ErrorList {
 	allErrs := field.ErrorList{}
-	rootPath := field.NewPath("providers")
 
+	allErrs = append(allErrs, validateOutput(c.Output, field.NewPath("output"))...)
+
+	rootPath := field.NewPath("providers")
+	knownIDs := knownProviderIDs(validateFuncs)
 	seenProviderIDs := make(map[string]struct{})
 	for providerIdx, providerConfig := range c.Providers {
 		fldPath := rootPath.Index(providerIdx)
@@ -30,7 +35,7 @@ func ValidateConfig(c *config.DikiConfig, validateFuncs map[string]provider.Vali
 
 		validateFunc, ok := validateFuncs[providerConfig.ID]
 		if !ok {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("id"), providerConfig.ID, knownProviderIDs(validateFuncs)))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("id"), providerConfig.ID, knownIDs))
 			continue
 		}
 
@@ -38,6 +43,23 @@ func ValidateConfig(c *config.DikiConfig, validateFuncs map[string]provider.Vali
 	}
 
 	return allErrs
+}
+
+func validateOutput(output *config.OutputConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if output == nil || len(output.MinStatus) == 0 {
+		return allErrs
+	}
+
+	statuses := rule.Statuses()
+	if slices.Contains(statuses, rule.Status(output.MinStatus)) {
+		return allErrs
+	}
+	statusStrings := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		statusStrings = append(statusStrings, string(s))
+	}
+	return append(allErrs, field.NotSupported(fldPath.Child("minStatus"), output.MinStatus, statusStrings))
 }
 
 func knownProviderIDs(funcs map[string]provider.ValidateConfigFunc) []string {

--- a/pkg/config/validate/validate_suite_test.go
+++ b/pkg/config/validate/validate_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Validate Suite")
+}

--- a/pkg/config/validate/validate_test.go
+++ b/pkg/config/validate/validate_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/config/validate"
+	"github.com/gardener/diki/pkg/provider"
+)
+
+var _ = Describe("ValidateConfig", func() {
+	var validateFuncs map[string]provider.ValidateConfigFunc
+
+	BeforeEach(func() {
+		validateFuncs = map[string]provider.ValidateConfigFunc{
+			"foo": func(_ config.ProviderConfig, _ *field.Path) field.ErrorList { return nil },
+		}
+	})
+
+	It("should accept a valid output minStatus", func() {
+		conf := &config.DikiConfig{
+			Output: &config.OutputConfig{MinStatus: "Passed"},
+		}
+
+		Expect(validate.ValidateConfig(conf, validateFuncs)).To(BeEmpty())
+	})
+
+	It("should accept a missing output", func() {
+		conf := &config.DikiConfig{}
+
+		Expect(validate.ValidateConfig(conf, validateFuncs)).To(BeEmpty())
+	})
+
+	It("should accept an empty minStatus", func() {
+		conf := &config.DikiConfig{
+			Output: &config.OutputConfig{},
+		}
+
+		Expect(validate.ValidateConfig(conf, validateFuncs)).To(BeEmpty())
+	})
+
+	It("should reject an unknown minStatus", func() {
+		conf := &config.DikiConfig{
+			Output: &config.OutputConfig{MinStatus: "NotAStatus"},
+		}
+
+		errs := validate.ValidateConfig(conf, validateFuncs)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeNotSupported))
+		Expect(errs[0].Field).To(Equal("output.minStatus"))
+		Expect(errs[0].BadValue).To(Equal("NotAStatus"))
+	})
+
+	It("should reject a duplicate provider id", func() {
+		conf := &config.DikiConfig{
+			Providers: []config.ProviderConfig{
+				{ID: "foo"},
+				{ID: "foo"},
+			},
+		}
+
+		errs := validate.ValidateConfig(conf, validateFuncs)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeDuplicate))
+		Expect(errs[0].Field).To(Equal("providers[1].id"))
+	})
+
+	It("should reject an unknown provider id", func() {
+		conf := &config.DikiConfig{
+			Providers: []config.ProviderConfig{
+				{ID: "unknown"},
+			},
+		}
+
+		errs := validate.ValidateConfig(conf, validateFuncs)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeNotSupported))
+		Expect(errs[0].Field).To(Equal("providers[0].id"))
+	})
+})

--- a/pkg/provider/garden/garden_suite_test.go
+++ b/pkg/provider/garden/garden_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package garden_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGarden(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Provider Garden Suite")
+}

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -81,8 +81,8 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config, logger provider.Logger, fldPath *field.Path) (*Ruleset, error) {
-	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
-		return nil, err
+	if errs := ValidateRulesetConfig(rulesetConfig, fldPath); len(errs) > 0 {
+		return nil, errs.ToAggregate()
 	}
 
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
@@ -124,18 +124,19 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 }
 
 // ValidateRulesetConfig validates a [config.RulesetConfig].
-func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
 	var rulesetArgs Args
 	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
-	allErrs := field.ErrorList{}
 	if len(rulesetArgs.ShootName) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("args", "shootName"), ""))
 	}
@@ -145,25 +146,20 @@ func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Pa
 
 	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
 	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath.Child("ruleOptions"), err))
-		return allErrs.ToAggregate()
+		return append(allErrs, field.Invalid(fldPath.Child("ruleOptions"), rulesetConfig.RuleOptions, err.Error()))
 	}
 
 	r := &Ruleset{}
 	switch rulesetConfig.Version {
 	case "v0.1.0":
-		if err := r.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			allErrs = append(allErrs, field.InternalError(fldPath.Child("ruleOptions"), err))
-		}
+		allErrs = append(allErrs, r.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	case "v0.2.0", "v0.2.1":
-		if err := r.validateV02RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			allErrs = append(allErrs, field.InternalError(fldPath.Child("ruleOptions"), err))
-		}
+		allErrs = append(allErrs, r.validateV02RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, []string{"v0.1.0", "v0.2.0", "v0.2.1"}))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, SupportedVersions))
 	}
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/gardener/diki/pkg/config"
-	internalconfig "github.com/gardener/diki/pkg/internal/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
 	"github.com/gardener/diki/pkg/shared/provider"
@@ -82,6 +81,10 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config, logger provider.Logger, fldPath *field.Path) (*Ruleset, error) {
+	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
+		return nil, err
+	}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
 		return nil, err
@@ -101,52 +104,77 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 		return nil, err
 	}
 
-	var (
-		indexedRuleOptions = make(map[string]internalconfig.IndexedRuleOptionsConfig)
-		ruleOptions        = make(map[string]config.RuleOptionsConfig)
-	)
-
-	for index, opt := range rulesetConfig.RuleOptions {
-		if _, ok := ruleOptions[opt.RuleID]; ok {
-			return nil, fmt.Errorf("rule option for rule id: %s is already registered", opt.RuleID)
-		}
-
+	ruleOptions := make(map[string]config.RuleOptionsConfig)
+	for _, opt := range rulesetConfig.RuleOptions {
 		ruleOptions[opt.RuleID] = opt
-		indexedRuleOptions[opt.RuleID] = internalconfig.IndexedRuleOptionsConfig{Index: index, RuleOptionsConfig: opt}
 	}
 
-	switch rulesetConfig.Version {
-	case "v0.1.0":
-		if err := ruleset.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV01Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	case "v0.2.0":
+	if rulesetConfig.Version == "v0.2.0" {
 		logger.Info("Using version v0.2.1 as latest patch version of security-hardened-shoot-cluster v0.2.x ruleset")
 
 		setLatestPatchVersion := WithVersion("v0.2.1")
 		setLatestPatchVersion(ruleset)
+	}
 
-		if err := ruleset.validateV02RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV02Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	case "v0.2.1":
-		if err := ruleset.validateV02RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV02Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider garden' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+	if err := ruleset.registerRules(ruleOptions); err != nil {
+		return nil, err
 	}
 
 	return ruleset, nil
+}
+
+// ValidateRulesetConfig validates a [config.RulesetConfig].
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
+	if err != nil {
+		return err
+	}
+
+	var rulesetArgs Args
+	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
+		return err
+	}
+
+	allErrs := field.ErrorList{}
+	if len(rulesetArgs.ShootName) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "shootName"), ""))
+	}
+	if len(rulesetArgs.ProjectNamespace) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "projectNamespace"), ""))
+	}
+
+	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath.Child("ruleOptions"), err))
+		return allErrs.ToAggregate()
+	}
+
+	r := &Ruleset{}
+	switch rulesetConfig.Version {
+	case "v0.1.0":
+		if err := r.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
+			allErrs = append(allErrs, field.InternalError(fldPath.Child("ruleOptions"), err))
+		}
+	case "v0.2.0", "v0.2.1":
+		if err := r.validateV02RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
+			allErrs = append(allErrs, field.InternalError(fldPath.Child("ruleOptions"), err))
+		}
+	default:
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, []string{"v0.1.0", "v0.2.0", "v0.2.1"}))
+	}
+
+	return allErrs.ToAggregate()
+}
+
+func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {
+	switch r.version {
+	case "v0.1.0":
+		return r.registerV01Rules(ruleOptions)
+	case "v0.2.0", "v0.2.1":
+		return r.registerV02Rules(ruleOptions)
+	default:
+		return sharedruleset.UnknownVersionError(r.ID(), r.Version(), "garden")
+	}
 }
 
 // RunRule executes specific known Rule of the Ruleset.

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -19,14 +19,14 @@ import (
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 )
 
-func (r *Ruleset) validateV01RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV01RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV01Options[rules.Options1000](ruleOptions["1000"].Args, fldPath.Index(ruleOptions["1000"].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV01Options[rules.Options2000](ruleOptions["2000"].Args, fldPath.Index(ruleOptions["2000"].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV01Options[rules.Options2000](ruleOptions["2007"].Args, fldPath.Index(ruleOptions["2007"].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
@@ -131,7 +131,7 @@ func validateV01Options[O rules.RuleOption](options any, fldPath *field.Path) fi
 	parsedOptions, err := getV01OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 )
 
-func (r *Ruleset) validateV02RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV02RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV02Options[rules.Options1000](ruleOptions["1000"].Args, fldPath.Index(ruleOptions["1000"].Index).Child("args"))...)
@@ -29,7 +29,7 @@ func (r *Ruleset) validateV02RuleOptions(ruleOptions map[string]internalconfig.I
 	allErrs = append(allErrs, validateV02Options[rules.Options2000](ruleOptions["2000"].Args, fldPath.Index(ruleOptions["2000"].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV02Options[rules.Options2007](ruleOptions["2007"].Args, fldPath.Index(ruleOptions["2007"].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV02Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
@@ -156,7 +156,7 @@ func validateV02Options[O rules.RuleOption](options any, fldPath *field.Path) fi
 	parsedOptions, err := getV02OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 

--- a/pkg/provider/garden/validate.go
+++ b/pkg/provider/garden/validate.go
@@ -27,11 +27,11 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
 	}
 
-	seenRulesets := make(map[string]struct{})
+	seenRulesets := make(map[struct{ ID, Version string }]struct{})
 	for rulesetIdx, rulesetConfig := range conf.Rulesets {
 		var (
 			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
-			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+			rulesetKey  = struct{ ID, Version string }{rulesetConfig.ID, rulesetConfig.Version}
 		)
 		if _, seen := seenRulesets[rulesetKey]; seen {
 			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))

--- a/pkg/provider/garden/validate.go
+++ b/pkg/provider/garden/validate.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package garden
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot"
+)
+
+// ValidateProviderConfig validates a Garden provider configuration structurally.
+func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	providerArgsByte, err := json.Marshal(conf.Args)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	var args providerArgs
+	if err := json.Unmarshal(providerArgsByte, &args); err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	seenRulesets := make(map[string]struct{})
+	for rulesetIdx, rulesetConfig := range conf.Rulesets {
+		var (
+			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
+			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+		)
+		if _, seen := seenRulesets[rulesetKey]; seen {
+			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))
+			continue
+		}
+		seenRulesets[rulesetKey] = struct{}{}
+
+		switch rulesetConfig.ID {
+		case securityhardenedshoot.RulesetID:
+			if err := securityhardenedshoot.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
+				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
+			}
+		default:
+			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{securityhardenedshoot.RulesetID}))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/provider/garden/validate.go
+++ b/pkg/provider/garden/validate.go
@@ -41,9 +41,7 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 
 		switch rulesetConfig.ID {
 		case securityhardenedshoot.RulesetID:
-			if err := securityhardenedshoot.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
-				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
-			}
+			allErrs = append(allErrs, securityhardenedshoot.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
 		default:
 			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{securityhardenedshoot.RulesetID}))
 		}

--- a/pkg/provider/garden/validate_test.go
+++ b/pkg/provider/garden/validate_test.go
@@ -83,10 +83,11 @@ var _ = Describe("ValidateProviderConfig", func() {
 		}
 
 		errs := garden.ValidateProviderConfig(conf, fldPath)
-		Expect(errs).To(HaveLen(1))
-		Expect(errs[0].Type).To(Equal(field.ErrorTypeInternal))
-		Expect(errs[0].Error()).To(ContainSubstring("shootName"))
-		Expect(errs[0].Error()).To(ContainSubstring("projectNamespace"))
+		Expect(errs).To(HaveLen(2))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[0].args.shootName"))
+		Expect(errs[1].Type).To(Equal(field.ErrorTypeRequired))
+		Expect(errs[1].Field).To(Equal("providers[0].rulesets[0].args.projectNamespace"))
 	})
 
 	It("should return error for invalid args", func() {

--- a/pkg/provider/garden/validate_test.go
+++ b/pkg/provider/garden/validate_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package garden_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/garden"
+)
+
+var _ = Describe("ValidateProviderConfig", func() {
+	var fldPath *field.Path
+
+	BeforeEach(func() {
+		fldPath = field.NewPath("providers").Index(0)
+	})
+
+	It("should return no errors for a valid config", func() {
+		conf := config.ProviderConfig{
+			ID:   "garden",
+			Name: "Garden",
+			Args: map[string]string{
+				"kubeconfigPath": "/path/to/kubeconfig",
+			},
+			Rulesets: []config.RulesetConfig{
+				{
+					ID:      "security-hardened-shoot-cluster",
+					Version: "v0.2.1",
+					Args:    map[string]string{"shootName": "my-shoot", "projectNamespace": "garden-my-project"},
+				},
+			},
+		}
+
+		errs := garden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("should return error for unsupported ruleset ID", func() {
+		conf := config.ProviderConfig{
+			ID:   "garden",
+			Name: "Garden",
+			Args: map[string]any{},
+			Rulesets: []config.RulesetConfig{
+				{ID: "unknown-ruleset", Version: "v1"},
+			},
+		}
+
+		errs := garden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[0].id"))
+	})
+
+	It("should return error for duplicate ruleset ID and version", func() {
+		conf := config.ProviderConfig{
+			ID:   "garden",
+			Name: "Garden",
+			Args: map[string]any{},
+			Rulesets: []config.RulesetConfig{
+				{ID: "security-hardened-shoot-cluster", Version: "v0.2.1", Args: map[string]string{"shootName": "my-shoot", "projectNamespace": "garden-my-project"}},
+				{ID: "security-hardened-shoot-cluster", Version: "v0.2.1", Args: map[string]string{"shootName": "my-shoot", "projectNamespace": "garden-my-project"}},
+			},
+		}
+
+		errs := garden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[1]"))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeDuplicate))
+	})
+
+	It("should return error for missing required ruleset args", func() {
+		conf := config.ProviderConfig{
+			ID:   "garden",
+			Name: "Garden",
+			Args: map[string]any{},
+			Rulesets: []config.RulesetConfig{
+				{ID: "security-hardened-shoot-cluster", Version: "v0.2.1", Args: map[string]any{}},
+			},
+		}
+
+		errs := garden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeInternal))
+		Expect(errs[0].Error()).To(ContainSubstring("shootName"))
+		Expect(errs[0].Error()).To(ContainSubstring("projectNamespace"))
+	})
+
+	It("should return error for invalid args", func() {
+		conf := config.ProviderConfig{
+			ID:   "garden",
+			Name: "Garden",
+			Args: "not-a-map",
+		}
+
+		errs := garden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].args"))
+	})
+})

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -89,8 +89,8 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, shootConfig, seedConfig *rest.Config, shootNamespace string, fldPath *field.Path) (*Ruleset, error) {
-	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
-		return nil, err
+	if errs := ValidateRulesetConfig(rulesetConfig, fldPath); len(errs) > 0 {
+		return nil, errs.ToAggregate()
 	}
 
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
@@ -128,31 +128,35 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 }
 
 // ValidateRulesetConfig validates a [config.RulesetConfig].
-func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
 	var rulesetArgs Args
 	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
 	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("ruleOptions"), rulesetConfig.RuleOptions, err.Error()))
 	}
 
 	r := &Ruleset{}
 	switch rulesetConfig.Version {
 	case "v2r4":
-		return r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+		allErrs = append(allErrs, r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	case "v2r5":
-		return r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+		allErrs = append(allErrs, r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	default:
-		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "gardener")
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, SupportedVersions))
 	}
+
+	return allErrs
 }
 
 func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/diki/pkg/config"
-	internalconfig "github.com/gardener/diki/pkg/internal/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
 	sharedruleset "github.com/gardener/diki/pkg/shared/ruleset"
@@ -90,6 +89,10 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, shootConfig, seedConfig *rest.Config, shootNamespace string, fldPath *field.Path) (*Ruleset, error) {
+	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
+		return nil, err
+	}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
 		return nil, err
@@ -100,7 +103,6 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 		return nil, err
 	}
 
-	// TODO: add all known rules and validate
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
 		WithAdditionalOpsPodLabels(additionalOpsPodLabels),
@@ -113,40 +115,55 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 		return nil, err
 	}
 
-	var (
-		indexedRuleOptions = make(map[string]internalconfig.IndexedRuleOptionsConfig)
-		ruleOptions        = make(map[string]config.RuleOptionsConfig)
-	)
-
-	for index, opt := range rulesetConfig.RuleOptions {
-		if _, ok := ruleOptions[opt.RuleID]; ok {
-			return nil, fmt.Errorf("rule option for rule id: %s is already registered", opt.RuleID)
-		}
-
+	ruleOptions := make(map[string]config.RuleOptionsConfig)
+	for _, opt := range rulesetConfig.RuleOptions {
 		ruleOptions[opt.RuleID] = opt
-		indexedRuleOptions[opt.RuleID] = internalconfig.IndexedRuleOptionsConfig{Index: index, RuleOptionsConfig: opt}
 	}
 
-	switch rulesetConfig.Version {
-	case "v2r4":
-		if err := ruleset.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV2R4Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	case "v2r5":
-		if err := ruleset.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV2R5Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider gardener' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+	if err := ruleset.registerRules(ruleOptions); err != nil {
+		return nil, err
 	}
 
 	return ruleset, nil
+}
+
+// ValidateRulesetConfig validates a [config.RulesetConfig].
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
+	if err != nil {
+		return err
+	}
+
+	var rulesetArgs Args
+	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
+		return err
+	}
+
+	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
+	if err != nil {
+		return err
+	}
+
+	r := &Ruleset{}
+	switch rulesetConfig.Version {
+	case "v2r4":
+		return r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+	case "v2r5":
+		return r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+	default:
+		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "gardener")
+	}
+}
+
+func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {
+	switch r.version {
+	case "v2r4":
+		return r.registerV2R4Rules(ruleOptions)
+	case "v2r5":
+		return r.registerV2R5Rules(ruleOptions)
+	default:
+		return sharedruleset.UnknownVersionError(r.ID(), r.Version(), "gardener")
+	}
 }
 
 // RunRule executes specific known Rule of the Ruleset.

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r4_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r4_ruleset.go
@@ -31,7 +31,7 @@ func validateV2R4Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	parsedOptions, err := getV2R4OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 
@@ -67,7 +67,7 @@ func getV2R4OptionOrNil[O rules.RuleOption](options any) (*O, error) {
 	return parseV2R4Options[O](options)
 }
 
-func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R4Options[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args, fldPath.Index(ruleOptions[sharedrules.ID242390].Index).Child("args"))...)
@@ -83,7 +83,7 @@ func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R4Options[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args, fldPath.Index(ruleOptions[sharedrules.ID245543].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R4Options[sharedrules.Options254800](ruleOptions[sharedrules.ID254800].Args, fldPath.Index(ruleOptions[sharedrules.ID254800].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV2R4Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r5_ruleset.go
@@ -31,7 +31,7 @@ func validateV2R5Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	parsedOptions, err := getV2R5OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 
@@ -67,7 +67,7 @@ func getV2R5OptionOrNil[O rules.RuleOption](options any) (*O, error) {
 	return parseV2R5Options[O](options)
 }
 
-func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R5Options[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args, fldPath.Index(ruleOptions[sharedrules.ID242390].Index).Child("args"))...)
@@ -83,7 +83,7 @@ func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R5Options[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args, fldPath.Index(ruleOptions[sharedrules.ID245543].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R5Options[sharedrules.Options254800](ruleOptions[sharedrules.ID254800].Args, fldPath.Index(ruleOptions[sharedrules.ID254800].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV2R5Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig

--- a/pkg/provider/gardener/validate.go
+++ b/pkg/provider/gardener/validate.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardener
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig"
+)
+
+// ValidateProviderConfig validates a Gardener provider configuration structurally.
+func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	providerArgsByte, err := json.Marshal(conf.Args)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	var args providerArgs
+	if err := json.Unmarshal(providerArgsByte, &args); err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	if len(args.ShootName) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "shootName"), ""))
+	}
+	if len(args.ShootNamespace) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "shootNamespace"), ""))
+	}
+
+	seenRulesets := make(map[string]struct{})
+	for rulesetIdx, rulesetConfig := range conf.Rulesets {
+		var (
+			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
+			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+		)
+		if _, seen := seenRulesets[rulesetKey]; seen {
+			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))
+			continue
+		}
+		seenRulesets[rulesetKey] = struct{}{}
+
+		switch rulesetConfig.ID {
+		case disak8sstig.RulesetID:
+			if err := disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
+				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
+			}
+		default:
+			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID}))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/provider/gardener/validate.go
+++ b/pkg/provider/gardener/validate.go
@@ -34,11 +34,11 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 		allErrs = append(allErrs, field.Required(fldPath.Child("args", "shootNamespace"), ""))
 	}
 
-	seenRulesets := make(map[string]struct{})
+	seenRulesets := make(map[struct{ ID, Version string }]struct{})
 	for rulesetIdx, rulesetConfig := range conf.Rulesets {
 		var (
 			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
-			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+			rulesetKey  = struct{ ID, Version string }{rulesetConfig.ID, rulesetConfig.Version}
 		)
 		if _, seen := seenRulesets[rulesetKey]; seen {
 			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))

--- a/pkg/provider/gardener/validate.go
+++ b/pkg/provider/gardener/validate.go
@@ -48,9 +48,7 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			if err := disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
-				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
-			}
+			allErrs = append(allErrs, disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
 		default:
 			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID}))
 		}

--- a/pkg/provider/gardener/validate_test.go
+++ b/pkg/provider/gardener/validate_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardener_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/gardener"
+)
+
+var _ = Describe("ValidateProviderConfig", func() {
+	var fldPath *field.Path
+
+	BeforeEach(func() {
+		fldPath = field.NewPath("providers").Index(0)
+	})
+
+	It("should return no errors for a valid config", func() {
+		conf := config.ProviderConfig{
+			ID:   "gardener",
+			Name: "Gardener",
+			Args: map[string]string{
+				"shootName":      "my-shoot",
+				"shootNamespace": "garden-dev",
+			},
+			Rulesets: []config.RulesetConfig{
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+			},
+		}
+
+		errs := gardener.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("should return errors when required args are missing", func() {
+		conf := config.ProviderConfig{
+			ID:   "gardener",
+			Name: "Gardener",
+			Args: map[string]any{},
+		}
+
+		errs := gardener.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(2))
+		Expect(errs[0].Field).To(Equal("providers[0].args.shootName"))
+		Expect(errs[1].Field).To(Equal("providers[0].args.shootNamespace"))
+	})
+
+	It("should return error for unsupported ruleset ID", func() {
+		conf := config.ProviderConfig{
+			ID:   "gardener",
+			Name: "Gardener",
+			Args: map[string]string{
+				"shootName":      "my-shoot",
+				"shootNamespace": "garden-dev",
+			},
+			Rulesets: []config.RulesetConfig{
+				{ID: "unknown-ruleset", Version: "v1"},
+			},
+		}
+
+		errs := gardener.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[0].id"))
+	})
+
+	It("should return error for duplicate ruleset ID and version", func() {
+		conf := config.ProviderConfig{
+			ID:   "gardener",
+			Name: "Gardener",
+			Args: map[string]string{
+				"shootName":      "my-shoot",
+				"shootNamespace": "garden-dev",
+			},
+			Rulesets: []config.RulesetConfig{
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+			},
+		}
+
+		errs := gardener.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[1]"))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeDuplicate))
+	})
+
+	It("should return error for invalid args", func() {
+		conf := config.ProviderConfig{
+			ID:   "gardener",
+			Name: "Gardener",
+			Args: "not-a-map",
+		}
+
+		errs := gardener.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].args"))
+	})
+})

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -87,8 +87,8 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, managedConfig *rest.Config, fldPath *field.Path) (*Ruleset, error) {
-	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
-		return nil, err
+	if errs := ValidateRulesetConfig(rulesetConfig, fldPath); len(errs) > 0 {
+		return nil, errs.ToAggregate()
 	}
 
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
@@ -124,31 +124,35 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 }
 
 // ValidateRulesetConfig validates a [config.RulesetConfig].
-func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
 	var rulesetArgs Args
 	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
 	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("ruleOptions"), rulesetConfig.RuleOptions, err.Error()))
 	}
 
 	r := &Ruleset{}
 	switch rulesetConfig.Version {
 	case "v2r4":
-		return r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+		allErrs = append(allErrs, r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	case "v2r5":
-		return r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+		allErrs = append(allErrs, r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	default:
-		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "managedk8s")
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, SupportedVersions))
 	}
+
+	return allErrs
 }
 
 func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/diki/pkg/config"
-	internalconfig "github.com/gardener/diki/pkg/internal/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
 	sharedruleset "github.com/gardener/diki/pkg/shared/ruleset"
@@ -88,6 +87,10 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, managedConfig *rest.Config, fldPath *field.Path) (*Ruleset, error) {
+	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
+		return nil, err
+	}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
 		return nil, err
@@ -108,40 +111,55 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 		return nil, err
 	}
 
-	var (
-		ruleOptions        = make(map[string]config.RuleOptionsConfig)
-		indexedRuleOptions = make(map[string]internalconfig.IndexedRuleOptionsConfig)
-	)
-
-	for index, opt := range rulesetConfig.RuleOptions {
-		if _, ok := ruleOptions[opt.RuleID]; ok {
-			return nil, fmt.Errorf("rule option for rule id: %s is already registered", opt.RuleID)
-		}
-
+	ruleOptions := make(map[string]config.RuleOptionsConfig)
+	for _, opt := range rulesetConfig.RuleOptions {
 		ruleOptions[opt.RuleID] = opt
-		indexedRuleOptions[opt.RuleID] = internalconfig.IndexedRuleOptionsConfig{Index: index, RuleOptionsConfig: opt}
 	}
 
-	switch rulesetConfig.Version {
-	case "v2r4":
-		if err := ruleset.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV2R4Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	case "v2r5":
-		if err := ruleset.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV2R5Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider managedk8s' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+	if err := ruleset.registerRules(ruleOptions); err != nil {
+		return nil, err
 	}
 
 	return ruleset, nil
+}
+
+// ValidateRulesetConfig validates a [config.RulesetConfig].
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
+	if err != nil {
+		return err
+	}
+
+	var rulesetArgs Args
+	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
+		return err
+	}
+
+	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
+	if err != nil {
+		return err
+	}
+
+	r := &Ruleset{}
+	switch rulesetConfig.Version {
+	case "v2r4":
+		return r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+	case "v2r5":
+		return r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+	default:
+		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "managedk8s")
+	}
+}
+
+func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {
+	switch r.version {
+	case "v2r4":
+		return r.registerV2R4Rules(ruleOptions)
+	case "v2r5":
+		return r.registerV2R5Rules(ruleOptions)
+	default:
+		return sharedruleset.UnknownVersionError(r.ID(), r.Version(), "managedk8s")
+	}
 }
 
 // RunRule executes specific known Rule of the Ruleset.

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r4_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r4_ruleset.go
@@ -34,7 +34,7 @@ func validateV2R4Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	parsedOptions, err := getV2R4OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 
@@ -49,7 +49,7 @@ func validateV2R4Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	return nil
 }
 
-func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R4Options[sharedrules.Options242383](ruleOptions[sharedrules.ID242383].Args, fldPath.Index(ruleOptions[sharedrules.ID242383].Index).Child("args"))...)
@@ -74,7 +74,7 @@ func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R4Options[rules.Options242466](ruleOptions[sharedrules.ID242466].Args, fldPath.Index(ruleOptions[sharedrules.ID242466].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R4Options[rules.Options242467](ruleOptions[sharedrules.ID242467].Args, fldPath.Index(ruleOptions[sharedrules.ID242467].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV2R4Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r5_ruleset.go
@@ -34,7 +34,7 @@ func validateV2R5Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	parsedOptions, err := getV2R5OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 
@@ -49,7 +49,7 @@ func validateV2R5Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	return nil
 }
 
-func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R5Options[sharedrules.Options242383](ruleOptions[sharedrules.ID242383].Args, fldPath.Index(ruleOptions[sharedrules.ID242383].Index).Child("args"))...)
@@ -74,7 +74,7 @@ func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R5Options[rules.Options242466](ruleOptions[sharedrules.ID242466].Args, fldPath.Index(ruleOptions[sharedrules.ID242466].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R5Options[rules.Options242467](ruleOptions[sharedrules.ID242467].Args, fldPath.Index(ruleOptions[sharedrules.ID242467].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV2R5Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/gardener/diki/pkg/config"
-	internalconfig "github.com/gardener/diki/pkg/internal/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
 	sharedruleset "github.com/gardener/diki/pkg/shared/ruleset"
@@ -73,6 +72,10 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config, fldPath *field.Path) (*Ruleset, error) {
+	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
+		return nil, err
+	}
+
 	ruleset, err := New(
 		WithVersion(rulesetConfig.Version),
 		WithConfig(managedConfig),
@@ -81,32 +84,41 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 		return nil, err
 	}
 
-	var (
-		indexedRuleOptions = make(map[string]internalconfig.IndexedRuleOptionsConfig)
-		ruleOptions        = make(map[string]config.RuleOptionsConfig)
-	)
-	for index, opt := range rulesetConfig.RuleOptions {
-		if _, ok := indexedRuleOptions[opt.RuleID]; ok {
-			return nil, fmt.Errorf("rule option for rule id: %s is already registered", opt.RuleID)
-		}
-
+	ruleOptions := make(map[string]config.RuleOptionsConfig)
+	for _, opt := range rulesetConfig.RuleOptions {
 		ruleOptions[opt.RuleID] = opt
-		indexedRuleOptions[opt.RuleID] = internalconfig.IndexedRuleOptionsConfig{Index: index, RuleOptionsConfig: opt}
 	}
 
-	switch rulesetConfig.Version {
-	case "v0.1.0":
-		if err := ruleset.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV01Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider managedk8s' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+	if err := ruleset.registerRules(ruleOptions); err != nil {
+		return nil, err
 	}
 
 	return ruleset, nil
+}
+
+// ValidateRulesetConfig validates a [config.RulesetConfig].
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
+	if err != nil {
+		return err
+	}
+
+	r := &Ruleset{}
+	switch rulesetConfig.Version {
+	case "v0.1.0":
+		return r.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+	default:
+		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "managedk8s")
+	}
+}
+
+func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {
+	switch r.version {
+	case "v0.1.0":
+		return r.registerV01Rules(ruleOptions)
+	default:
+		return sharedruleset.UnknownVersionError(r.ID(), r.Version(), "managedk8s")
+	}
 }
 
 // RunRule executes specific known Rule of the Ruleset.

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
@@ -72,8 +72,8 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config, fldPath *field.Path) (*Ruleset, error) {
-	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
-		return nil, err
+	if errs := ValidateRulesetConfig(rulesetConfig, fldPath); len(errs) > 0 {
+		return nil, errs.ToAggregate()
 	}
 
 	ruleset, err := New(
@@ -97,19 +97,23 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 }
 
 // ValidateRulesetConfig validates a [config.RulesetConfig].
-func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
 	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("ruleOptions"), rulesetConfig.RuleOptions, err.Error()))
 	}
 
 	r := &Ruleset{}
 	switch rulesetConfig.Version {
 	case "v0.1.0":
-		return r.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+		allErrs = append(allErrs, r.validateV01RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	default:
-		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "managedk8s")
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, SupportedVersions))
 	}
+
+	return allErrs
 }
 
 func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 )
 
-func (r *Ruleset) validateV01RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV01RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV01Options[rules.Options2000](ruleOptions["2000"].Args, fldPath.Index(ruleOptions["2000"].Index).Child("args"))...)
@@ -31,7 +31,7 @@ func (r *Ruleset) validateV01RuleOptions(ruleOptions map[string]internalconfig.I
 	allErrs = append(allErrs, validateV01Options[rules.Options2007](ruleOptions["2007"].Args, fldPath.Index(ruleOptions["2007"].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV01Options[rules.Options2008](ruleOptions["2008"].Args, fldPath.Index(ruleOptions["2008"].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV01Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig
@@ -143,7 +143,7 @@ func validateV01Options[O rules.RuleOption](options any, fldPath *field.Path) fi
 	parsedOptions, err := getV01OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 

--- a/pkg/provider/managedk8s/validate.go
+++ b/pkg/provider/managedk8s/validate.go
@@ -42,13 +42,9 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			if err := disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
-				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
-			}
+			allErrs = append(allErrs, disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
 		case securityhardenedk8s.RulesetID:
-			if err := securityhardenedk8s.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
-				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
-			}
+			allErrs = append(allErrs, securityhardenedk8s.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
 		default:
 			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID, securityhardenedk8s.RulesetID}))
 		}

--- a/pkg/provider/managedk8s/validate.go
+++ b/pkg/provider/managedk8s/validate.go
@@ -28,11 +28,11 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
 	}
 
-	seenRulesets := make(map[string]struct{})
+	seenRulesets := make(map[struct{ ID, Version string }]struct{})
 	for rulesetIdx, rulesetConfig := range conf.Rulesets {
 		var (
 			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
-			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+			rulesetKey  = struct{ ID, Version string }{rulesetConfig.ID, rulesetConfig.Version}
 		)
 		if _, seen := seenRulesets[rulesetKey]; seen {
 			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))

--- a/pkg/provider/managedk8s/validate.go
+++ b/pkg/provider/managedk8s/validate.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package managedk8s
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig"
+	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s"
+)
+
+// ValidateProviderConfig validates a ManagedK8S provider configuration structurally.
+func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	providerArgsByte, err := json.Marshal(conf.Args)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	var args providerArgs
+	if err := json.Unmarshal(providerArgsByte, &args); err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	seenRulesets := make(map[string]struct{})
+	for rulesetIdx, rulesetConfig := range conf.Rulesets {
+		var (
+			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
+			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+		)
+		if _, seen := seenRulesets[rulesetKey]; seen {
+			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))
+			continue
+		}
+		seenRulesets[rulesetKey] = struct{}{}
+
+		switch rulesetConfig.ID {
+		case disak8sstig.RulesetID:
+			if err := disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
+				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
+			}
+		case securityhardenedk8s.RulesetID:
+			if err := securityhardenedk8s.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
+				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
+			}
+		default:
+			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID, securityhardenedk8s.RulesetID}))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/provider/managedk8s/validate_test.go
+++ b/pkg/provider/managedk8s/validate_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package managedk8s_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/managedk8s"
+)
+
+var _ = Describe("ValidateProviderConfig", func() {
+	var fldPath *field.Path
+
+	BeforeEach(func() {
+		fldPath = field.NewPath("providers").Index(0)
+	})
+
+	It("should return no errors for a valid config", func() {
+		conf := config.ProviderConfig{
+			ID:   "managedk8s",
+			Name: "ManagedK8S",
+			Args: map[string]string{
+				"kubeconfigPath": "/path/to/kubeconfig",
+			},
+			Rulesets: []config.RulesetConfig{
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+			},
+		}
+
+		errs := managedk8s.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("should return error for unsupported ruleset ID", func() {
+		conf := config.ProviderConfig{
+			ID:   "managedk8s",
+			Name: "ManagedK8S",
+			Args: map[string]any{},
+			Rulesets: []config.RulesetConfig{
+				{ID: "unknown-ruleset", Version: "v1"},
+			},
+		}
+
+		errs := managedk8s.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[0].id"))
+	})
+
+	It("should return error for duplicate ruleset ID and version", func() {
+		conf := config.ProviderConfig{
+			ID:   "managedk8s",
+			Name: "ManagedK8S",
+			Args: map[string]any{},
+			Rulesets: []config.RulesetConfig{
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+			},
+		}
+
+		errs := managedk8s.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[1]"))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeDuplicate))
+	})
+
+	It("should return error for invalid args", func() {
+		conf := config.ProviderConfig{
+			ID:   "managedk8s",
+			Name: "ManagedK8S",
+			Args: "not-a-map",
+		}
+
+		errs := managedk8s.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].args"))
+	})
+})

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -42,9 +42,13 @@ type MetadataFunc func() metadata.ProviderDetailed
 // DefaultDikiConfigFunc constructs a default [config.DikiConfig] for a specific provider.
 type DefaultDikiConfigFunc func() config.DikiConfig
 
+// ValidateConfigFunc validates a [config.ProviderConfig]. It returns a list of validation errors.
+type ValidateConfigFunc func(conf config.ProviderConfig, fldPath *field.Path) field.ErrorList
+
 // ProviderOption constructs a pair of a configuration and metadata function for a specific provider.
 type ProviderOption struct {
 	ProviderFromConfigFunc
+	ValidateConfigFunc
 	MetadataFunc
 	DefaultDikiConfigFunc
 }

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -87,8 +87,8 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, runtimeConfig *rest.Config, fldPath *field.Path) (*Ruleset, error) {
-	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
-		return nil, err
+	if errs := ValidateRulesetConfig(rulesetConfig, fldPath); len(errs) > 0 {
+		return nil, errs.ToAggregate()
 	}
 
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
@@ -124,31 +124,35 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 }
 
 // ValidateRulesetConfig validates a [config.RulesetConfig].
-func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
 	var rulesetArgs Args
 	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
 	}
 
 	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
 	if err != nil {
-		return err
+		return append(allErrs, field.Invalid(fldPath.Child("ruleOptions"), rulesetConfig.RuleOptions, err.Error()))
 	}
 
 	r := &Ruleset{}
 	switch rulesetConfig.Version {
 	case "v2r4":
-		return r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+		allErrs = append(allErrs, r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	case "v2r5":
-		return r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+		allErrs = append(allErrs, r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))...)
 	default:
-		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "virtualgarden")
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, SupportedVersions))
 	}
+
+	return allErrs
 }
 
 func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/diki/pkg/config"
-	internalconfig "github.com/gardener/diki/pkg/internal/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
 	sharedruleset "github.com/gardener/diki/pkg/shared/ruleset"
@@ -88,6 +87,10 @@ func (r *Ruleset) Version() string {
 
 // FromGenericConfig creates a Ruleset from a RulesetConfig
 func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabels map[string]string, runtimeConfig *rest.Config, fldPath *field.Path) (*Ruleset, error) {
+	if err := ValidateRulesetConfig(rulesetConfig, fldPath); err != nil {
+		return nil, err
+	}
+
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
 		return nil, err
@@ -108,40 +111,55 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, additionalOpsPodLabel
 		return nil, err
 	}
 
-	var (
-		ruleOptions        = make(map[string]config.RuleOptionsConfig)
-		indexedRuleOptions = make(map[string]internalconfig.IndexedRuleOptionsConfig)
-	)
-
-	for index, opt := range rulesetConfig.RuleOptions {
-		if _, ok := ruleOptions[opt.RuleID]; ok {
-			return nil, fmt.Errorf("rule option for rule id: %s is already registered", opt.RuleID)
-		}
-
+	ruleOptions := make(map[string]config.RuleOptionsConfig)
+	for _, opt := range rulesetConfig.RuleOptions {
 		ruleOptions[opt.RuleID] = opt
-		indexedRuleOptions[opt.RuleID] = internalconfig.IndexedRuleOptionsConfig{Index: index, RuleOptionsConfig: opt}
 	}
 
-	switch rulesetConfig.Version {
-	case "v2r4":
-		if err := ruleset.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV2R4Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	case "v2r5":
-		if err := ruleset.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions")); err != nil {
-			return nil, err
-		}
-		if err := ruleset.registerV2R5Rules(ruleOptions); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider virtualgarden' to see the provider's supported rulesets", rulesetConfig.ID, rulesetConfig.Version)
+	if err := ruleset.registerRules(ruleOptions); err != nil {
+		return nil, err
 	}
 
 	return ruleset, nil
+}
+
+// ValidateRulesetConfig validates a [config.RulesetConfig].
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) error {
+	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
+	if err != nil {
+		return err
+	}
+
+	var rulesetArgs Args
+	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
+		return err
+	}
+
+	indexedRuleOptions, err := sharedruleset.IndexRuleOptions(rulesetConfig.RuleOptions)
+	if err != nil {
+		return err
+	}
+
+	r := &Ruleset{}
+	switch rulesetConfig.Version {
+	case "v2r4":
+		return r.validateV2R4RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+	case "v2r5":
+		return r.validateV2R5RuleOptions(indexedRuleOptions, fldPath.Child("ruleOptions"))
+	default:
+		return sharedruleset.UnknownVersionError(rulesetConfig.ID, rulesetConfig.Version, "virtualgarden")
+	}
+}
+
+func (r *Ruleset) registerRules(ruleOptions map[string]config.RuleOptionsConfig) error {
+	switch r.version {
+	case "v2r4":
+		return r.registerV2R4Rules(ruleOptions)
+	case "v2r5":
+		return r.registerV2R5Rules(ruleOptions)
+	default:
+		return sharedruleset.UnknownVersionError(r.ID(), r.Version(), "virtualgarden")
+	}
 }
 
 // RunRule executes specific known Rule of the Ruleset.

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r4_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r4_ruleset.go
@@ -28,7 +28,7 @@ func validateV2R4Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	parsedOptions, err := getV2R4OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 
@@ -43,7 +43,7 @@ func validateV2R4Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	return nil
 }
 
-func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R4Options[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args, fldPath.Index(ruleOptions[sharedrules.ID242390].Index).Child("args"))...)
@@ -53,7 +53,7 @@ func (r *Ruleset) validateV2R4RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R4Options[disaoption.FileOwnerOptions](ruleOptions[sharedrules.ID242451].Args, fldPath.Index(ruleOptions[sharedrules.ID242451].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R4Options[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args, fldPath.Index(ruleOptions[sharedrules.ID245543].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV2R4Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r5_ruleset.go
@@ -28,7 +28,7 @@ func validateV2R5Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	parsedOptions, err := getV2R5OptionOrNil[O](options)
 	if err != nil {
 		return field.ErrorList{
-			field.InternalError(fldPath, err),
+			field.Invalid(fldPath, options, err.Error()),
 		}
 	}
 
@@ -43,7 +43,7 @@ func validateV2R5Options[O rules.RuleOption](options any, fldPath *field.Path) f
 	return nil
 }
 
-func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) error {
+func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.IndexedRuleOptionsConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateV2R5Options[sharedrules.Options242390](ruleOptions[sharedrules.ID242390].Args, fldPath.Index(ruleOptions[sharedrules.ID242390].Index).Child("args"))...)
@@ -53,7 +53,7 @@ func (r *Ruleset) validateV2R5RuleOptions(ruleOptions map[string]internalconfig.
 	allErrs = append(allErrs, validateV2R5Options[disaoption.FileOwnerOptions](ruleOptions[sharedrules.ID242451].Args, fldPath.Index(ruleOptions[sharedrules.ID242451].Index).Child("args"))...)
 	allErrs = append(allErrs, validateV2R5Options[sharedrules.Options245543](ruleOptions[sharedrules.ID245543].Args, fldPath.Index(ruleOptions[sharedrules.ID245543].Index).Child("args"))...)
 
-	return allErrs.ToAggregate()
+	return allErrs
 }
 
 func (r *Ruleset) registerV2R5Rules(ruleOptions map[string]config.RuleOptionsConfig) error { // TODO: add to FromGenericConfig

--- a/pkg/provider/virtualgarden/validate.go
+++ b/pkg/provider/virtualgarden/validate.go
@@ -27,11 +27,11 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
 	}
 
-	seenRulesets := make(map[string]struct{})
+	seenRulesets := make(map[struct{ ID, Version string }]struct{})
 	for rulesetIdx, rulesetConfig := range conf.Rulesets {
 		var (
 			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
-			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+			rulesetKey  = struct{ ID, Version string }{rulesetConfig.ID, rulesetConfig.Version}
 		)
 		if _, seen := seenRulesets[rulesetKey]; seen {
 			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))

--- a/pkg/provider/virtualgarden/validate.go
+++ b/pkg/provider/virtualgarden/validate.go
@@ -41,9 +41,7 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 
 		switch rulesetConfig.ID {
 		case disak8sstig.RulesetID:
-			if err := disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
-				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
-			}
+			allErrs = append(allErrs, disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
 		default:
 			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID}))
 		}

--- a/pkg/provider/virtualgarden/validate.go
+++ b/pkg/provider/virtualgarden/validate.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualgarden
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/virtualgarden/ruleset/disak8sstig"
+)
+
+// ValidateProviderConfig validates a Virtual Garden provider configuration structurally.
+func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	providerArgsByte, err := json.Marshal(conf.Args)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	var args providerArgs
+	if err := json.Unmarshal(providerArgsByte, &args); err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
+	}
+
+	seenRulesets := make(map[string]struct{})
+	for rulesetIdx, rulesetConfig := range conf.Rulesets {
+		var (
+			rulesetPath = fldPath.Child("rulesets").Index(rulesetIdx)
+			rulesetKey  = rulesetConfig.ID + "/" + rulesetConfig.Version
+		)
+		if _, seen := seenRulesets[rulesetKey]; seen {
+			allErrs = append(allErrs, field.Duplicate(rulesetPath, rulesetKey))
+			continue
+		}
+		seenRulesets[rulesetKey] = struct{}{}
+
+		switch rulesetConfig.ID {
+		case disak8sstig.RulesetID:
+			if err := disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath); err != nil {
+				allErrs = append(allErrs, field.InternalError(rulesetPath, err))
+			}
+		default:
+			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID}))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/provider/virtualgarden/validate_test.go
+++ b/pkg/provider/virtualgarden/validate_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualgarden_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/provider/virtualgarden"
+)
+
+var _ = Describe("ValidateProviderConfig", func() {
+	var fldPath *field.Path
+
+	BeforeEach(func() {
+		fldPath = field.NewPath("providers").Index(0)
+	})
+
+	It("should return no errors for a valid config", func() {
+		conf := config.ProviderConfig{
+			ID:   "virtualgarden",
+			Name: "Virtual Garden",
+			Args: map[string]string{
+				"runtimeKubeconfigPath": "/path/to/kubeconfig",
+			},
+			Rulesets: []config.RulesetConfig{
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+			},
+		}
+
+		errs := virtualgarden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("should return error for unsupported ruleset ID", func() {
+		conf := config.ProviderConfig{
+			ID:   "virtualgarden",
+			Name: "Virtual Garden",
+			Args: map[string]any{},
+			Rulesets: []config.RulesetConfig{
+				{ID: "unknown-ruleset", Version: "v1"},
+			},
+		}
+
+		errs := virtualgarden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[0].id"))
+	})
+
+	It("should return error for duplicate ruleset ID and version", func() {
+		conf := config.ProviderConfig{
+			ID:   "virtualgarden",
+			Name: "Virtual Garden",
+			Args: map[string]any{},
+			Rulesets: []config.RulesetConfig{
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+				{ID: "disa-kubernetes-stig", Version: "v2r5"},
+			},
+		}
+
+		errs := virtualgarden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].rulesets[1]"))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeDuplicate))
+	})
+
+	It("should return error for invalid args", func() {
+		conf := config.ProviderConfig{
+			ID:   "virtualgarden",
+			Name: "Virtual Garden",
+			Args: "not-a-map",
+		}
+
+		errs := virtualgarden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("providers[0].args"))
+	})
+})

--- a/pkg/provider/virtualgarden/virtualgarden_suite_test.go
+++ b/pkg/provider/virtualgarden/virtualgarden_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualgarden_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVirtualGarden(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Provider VirtualGarden Suite")
+}

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -36,7 +36,7 @@ func (o FileOwnerOptions) Validate(fldPath *field.Path) field.ErrorList {
 	for uIdx, user := range o.ExpectedFileOwner.Users {
 		userID, err := strconv.ParseInt(user, 10, 64)
 		if err != nil {
-			allErrs = append(allErrs, field.InternalError(expectedFileOwnerPath.Child("users").Index(uIdx), err))
+			allErrs = append(allErrs, field.Invalid(expectedFileOwnerPath.Child("users").Index(uIdx), user, err.Error()))
 			continue
 		}
 		for _, msg := range validation.IsValidUserID(userID) {
@@ -47,7 +47,7 @@ func (o FileOwnerOptions) Validate(fldPath *field.Path) field.ErrorList {
 	for gIdx, group := range o.ExpectedFileOwner.Groups {
 		groupID, err := strconv.ParseInt(group, 10, 64)
 		if err != nil {
-			allErrs = append(allErrs, field.InternalError(expectedFileOwnerPath.Child("groups").Index(gIdx), err))
+			allErrs = append(allErrs, field.Invalid(expectedFileOwnerPath.Child("groups").Index(gIdx), group, err.Error()))
 			continue
 		}
 		for _, msg := range validation.IsValidGroupID(groupID) {

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -31,15 +31,16 @@ var _ = Describe("options", func() {
 				"BadValue": Equal("-1"),
 			})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInternal),
+					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("foo.expectedFileOwner.groups[0]"),
-					"BadValue": BeNil(),
+					"BadValue": Equal(""),
 					"Detail":   Equal("strconv.ParseInt: parsing \"\": invalid syntax"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInternal),
-					"Field":  Equal("foo.expectedFileOwner.groups[1]"),
-					"Detail": Equal("strconv.ParseInt: parsing \"asd\": invalid syntax"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("foo.expectedFileOwner.groups[1]"),
+					"BadValue": Equal("asd"),
+					"Detail":   Equal("strconv.ParseInt: parsing \"asd\": invalid syntax"),
 				})),
 			))
 		})

--- a/pkg/shared/ruleset/ruleset.go
+++ b/pkg/shared/ruleset/ruleset.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/gardener/diki/pkg/config"
+	internalconfig "github.com/gardener/diki/pkg/internal/config"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
 	"github.com/gardener/diki/pkg/shared/provider"
@@ -109,4 +111,21 @@ func Run(
 		return ruleset.RulesetResult{}, err
 	}
 	return result, nil
+}
+
+// UnknownVersionError returns a standardized error for unsupported ruleset versions.
+func UnknownVersionError(rulesetID, version, providerID string) error {
+	return fmt.Errorf("unknown ruleset %s version: %s - use 'diki show provider %s' to see the provider's supported rulesets", rulesetID, version, providerID)
+}
+
+// IndexRuleOptions builds an indexed map of rule options, returning an error if duplicate rule IDs are found.
+func IndexRuleOptions(ruleOptions []config.RuleOptionsConfig) (map[string]internalconfig.IndexedRuleOptionsConfig, error) {
+	indexed := make(map[string]internalconfig.IndexedRuleOptionsConfig, len(ruleOptions))
+	for index, opt := range ruleOptions {
+		if _, ok := indexed[opt.RuleID]; ok {
+			return nil, fmt.Errorf("rule option for rule id: %s is already registered", opt.RuleID)
+		}
+		indexed[opt.RuleID] = internalconfig.IndexedRuleOptionsConfig{Index: index, RuleOptionsConfig: opt}
+	}
+	return indexed, nil
 }

--- a/pkg/shared/ruleset/ruleset_suite_test.go
+++ b/pkg/shared/ruleset/ruleset_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ruleset_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSharedRuleset(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shared Ruleset Test Suite")
+}

--- a/pkg/shared/ruleset/ruleset_test.go
+++ b/pkg/shared/ruleset/ruleset_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ruleset_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/diki/pkg/config"
+	sharedruleset "github.com/gardener/diki/pkg/shared/ruleset"
+)
+
+var _ = Describe("Ruleset", func() {
+	Describe("UnknownVersionError", func() {
+		It("should return an error with the correct format", func() {
+			err := sharedruleset.UnknownVersionError("disa-kubernetes-stig", "v99", "gardener")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown ruleset disa-kubernetes-stig version: v99 - use 'diki show provider gardener' to see the provider's supported rulesets"))
+		})
+	})
+
+	Describe("IndexRuleOptions", func() {
+		It("should return an empty map for empty input", func() {
+			indexed, err := sharedruleset.IndexRuleOptions(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(indexed).To(BeEmpty())
+		})
+
+		It("should index rule options by rule ID", func() {
+			ruleOptions := []config.RuleOptionsConfig{
+				{RuleID: "rule-1", Args: "args1"},
+				{RuleID: "rule-2", Args: "args2"},
+				{RuleID: "rule-3", Args: "args3"},
+			}
+
+			indexed, err := sharedruleset.IndexRuleOptions(ruleOptions)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(indexed).To(HaveLen(3))
+			Expect(indexed["rule-1"].Index).To(Equal(0))
+			Expect(indexed["rule-1"].RuleID).To(Equal("rule-1"))
+			Expect(indexed["rule-2"].Index).To(Equal(1))
+			Expect(indexed["rule-3"].Index).To(Equal(2))
+		})
+
+		It("should return an error for duplicate rule IDs", func() {
+			ruleOptions := []config.RuleOptionsConfig{
+				{RuleID: "rule-1", Args: "args1"},
+				{RuleID: "rule-2", Args: "args2"},
+				{RuleID: "rule-1", Args: "args3"},
+			}
+
+			indexed, err := sharedruleset.IndexRuleOptions(ruleOptions)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("rule option for rule id: rule-1 is already registered"))
+			Expect(indexed).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Adds a `diki config validate` command that validated the structure and content of a diki configuration file. This is useful for catching configuration errors early (e.g. in CI) before attempting a full `diki run`.

The command validates:
- Provider IDs are known/registered
- No duplicate provider IDs
- Provider args parse correctly and required fields are present
- Ruleset IDs+Versions are supported for each provider
- No duplicate ruleset ID+Version combinations
- Per-rule option type/field validation
- Required ruleset args (e.g. `shootName`, `projectNamespace` for the garden provider)

Usage:
```bash
diki config validate config.yaml
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added `diki config validate` command for structural and content validation of configuration files
```
