### PR TITLE
Merged diki config improvements to indentation and optional fields

### DIFF
--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -659,7 +659,7 @@ func configMergeCmd(opts configMergeOptions, registryFuncs []provider.MergeRegis
 		return errors.New("merged configuration is not valid, please check the base configuration")
 	}
 
-	data, err := yaml.Marshal(merged)
+	data, err := yaml.Dump(merged, yaml.WithIndent(2))
 	if err != nil {
 		return fmt.Errorf("failed to marshal merged config: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,11 +21,11 @@ type ProviderConfig struct {
 	// Name is the user friendly name of a provider.
 	Name string `yaml:"name"`
 	// Metadata represents additional values used to describe a provider.
-	Metadata map[string]string `yaml:"metadata"`
+	Metadata map[string]string `yaml:"metadata,omitempty"`
 	// Rulesets represents ruleset specific configurations.
 	Rulesets []RulesetConfig `yaml:"rulesets"`
 	// Args are provider specific arguments that each provider should be able to parse.
-	Args any `yaml:"args"`
+	Args any `yaml:"args,omitempty"`
 }
 
 // RulesetConfig is used to describe and configure a ruleset.
@@ -37,9 +37,9 @@ type RulesetConfig struct {
 	// Version is the ruleset's version.
 	Version string `yaml:"version"`
 	// RuleOptions is used to provide per rule configurations.
-	RuleOptions []RuleOptionsConfig `yaml:"ruleOptions"`
+	RuleOptions []RuleOptionsConfig `yaml:"ruleOptions,omitempty"`
 	// Args are ruleset specific arguments that each ruleset should be able to parse.
-	Args any `yaml:"args"`
+	Args any `yaml:"args,omitempty"`
 }
 
 // RuleOptionsConfig represents per rule options.

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -32,8 +32,8 @@ type MergeableOption interface {
 type ClusterObjectSelector struct {
 	// Deprecated: This field is deprecated and will be forbidden in a future release.
 	// Please configure and use LabelSelector instead.
-	MatchLabels   map[string]string     `json:"matchLabels" yaml:"matchLabels"`
-	LabelSelector *metav1.LabelSelector `json:"labelSelector" yaml:"labelSelector"`
+	MatchLabels   map[string]string     `json:"matchLabels,omitempty" yaml:"matchLabels,omitempty"`
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty"`
 }
 
 var _ Option = (*ClusterObjectSelector)(nil)
@@ -80,12 +80,12 @@ func (s *ClusterObjectSelector) Matches(objectLabels map[string]string) (bool, e
 type NamespacedObjectSelector struct {
 	// Deprecated: This field is deprecated and will be forbidden in a future release.
 	// Please configure and use LabelSelector instead.
-	MatchLabels map[string]string `json:"matchLabels" yaml:"matchLabels"`
+	MatchLabels map[string]string `json:"matchLabels,omitempty" yaml:"matchLabels,omitempty"`
 	// Deprecated: This field is deprecated and will be forbidden in a future release.
 	// Please configure and use NamespaceMatchLabels instead.
-	NamespaceMatchLabels   map[string]string     `json:"namespaceMatchLabels" yaml:"namespaceMatchLabels"`
-	LabelSelector          *metav1.LabelSelector `json:"labelSelector" yaml:"labelSelector"`
-	NamespaceLabelSelector *metav1.LabelSelector `json:"namespaceLabelSelector" yaml:"namespaceLabelSelector"`
+	NamespaceMatchLabels   map[string]string     `json:"namespaceMatchLabels,omitempty" yaml:"namespaceMatchLabels,omitempty"`
+	LabelSelector          *metav1.LabelSelector `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty"`
+	NamespaceLabelSelector *metav1.LabelSelector `json:"namespaceLabelSelector,omitempty" yaml:"namespaceLabelSelector,omitempty"`
 }
 
 var _ Option = (*NamespacedObjectSelector)(nil)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR does 2 minor improvements to diki config:
- merged config have indentation set to `2`, previously was `4`
- optional fields in diki config are now omitted when empty

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
