### PR TITLE
chore(ci): use client-id for gardener-github-pkg-mngr app token

### DIFF
--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -41,7 +41,7 @@ jobs:
         id: gardener-github-workflows
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1   # v3.2.0
         with:
-          app-id:      ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID }}
+          client-id:   ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID }}
           private-key: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY }}
           owner:       ${{ github.repository_owner }}
           repositories: |


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/kind cleanup

**What this PR does / why we need it**:
The `app-id` input of `actions/create-github-app-token` is deprecated in favor of `client-id`. This PR renames the workflow secret from `GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID` to `GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID` and passes it as `client-id` to the action.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The new secret `GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID` is already in place at the org level and ready to be consumed by the repos.

**Release note**:
```other dependency
NONE
```