### PR TITLE
[Security Hardened Kubernetes Cluster] Implement `MergeableOption` for all rules

### DIFF
--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -1256,5 +1256,14 @@ var _ = Describe("#2000", func() {
 			Expect(ok).To(BeTrue())
 			Expect(mergedOpts.AcceptedNamespaces).To(BeEmpty())
 		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2000{}
+			other := &rules.Options2001{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -52,6 +52,8 @@ func (o Options2001) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// Merge returns a new Options2001 that is the result of merging other into the receiver.
+// AcceptedPods slices are concatenated. If other is not *Options2001, an error is returned.
 func (o *Options2001) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -23,9 +24,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2001{}
-	_ rule.Severity = &Rule2001{}
-	_ option.Option = &Options2001{}
+	_ rule.Rule              = &Rule2001{}
+	_ rule.Severity          = &Rule2001{}
+	_ option.Option          = &Options2001{}
+	_ option.MergeableOption = &Options2001{}
 )
 
 type Rule2001 struct {
@@ -48,6 +50,25 @@ func (o Options2001) Validate(fldPath *field.Path) field.ErrorList {
 	}
 
 	return allErrs
+}
+
+func (o *Options2001) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2001)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2001", other)
+	}
+
+	merged := &Options2001{
+		AcceptedPods: make([]option.AcceptedNamespacedObject, 0, len(o.AcceptedPods)+len(otherOpts.AcceptedPods)),
+	}
+	merged.AcceptedPods = append(merged.AcceptedPods, o.AcceptedPods...)
+	merged.AcceptedPods = append(merged.AcceptedPods, otherOpts.AcceptedPods...)
+
+	return merged, nil
 }
 
 func (r *Rule2001) ID() string {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
@@ -208,4 +208,74 @@ var _ = Describe("#2001", func() {
 			},
 		))
 	})
+
+	Describe("#Merge Options2001", func() {
+		It("should merge two Options2001 by appending AcceptedPods", func() {
+			base := &rules.Options2001{
+				AcceptedPods: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "base"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "base"}},
+						},
+						Justification: "base justification",
+					},
+				},
+			}
+
+			override := &rules.Options2001{
+				AcceptedPods: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "override"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "override"}},
+						},
+						Justification: "override justification",
+					},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2001)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedPods[0].Justification).To(Equal("base justification"))
+			Expect(mergedOpts.AcceptedPods[1].Justification).To(Equal("override justification"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2001{
+				AcceptedPods: []option.AcceptedNamespacedObject{
+					{Justification: "base"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2001", func() {
+			base := &rules.Options2001{}
+			other := &rules.Options2001{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2001)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2001{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"cmp"
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,9 +21,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2002{}
-	_ rule.Severity = &Rule2002{}
-	_ option.Option = &Options2002{}
+	_ rule.Rule              = &Rule2002{}
+	_ rule.Severity          = &Rule2002{}
+	_ option.Option          = &Options2002{}
+	_ option.MergeableOption = &Options2002{}
 )
 
 type Rule2002 struct {
@@ -45,6 +47,25 @@ func (o Options2002) Validate(fldPath *field.Path) field.ErrorList {
 	}
 
 	return allErrs
+}
+
+func (o *Options2002) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2002)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2002", other)
+	}
+
+	merged := &Options2002{
+		AcceptedStorageClasses: make([]option.AcceptedClusterObject, 0, len(o.AcceptedStorageClasses)+len(otherOpts.AcceptedStorageClasses)),
+	}
+	merged.AcceptedStorageClasses = append(merged.AcceptedStorageClasses, o.AcceptedStorageClasses...)
+	merged.AcceptedStorageClasses = append(merged.AcceptedStorageClasses, otherOpts.AcceptedStorageClasses...)
+
+	return merged, nil
 }
 
 func (r *Rule2002) ID() string {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
@@ -49,6 +49,8 @@ func (o Options2002) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// Merge returns a new Options2002 that is the result of merging other into the receiver.
+// AcceptedStorageClasses slices are concatenated. If other is not *Options2002, an error is returned.
 func (o *Options2002) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
@@ -156,4 +156,72 @@ var _ = Describe("#2002", func() {
 			},
 		),
 	)
+
+	Describe("#Merge Options2002", func() {
+		It("should merge two Options2002 by appending AcceptedStorageClasses", func() {
+			base := &rules.Options2002{
+				AcceptedStorageClasses: []option.AcceptedClusterObject{
+					{
+						ClusterObjectSelector: option.ClusterObjectSelector{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"type": "base"}},
+						},
+						Justification: "base justification",
+					},
+				},
+			}
+
+			override := &rules.Options2002{
+				AcceptedStorageClasses: []option.AcceptedClusterObject{
+					{
+						ClusterObjectSelector: option.ClusterObjectSelector{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"type": "override"}},
+						},
+						Justification: "override justification",
+					},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2002)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedStorageClasses).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedStorageClasses[0].Justification).To(Equal("base justification"))
+			Expect(mergedOpts.AcceptedStorageClasses[1].Justification).To(Equal("override justification"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2002{
+				AcceptedStorageClasses: []option.AcceptedClusterObject{
+					{Justification: "base"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2002", func() {
+			base := &rules.Options2002{}
+			other := &rules.Options2002{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2002)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedStorageClasses).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2002{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -42,6 +42,8 @@ func (o Options2003) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// Merge returns a new Options2003 that is the result of merging other into the receiver.
+// AcceptedPods slices are concatenated. If other is not *Options2003, an error is returned.
 func (o *Options2003) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -6,6 +6,7 @@ package rules
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -19,9 +20,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2003{}
-	_ rule.Severity = &Rule2003{}
-	_ option.Option = &Options2003{}
+	_ rule.Rule              = &Rule2003{}
+	_ rule.Severity          = &Rule2003{}
+	_ option.Option          = &Options2003{}
+	_ option.MergeableOption = &Options2003{}
 )
 
 type Options2003 struct {
@@ -38,6 +40,25 @@ func (o Options2003) Validate(fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, p.Validate(acceptedPodsPath.Index(pIdx))...)
 	}
 	return allErrs
+}
+
+func (o *Options2003) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2003)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2003", other)
+	}
+
+	merged := &Options2003{
+		AcceptedPods: make([]option.AcceptedPodVolumes, 0, len(o.AcceptedPods)+len(otherOpts.AcceptedPods)),
+	}
+	merged.AcceptedPods = append(merged.AcceptedPods, o.AcceptedPods...)
+	merged.AcceptedPods = append(merged.AcceptedPods, otherOpts.AcceptedPods...)
+
+	return merged, nil
 }
 
 type Rule2003 struct {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
@@ -647,4 +647,83 @@ var _ = Describe("#2003", func() {
 		))
 	})
 
+	Describe("#Merge Options2003", func() {
+		It("should merge two Options2003 by appending AcceptedPods", func() {
+			base := &rules.Options2003{
+				AcceptedPods: []option.AcceptedPodVolumes{
+					{
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "base"}},
+								NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "base"}},
+							},
+							Justification: "base justification",
+						},
+						VolumeNames: []string{"vol1"},
+					},
+				},
+			}
+
+			override := &rules.Options2003{
+				AcceptedPods: []option.AcceptedPodVolumes{
+					{
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "override"}},
+								NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "override"}},
+							},
+							Justification: "override justification",
+						},
+						VolumeNames: []string{"vol2"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2003)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedPods[0].Justification).To(Equal("base justification"))
+			Expect(mergedOpts.AcceptedPods[1].Justification).To(Equal("override justification"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2003{
+				AcceptedPods: []option.AcceptedPodVolumes{
+					{
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{Justification: "base"},
+						VolumeNames:              []string{"vol1"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2003", func() {
+			base := &rules.Options2003{}
+			other := &rules.Options2003{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2003)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2003{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
+
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
@@ -725,5 +725,4 @@ var _ = Describe("#2003", func() {
 			Expect(merged).To(BeNil())
 		})
 	})
-
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
@@ -49,6 +49,8 @@ func (o Options2004) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// Merge returns a new Options2004 that is the result of merging other into the receiver.
+// AcceptedServices slices are concatenated. If other is not *Options2004, an error is returned.
 func (o *Options2004) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"cmp"
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,9 +21,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2004{}
-	_ rule.Severity = &Rule2004{}
-	_ option.Option = &Options2004{}
+	_ rule.Rule              = &Rule2004{}
+	_ rule.Severity          = &Rule2004{}
+	_ option.Option          = &Options2004{}
+	_ option.MergeableOption = &Options2004{}
 )
 
 type Rule2004 struct {
@@ -45,6 +47,25 @@ func (o Options2004) Validate(fldPath *field.Path) field.ErrorList {
 	}
 
 	return allErrs
+}
+
+func (o *Options2004) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2004)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2004", other)
+	}
+
+	merged := &Options2004{
+		AcceptedServices: make([]option.AcceptedNamespacedObject, 0, len(o.AcceptedServices)+len(otherOpts.AcceptedServices)),
+	}
+	merged.AcceptedServices = append(merged.AcceptedServices, o.AcceptedServices...)
+	merged.AcceptedServices = append(merged.AcceptedServices, otherOpts.AcceptedServices...)
+
+	return merged, nil
 }
 
 func (r *Rule2004) ID() string {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
@@ -114,4 +114,74 @@ var _ = Describe("#2004", func() {
 			rule.CheckResult{Status: rule.Accepted, Message: "foo justify", Target: rule.NewTarget("kind", "Service", "name", "foo", "namespace", "foo")},
 		),
 	)
+
+	Describe("#Merge Options2004", func() {
+		It("should merge two Options2004 by appending AcceptedServices", func() {
+			base := &rules.Options2004{
+				AcceptedServices: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "base"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "base"}},
+						},
+						Justification: "base justification",
+					},
+				},
+			}
+
+			override := &rules.Options2004{
+				AcceptedServices: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "override"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "override"}},
+						},
+						Justification: "override justification",
+					},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2004)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedServices).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedServices[0].Justification).To(Equal("base justification"))
+			Expect(mergedOpts.AcceptedServices[1].Justification).To(Equal("override justification"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2004{
+				AcceptedServices: []option.AcceptedNamespacedObject{
+					{Justification: "base"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2004", func() {
+			base := &rules.Options2004{}
+			other := &rules.Options2004{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2004)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedServices).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2004{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -40,6 +40,8 @@ type AllowedImage struct {
 	Prefix string `json:"prefix" yaml:"prefix"`
 }
 
+// Merge returns a new Options2005 that is the result of merging other into the receiver.
+// AllowedImages slices are concatenated. If other is not *Options2005, an error is returned.
 func (o *Options2005) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -6,6 +6,7 @@ package rules
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -20,9 +21,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2005{}
-	_ rule.Severity = &Rule2005{}
-	_ option.Option = &Options2005{}
+	_ rule.Rule              = &Rule2005{}
+	_ rule.Severity          = &Rule2005{}
+	_ option.Option          = &Options2005{}
+	_ option.MergeableOption = &Options2005{}
 )
 
 type Rule2005 struct {
@@ -36,6 +38,25 @@ type Options2005 struct {
 
 type AllowedImage struct {
 	Prefix string `json:"prefix" yaml:"prefix"`
+}
+
+func (o *Options2005) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2005)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2005", other)
+	}
+
+	merged := &Options2005{
+		AllowedImages: make([]AllowedImage, 0, len(o.AllowedImages)+len(otherOpts.AllowedImages)),
+	}
+	merged.AllowedImages = append(merged.AllowedImages, o.AllowedImages...)
+	merged.AllowedImages = append(merged.AllowedImages, otherOpts.AllowedImages...)
+
+	return merged, nil
 }
 
 // Validate validates that option configurations are correctly defined.

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
@@ -311,4 +311,62 @@ var _ = Describe("#2005", func() {
 			))
 		})
 	})
+
+	Describe("#Merge Options2005", func() {
+		It("should merge two Options2005 by appending AllowedImages", func() {
+			base := &rules.Options2005{
+				AllowedImages: []rules.AllowedImage{
+					{Prefix: "registry.example.com/"},
+				},
+			}
+
+			override := &rules.Options2005{
+				AllowedImages: []rules.AllowedImage{
+					{Prefix: "docker.io/library/"},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2005)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AllowedImages).To(HaveLen(2))
+			Expect(mergedOpts.AllowedImages[0].Prefix).To(Equal("registry.example.com/"))
+			Expect(mergedOpts.AllowedImages[1].Prefix).To(Equal("docker.io/library/"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2005{
+				AllowedImages: []rules.AllowedImage{
+					{Prefix: "registry.example.com/"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2005", func() {
+			base := &rules.Options2005{}
+			other := &rules.Options2005{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2005)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AllowedImages).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2005{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -21,9 +22,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2006{}
-	_ rule.Severity = &Rule2006{}
-	_ option.Option = &Options2006{}
+	_ rule.Rule              = &Rule2006{}
+	_ rule.Severity          = &Rule2006{}
+	_ option.Option          = &Options2006{}
+	_ option.MergeableOption = &Options2006{}
 )
 
 type Rule2006 struct {
@@ -49,6 +51,28 @@ func (o Options2006) Validate(fldPath *field.Path) field.ErrorList {
 	}
 
 	return allErrs
+}
+
+func (o *Options2006) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2006)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2006", other)
+	}
+
+	merged := &Options2006{
+		AcceptedRoles:        make([]option.AcceptedNamespacedObject, 0, len(o.AcceptedRoles)+len(otherOpts.AcceptedRoles)),
+		AcceptedClusterRoles: make([]option.AcceptedClusterObject, 0, len(o.AcceptedClusterRoles)+len(otherOpts.AcceptedClusterRoles)),
+	}
+	merged.AcceptedRoles = append(merged.AcceptedRoles, o.AcceptedRoles...)
+	merged.AcceptedRoles = append(merged.AcceptedRoles, otherOpts.AcceptedRoles...)
+	merged.AcceptedClusterRoles = append(merged.AcceptedClusterRoles, o.AcceptedClusterRoles...)
+	merged.AcceptedClusterRoles = append(merged.AcceptedClusterRoles, otherOpts.AcceptedClusterRoles...)
+
+	return merged, nil
 }
 
 func (r *Rule2006) ID() string {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
@@ -53,6 +53,8 @@ func (o Options2006) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// Merge returns a new Options2006 that is the result of merging other into the receiver.
+// AcceptedRoles and AcceptedClusterRoles slices are concatenated. If other is not *Options2006, an error is returned.
 func (o *Options2006) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
@@ -231,4 +231,94 @@ var _ = Describe("#2006", func() {
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 	})
+
+	Describe("#Merge Options2006", func() {
+		It("should merge two Options2006 by appending both slices", func() {
+			base := &rules.Options2006{
+				AcceptedRoles: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"role": "base"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "base"}},
+						},
+						Justification: "base role",
+					},
+				},
+				AcceptedClusterRoles: []option.AcceptedClusterObject{
+					{
+						ClusterObjectSelector: option.ClusterObjectSelector{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cr": "base"}},
+						},
+						Justification: "base cluster role",
+					},
+				},
+			}
+
+			override := &rules.Options2006{
+				AcceptedRoles: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"role": "override"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "override"}},
+						},
+						Justification: "override role",
+					},
+				},
+				AcceptedClusterRoles: []option.AcceptedClusterObject{
+					{
+						ClusterObjectSelector: option.ClusterObjectSelector{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cr": "override"}},
+						},
+						Justification: "override cluster role",
+					},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2006)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedRoles).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedRoles[0].Justification).To(Equal("base role"))
+			Expect(mergedOpts.AcceptedRoles[1].Justification).To(Equal("override role"))
+			Expect(mergedOpts.AcceptedClusterRoles).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedClusterRoles[0].Justification).To(Equal("base cluster role"))
+			Expect(mergedOpts.AcceptedClusterRoles[1].Justification).To(Equal("override cluster role"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2006{
+				AcceptedRoles: []option.AcceptedNamespacedObject{
+					{Justification: "base"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2006", func() {
+			base := &rules.Options2006{}
+			other := &rules.Options2006{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2006)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedRoles).To(BeEmpty())
+			Expect(mergedOpts.AcceptedClusterRoles).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2006{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -21,9 +22,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2007{}
-	_ rule.Severity = &Rule2007{}
-	_ option.Option = &Options2007{}
+	_ rule.Rule              = &Rule2007{}
+	_ rule.Severity          = &Rule2007{}
+	_ option.Option          = &Options2007{}
+	_ option.MergeableOption = &Options2007{}
 )
 
 type Rule2007 struct {
@@ -49,6 +51,28 @@ func (o Options2007) Validate(fldPath *field.Path) field.ErrorList {
 	}
 
 	return allErrs
+}
+
+func (o *Options2007) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2007)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2007", other)
+	}
+
+	merged := &Options2007{
+		AcceptedRoles:        make([]option.AcceptedNamespacedObject, 0, len(o.AcceptedRoles)+len(otherOpts.AcceptedRoles)),
+		AcceptedClusterRoles: make([]option.AcceptedClusterObject, 0, len(o.AcceptedClusterRoles)+len(otherOpts.AcceptedClusterRoles)),
+	}
+	merged.AcceptedRoles = append(merged.AcceptedRoles, o.AcceptedRoles...)
+	merged.AcceptedRoles = append(merged.AcceptedRoles, otherOpts.AcceptedRoles...)
+	merged.AcceptedClusterRoles = append(merged.AcceptedClusterRoles, o.AcceptedClusterRoles...)
+	merged.AcceptedClusterRoles = append(merged.AcceptedClusterRoles, otherOpts.AcceptedClusterRoles...)
+
+	return merged, nil
 }
 
 func (r *Rule2007) ID() string {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
@@ -53,6 +53,8 @@ func (o Options2007) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// Merge returns a new Options2007 that is the result of merging other into the receiver.
+// AcceptedRoles and AcceptedClusterRoles slices are concatenated. If other is not *Options2007, an error is returned.
 func (o *Options2007) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
@@ -231,4 +231,94 @@ var _ = Describe("#2007", func() {
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
 	})
+
+	Describe("#Merge Options2007", func() {
+		It("should merge two Options2007 by appending both slices", func() {
+			base := &rules.Options2007{
+				AcceptedRoles: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"role": "base"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "base"}},
+						},
+						Justification: "base role",
+					},
+				},
+				AcceptedClusterRoles: []option.AcceptedClusterObject{
+					{
+						ClusterObjectSelector: option.ClusterObjectSelector{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cr": "base"}},
+						},
+						Justification: "base cluster role",
+					},
+				},
+			}
+
+			override := &rules.Options2007{
+				AcceptedRoles: []option.AcceptedNamespacedObject{
+					{
+						NamespacedObjectSelector: option.NamespacedObjectSelector{
+							LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"role": "override"}},
+							NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "override"}},
+						},
+						Justification: "override role",
+					},
+				},
+				AcceptedClusterRoles: []option.AcceptedClusterObject{
+					{
+						ClusterObjectSelector: option.ClusterObjectSelector{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cr": "override"}},
+						},
+						Justification: "override cluster role",
+					},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2007)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedRoles).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedRoles[0].Justification).To(Equal("base role"))
+			Expect(mergedOpts.AcceptedRoles[1].Justification).To(Equal("override role"))
+			Expect(mergedOpts.AcceptedClusterRoles).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedClusterRoles[0].Justification).To(Equal("base cluster role"))
+			Expect(mergedOpts.AcceptedClusterRoles[1].Justification).To(Equal("override cluster role"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2007{
+				AcceptedRoles: []option.AcceptedNamespacedObject{
+					{Justification: "base"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2007", func() {
+			base := &rules.Options2007{}
+			other := &rules.Options2007{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2007)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedRoles).To(BeEmpty())
+			Expect(mergedOpts.AcceptedClusterRoles).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2007{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -7,6 +7,7 @@ package rules
 import (
 	"cmp"
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -20,9 +21,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2008{}
-	_ rule.Severity = &Rule2008{}
-	_ option.Option = &Options2008{}
+	_ rule.Rule              = &Rule2008{}
+	_ rule.Severity          = &Rule2008{}
+	_ option.Option          = &Options2008{}
+	_ option.MergeableOption = &Options2008{}
 )
 
 type Rule2008 struct {
@@ -44,6 +46,25 @@ func (o Options2008) Validate(fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, p.Validate(acceptedPodsPath.Index(pIdx))...)
 	}
 	return allErrs
+}
+
+func (o *Options2008) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2008)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2008", other)
+	}
+
+	merged := &Options2008{
+		AcceptedPods: make([]option.AcceptedPodVolumes, 0, len(o.AcceptedPods)+len(otherOpts.AcceptedPods)),
+	}
+	merged.AcceptedPods = append(merged.AcceptedPods, o.AcceptedPods...)
+	merged.AcceptedPods = append(merged.AcceptedPods, otherOpts.AcceptedPods...)
+
+	return merged, nil
 }
 
 func (r *Rule2008) ID() string {

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -48,6 +48,8 @@ func (o Options2008) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// Merge returns a new Options2008 that is the result of merging other into the receiver.
+// AcceptedPods slices are concatenated. If other is not *Options2008, an error is returned.
 func (o *Options2008) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
@@ -542,4 +542,83 @@ var _ = Describe("#2008", func() {
 			},
 		))
 	})
+
+	Describe("#Merge Options2008", func() {
+		It("should merge two Options2008 by appending AcceptedPods", func() {
+			base := &rules.Options2008{
+				AcceptedPods: []option.AcceptedPodVolumes{
+					{
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "base"}},
+								NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "base"}},
+							},
+							Justification: "base justification",
+						},
+						VolumeNames: []string{"vol1"},
+					},
+				},
+			}
+
+			override := &rules.Options2008{
+				AcceptedPods: []option.AcceptedPodVolumes{
+					{
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{
+							NamespacedObjectSelector: option.NamespacedObjectSelector{
+								LabelSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "override"}},
+								NamespaceLabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "override"}},
+							},
+							Justification: "override justification",
+						},
+						VolumeNames: []string{"vol2"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(override)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2008)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedPods[0].Justification).To(Equal("base justification"))
+			Expect(mergedOpts.AcceptedPods[1].Justification).To(Equal("override justification"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2008{
+				AcceptedPods: []option.AcceptedPodVolumes{
+					{
+						AcceptedNamespacedObject: option.AcceptedNamespacedObject{Justification: "base"},
+						VolumeNames:              []string{"vol1"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2008", func() {
+			base := &rules.Options2008{}
+			other := &rules.Options2008{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2008)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different option type", func() {
+			base := &rules.Options2008{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
+			Expect(merged).To(BeNil())
+		})
+	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR implements the `MergeableOption` interface for all rules in the Security Hardened Kubernetes Cluster guide.

**Which issue(s) this PR fixes**:
Part of #687 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[Security Hardened Kubernetes Cluster] All rules can now me merged using the `config merge` command.
```
