### PR TITLE
Add missing validations for provider args and AcceptedPodVolumes

### DIFF
--- a/pkg/provider/garden/validate.go
+++ b/pkg/provider/garden/validate.go
@@ -27,6 +27,10 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
 	}
 
+	if len(args.KubeconfigPath) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "kubeconfigPath"), ""))
+	}
+
 	seenRulesets := make(map[struct{ ID, Version string }]struct{})
 	for rulesetIdx, rulesetConfig := range conf.Rulesets {
 		var (

--- a/pkg/provider/garden/validate_test.go
+++ b/pkg/provider/garden/validate_test.go
@@ -96,6 +96,19 @@ var _ = Describe("ValidateProviderConfig", func() {
 		Expect(errs[1].Field).To(Equal("providers[0].rulesets[0].args.projectNamespace"))
 	})
 
+	It("should return error for missing required provider args", func() {
+		conf := config.ProviderConfig{
+			ID:   "garden",
+			Name: "Garden",
+			Args: map[string]any{},
+		}
+
+		errs := garden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+		Expect(errs[0].Field).To(Equal("providers[0].args.kubeconfigPath"))
+	})
+
 	It("should return error for invalid args", func() {
 		conf := config.ProviderConfig{
 			ID:   "garden",

--- a/pkg/provider/garden/validate_test.go
+++ b/pkg/provider/garden/validate_test.go
@@ -44,7 +44,9 @@ var _ = Describe("ValidateProviderConfig", func() {
 		conf := config.ProviderConfig{
 			ID:   "garden",
 			Name: "Garden",
-			Args: map[string]any{},
+			Args: map[string]string{
+				"kubeconfigPath": "/path/to/kubeconfig",
+			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "unknown-ruleset", Version: "v1"},
 			},
@@ -59,7 +61,9 @@ var _ = Describe("ValidateProviderConfig", func() {
 		conf := config.ProviderConfig{
 			ID:   "garden",
 			Name: "Garden",
-			Args: map[string]any{},
+			Args: map[string]string{
+				"kubeconfigPath": "/path/to/kubeconfig",
+			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "security-hardened-shoot-cluster", Version: "v0.2.1", Args: map[string]string{"shootName": "my-shoot", "projectNamespace": "garden-my-project"}},
 				{ID: "security-hardened-shoot-cluster", Version: "v0.2.1", Args: map[string]string{"shootName": "my-shoot", "projectNamespace": "garden-my-project"}},
@@ -76,7 +80,9 @@ var _ = Describe("ValidateProviderConfig", func() {
 		conf := config.ProviderConfig{
 			ID:   "garden",
 			Name: "Garden",
-			Args: map[string]any{},
+			Args: map[string]string{
+				"kubeconfigPath": "/path/to/kubeconfig",
+			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "security-hardened-shoot-cluster", Version: "v0.2.1", Args: map[string]any{}},
 			},

--- a/pkg/provider/gardener/validate.go
+++ b/pkg/provider/gardener/validate.go
@@ -33,6 +33,12 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 	if len(args.ShootNamespace) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("args", "shootNamespace"), ""))
 	}
+	if len(args.ShootKubeconfigPath) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "shootKubeconfigPath"), ""))
+	}
+	if len(args.SeedKubeconfigPath) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "seedKubeconfigPath"), ""))
+	}
 
 	seenRulesets := make(map[struct{ ID, Version string }]struct{})
 	for rulesetIdx, rulesetConfig := range conf.Rulesets {

--- a/pkg/provider/gardener/validate_test.go
+++ b/pkg/provider/gardener/validate_test.go
@@ -25,10 +25,10 @@ var _ = Describe("ValidateProviderConfig", func() {
 			ID:   "gardener",
 			Name: "Gardener",
 			Args: map[string]string{
-				"shootName":            "my-shoot",
-				"shootNamespace":       "garden-dev",
-				"shootKubeconfigPath":  "/path/to/shoot/kubeconfig",
-				"seedKubeconfigPath":   "/path/to/seed/kubeconfig",
+				"shootName":           "my-shoot",
+				"shootNamespace":      "garden-dev",
+				"shootKubeconfigPath": "/path/to/shoot/kubeconfig",
+				"seedKubeconfigPath":  "/path/to/seed/kubeconfig",
 			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "disa-kubernetes-stig", Version: "v2r5"},
@@ -59,10 +59,10 @@ var _ = Describe("ValidateProviderConfig", func() {
 			ID:   "gardener",
 			Name: "Gardener",
 			Args: map[string]string{
-				"shootName":            "my-shoot",
-				"shootNamespace":       "garden-dev",
-				"shootKubeconfigPath":  "/path/to/shoot/kubeconfig",
-				"seedKubeconfigPath":   "/path/to/seed/kubeconfig",
+				"shootName":           "my-shoot",
+				"shootNamespace":      "garden-dev",
+				"shootKubeconfigPath": "/path/to/shoot/kubeconfig",
+				"seedKubeconfigPath":  "/path/to/seed/kubeconfig",
 			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "unknown-ruleset", Version: "v1"},
@@ -79,10 +79,10 @@ var _ = Describe("ValidateProviderConfig", func() {
 			ID:   "gardener",
 			Name: "Gardener",
 			Args: map[string]string{
-				"shootName":            "my-shoot",
-				"shootNamespace":       "garden-dev",
-				"shootKubeconfigPath":  "/path/to/shoot/kubeconfig",
-				"seedKubeconfigPath":   "/path/to/seed/kubeconfig",
+				"shootName":           "my-shoot",
+				"shootNamespace":      "garden-dev",
+				"shootKubeconfigPath": "/path/to/shoot/kubeconfig",
+				"seedKubeconfigPath":  "/path/to/seed/kubeconfig",
 			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "disa-kubernetes-stig", Version: "v2r5"},

--- a/pkg/provider/gardener/validate_test.go
+++ b/pkg/provider/gardener/validate_test.go
@@ -25,8 +25,10 @@ var _ = Describe("ValidateProviderConfig", func() {
 			ID:   "gardener",
 			Name: "Gardener",
 			Args: map[string]string{
-				"shootName":      "my-shoot",
-				"shootNamespace": "garden-dev",
+				"shootName":            "my-shoot",
+				"shootNamespace":       "garden-dev",
+				"shootKubeconfigPath":  "/path/to/shoot/kubeconfig",
+				"seedKubeconfigPath":   "/path/to/seed/kubeconfig",
 			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "disa-kubernetes-stig", Version: "v2r5"},
@@ -45,9 +47,11 @@ var _ = Describe("ValidateProviderConfig", func() {
 		}
 
 		errs := gardener.ValidateProviderConfig(conf, fldPath)
-		Expect(errs).To(HaveLen(2))
+		Expect(errs).To(HaveLen(4))
 		Expect(errs[0].Field).To(Equal("providers[0].args.shootName"))
 		Expect(errs[1].Field).To(Equal("providers[0].args.shootNamespace"))
+		Expect(errs[2].Field).To(Equal("providers[0].args.shootKubeconfigPath"))
+		Expect(errs[3].Field).To(Equal("providers[0].args.seedKubeconfigPath"))
 	})
 
 	It("should return error for unsupported ruleset ID", func() {
@@ -55,8 +59,10 @@ var _ = Describe("ValidateProviderConfig", func() {
 			ID:   "gardener",
 			Name: "Gardener",
 			Args: map[string]string{
-				"shootName":      "my-shoot",
-				"shootNamespace": "garden-dev",
+				"shootName":            "my-shoot",
+				"shootNamespace":       "garden-dev",
+				"shootKubeconfigPath":  "/path/to/shoot/kubeconfig",
+				"seedKubeconfigPath":   "/path/to/seed/kubeconfig",
 			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "unknown-ruleset", Version: "v1"},
@@ -73,8 +79,10 @@ var _ = Describe("ValidateProviderConfig", func() {
 			ID:   "gardener",
 			Name: "Gardener",
 			Args: map[string]string{
-				"shootName":      "my-shoot",
-				"shootNamespace": "garden-dev",
+				"shootName":            "my-shoot",
+				"shootNamespace":       "garden-dev",
+				"shootKubeconfigPath":  "/path/to/shoot/kubeconfig",
+				"seedKubeconfigPath":   "/path/to/seed/kubeconfig",
 			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "disa-kubernetes-stig", Version: "v2r5"},

--- a/pkg/provider/virtualgarden/validate.go
+++ b/pkg/provider/virtualgarden/validate.go
@@ -27,6 +27,10 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 		return append(allErrs, field.Invalid(fldPath.Child("args"), conf.Args, err.Error()))
 	}
 
+	if len(args.RuntimeKubeconfigPath) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("args", "runtimeKubeconfigPath"), ""))
+	}
+
 	seenRulesets := make(map[struct{ ID, Version string }]struct{})
 	for rulesetIdx, rulesetConfig := range conf.Rulesets {
 		var (

--- a/pkg/provider/virtualgarden/validate_test.go
+++ b/pkg/provider/virtualgarden/validate_test.go
@@ -40,7 +40,9 @@ var _ = Describe("ValidateProviderConfig", func() {
 		conf := config.ProviderConfig{
 			ID:   "virtualgarden",
 			Name: "Virtual Garden",
-			Args: map[string]any{},
+			Args: map[string]string{
+				"runtimeKubeconfigPath": "/path/to/kubeconfig",
+			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "unknown-ruleset", Version: "v1"},
 			},
@@ -55,7 +57,9 @@ var _ = Describe("ValidateProviderConfig", func() {
 		conf := config.ProviderConfig{
 			ID:   "virtualgarden",
 			Name: "Virtual Garden",
-			Args: map[string]any{},
+			Args: map[string]string{
+				"runtimeKubeconfigPath": "/path/to/kubeconfig",
+			},
 			Rulesets: []config.RulesetConfig{
 				{ID: "disa-kubernetes-stig", Version: "v2r5"},
 				{ID: "disa-kubernetes-stig", Version: "v2r5"},

--- a/pkg/provider/virtualgarden/validate_test.go
+++ b/pkg/provider/virtualgarden/validate_test.go
@@ -72,6 +72,19 @@ var _ = Describe("ValidateProviderConfig", func() {
 		Expect(errs[0].Type).To(Equal(field.ErrorTypeDuplicate))
 	})
 
+	It("should return error for missing required provider args", func() {
+		conf := config.ProviderConfig{
+			ID:   "virtualgarden",
+			Name: "Virtual Garden",
+			Args: map[string]any{},
+		}
+
+		errs := virtualgarden.ValidateProviderConfig(conf, fldPath)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+		Expect(errs[0].Field).To(Equal("providers[0].args.runtimeKubeconfigPath"))
+	})
+
 	It("should return error for invalid args", func() {
 		conf := config.ProviderConfig{
 			ID:   "virtualgarden",

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -156,6 +156,8 @@ func (a *AcceptedPodVolumes) Validate(fldPath *field.Path) field.ErrorList {
 		allErrs               field.ErrorList
 	)
 
+	allErrs = append(allErrs, a.NamespacedObjectSelector.Validate(fldPath)...)
+
 	if len(a.VolumeNames) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeNames"), "must not be empty"))
 	}

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -458,6 +458,26 @@ var _ = Describe("options", func() {
 			results := option.Validate(field.NewPath("foo"))
 			Expect(results).To(BeNil())
 		})
+
+		It("should validate the embedded namespaced object selector", func() {
+			option := option.AcceptedPodVolumes{
+				AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+					NamespacedObjectSelector: option.NamespacedObjectSelector{},
+				},
+				VolumeNames: []string{"valid-volume"},
+			}
+
+			results := option.Validate(field.NewPath("foo"))
+
+			Expect(results).ToNot(BeEmpty())
+			Expect(results).To(ContainElement(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("foo"),
+					"Detail": ContainSubstring("labelSelector and namespaceLabelSelector must be set"),
+				})),
+			))
+		})
 	})
 
 	Describe("MatchesAcceptedPodVolumes", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds missing provider args validations for the `config validate` command. It also adds missing validation for the `AcceptedPodVolumes` options, which are used by rules 2003 and 2008 of the Security Hardened Kubernetes ruleset

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Improved validation of rule options for Security Hardened Kubernetes rules 2003 and 2008.
```
