### PR TITLE
[Security Hardened Shoot Cluster] Implement `MergeableOption` for all rules

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
@@ -20,9 +20,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule1000{}
-	_ rule.Severity = &Rule1000{}
-	_ option.Option = &Options1000{}
+	_ rule.Rule              = &Rule1000{}
+	_ rule.Severity          = &Rule1000{}
+	_ option.Option          = &Options1000{}
+	_ option.MergeableOption = &Options1000{}
 )
 
 type Options1000 struct {
@@ -31,6 +32,25 @@ type Options1000 struct {
 
 type Extension struct {
 	Type string `json:"type" yaml:"type"`
+}
+
+func (o *Options1000) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options1000)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options1000", other)
+	}
+
+	merged := &Options1000{
+		Extensions: make([]Extension, 0, len(o.Extensions)+len(otherOpts.Extensions)),
+	}
+	merged.Extensions = append(merged.Extensions, o.Extensions...)
+	merged.Extensions = append(merged.Extensions, otherOpts.Extensions...)
+
+	return merged, nil
 }
 
 func (o Options1000) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
@@ -283,4 +283,64 @@ var _ = Describe("#1000", func() {
 			}))
 		})
 	})
+
+	Describe("#Merge Options1000", func() {
+		It("should merge two Options1000 by appending Extensions", func() {
+			base := &rules.Options1000{
+				Extensions: []rules.Extension{
+					{Type: "ext-a"},
+				},
+			}
+			other := &rules.Options1000{
+				Extensions: []rules.Extension{
+					{Type: "ext-b"},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1000)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.Extensions).To(HaveLen(2))
+			Expect(mergedOpts.Extensions[0].Type).To(Equal("ext-a"))
+			Expect(mergedOpts.Extensions[1].Type).To(Equal("ext-b"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options1000{
+				Extensions: []rules.Extension{
+					{Type: "ext-a"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options1000", func() {
+			base := &rules.Options1000{}
+			other := &rules.Options1000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1000)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.Extensions).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different type", func() {
+			base := &rules.Options1000{
+				Extensions: []rules.Extension{
+					{Type: "ext-a"},
+				},
+			}
+
+			_, err := base.Merge(&rules.Options2000{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		})
+	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -21,9 +21,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule1001{}
-	_ rule.Severity = &Rule1001{}
-	_ option.Option = &Options1001{}
+	_ rule.Rule              = &Rule1001{}
+	_ rule.Severity          = &Rule1001{}
+	_ option.Option          = &Options1001{}
+	_ option.MergeableOption = &Options1001{}
 )
 
 type Rule1001 struct {
@@ -35,6 +36,25 @@ type Rule1001 struct {
 
 type Options1001 struct {
 	AllowedClassifications []gardencorev1beta1.VersionClassification `json:"allowedClassifications" yaml:"allowedClassifications"`
+}
+
+func (o *Options1001) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options1001)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options1001", other)
+	}
+
+	merged := &Options1001{
+		AllowedClassifications: make([]gardencorev1beta1.VersionClassification, 0, len(o.AllowedClassifications)+len(otherOpts.AllowedClassifications)),
+	}
+	merged.AllowedClassifications = append(merged.AllowedClassifications, o.AllowedClassifications...)
+	merged.AllowedClassifications = append(merged.AllowedClassifications, otherOpts.AllowedClassifications...)
+
+	return merged, nil
 }
 
 func (o Options1001) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -335,4 +335,64 @@ var _ = Describe("#1001", func() {
 			}))
 		})
 	})
+
+	Describe("#Merge Options1001", func() {
+		It("should merge two Options1001 by appending AllowedClassifications", func() {
+			base := &rules.Options1001{
+				AllowedClassifications: []gardencorev1beta1.VersionClassification{
+					gardencorev1beta1.ClassificationSupported,
+				},
+			}
+			other := &rules.Options1001{
+				AllowedClassifications: []gardencorev1beta1.VersionClassification{
+					gardencorev1beta1.ClassificationPreview,
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1001)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AllowedClassifications).To(HaveLen(2))
+			Expect(mergedOpts.AllowedClassifications[0]).To(Equal(gardencorev1beta1.ClassificationSupported))
+			Expect(mergedOpts.AllowedClassifications[1]).To(Equal(gardencorev1beta1.ClassificationPreview))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options1001{
+				AllowedClassifications: []gardencorev1beta1.VersionClassification{
+					gardencorev1beta1.ClassificationSupported,
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options1001", func() {
+			base := &rules.Options1001{}
+			other := &rules.Options1001{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1001)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AllowedClassifications).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different type", func() {
+			base := &rules.Options1001{
+				AllowedClassifications: []gardencorev1beta1.VersionClassification{
+					gardencorev1beta1.ClassificationSupported,
+				},
+			}
+
+			_, err := base.Merge(&rules.Options2000{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		})
+	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
@@ -21,9 +21,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule1002{}
-	_ rule.Severity = &Rule1002{}
-	_ option.Option = &Options1002{}
+	_ rule.Rule              = &Rule1002{}
+	_ rule.Severity          = &Rule1002{}
+	_ option.Option          = &Options1002{}
+	_ option.MergeableOption = &Options1002{}
 )
 
 type Rule1002 struct {
@@ -40,6 +41,25 @@ type Options1002 struct {
 type MachineImage struct {
 	Name                   string                                    `json:"name" yaml:"name"`
 	AllowedClassifications []gardencorev1beta1.VersionClassification `json:"allowedClassifications" yaml:"allowedClassifications"`
+}
+
+func (o *Options1002) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options1002)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options1002", other)
+	}
+
+	merged := &Options1002{
+		MachineImages: make([]MachineImage, 0, len(o.MachineImages)+len(otherOpts.MachineImages)),
+	}
+	merged.MachineImages = append(merged.MachineImages, o.MachineImages...)
+	merged.MachineImages = append(merged.MachineImages, otherOpts.MachineImages...)
+
+	return merged, nil
 }
 
 func (o Options1002) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
@@ -486,4 +486,64 @@ var _ = Describe("#1002", func() {
 			}))
 		})
 	})
+
+	Describe("#Merge Options1002", func() {
+		It("should merge two Options1002 by appending MachineImages", func() {
+			base := &rules.Options1002{
+				MachineImages: []rules.MachineImage{
+					{Name: "ubuntu", AllowedClassifications: []gardencorev1beta1.VersionClassification{gardencorev1beta1.ClassificationSupported}},
+				},
+			}
+			other := &rules.Options1002{
+				MachineImages: []rules.MachineImage{
+					{Name: "gardenlinux", AllowedClassifications: []gardencorev1beta1.VersionClassification{gardencorev1beta1.ClassificationPreview}},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1002)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.MachineImages).To(HaveLen(2))
+			Expect(mergedOpts.MachineImages[0].Name).To(Equal("ubuntu"))
+			Expect(mergedOpts.MachineImages[1].Name).To(Equal("gardenlinux"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options1002{
+				MachineImages: []rules.MachineImage{
+					{Name: "ubuntu"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options1002", func() {
+			base := &rules.Options1002{}
+			other := &rules.Options1002{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1002)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.MachineImages).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different type", func() {
+			base := &rules.Options1002{
+				MachineImages: []rules.MachineImage{
+					{Name: "ubuntu"},
+				},
+			}
+
+			_, err := base.Merge(&rules.Options2000{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		})
+	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
@@ -25,9 +25,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule1003{}
-	_ rule.Severity = &Rule1003{}
-	_ option.Option = &Options1003{}
+	_ rule.Rule              = &Rule1003{}
+	_ rule.Severity          = &Rule1003{}
+	_ option.Option          = &Options1003{}
+	_ option.MergeableOption = &Options1003{}
 )
 
 type Rule1003 struct {
@@ -39,6 +40,25 @@ type Rule1003 struct {
 
 type Options1003 struct {
 	AllowedLakomScopes []lakomapi.ScopeType `json:"allowedLakomScopes" yaml:"allowedLakomScopes"`
+}
+
+func (o *Options1003) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options1003)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options1003", other)
+	}
+
+	merged := &Options1003{
+		AllowedLakomScopes: make([]lakomapi.ScopeType, 0, len(o.AllowedLakomScopes)+len(otherOpts.AllowedLakomScopes)),
+	}
+	merged.AllowedLakomScopes = append(merged.AllowedLakomScopes, o.AllowedLakomScopes...)
+	merged.AllowedLakomScopes = append(merged.AllowedLakomScopes, otherOpts.AllowedLakomScopes...)
+
+	return merged, nil
 }
 
 func (o Options1003) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
@@ -297,4 +297,56 @@ var _ = Describe("#1003", func() {
 			}))
 		})
 	})
+
+	Describe("#Merge Options1003", func() {
+		It("should merge two Options1003 by appending AllowedLakomScopes", func() {
+			base := &rules.Options1003{
+				AllowedLakomScopes: []lakomapi.ScopeType{lakomapi.KubeSystem},
+			}
+			other := &rules.Options1003{
+				AllowedLakomScopes: []lakomapi.ScopeType{lakomapi.Cluster},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1003)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AllowedLakomScopes).To(HaveLen(2))
+			Expect(mergedOpts.AllowedLakomScopes[0]).To(Equal(lakomapi.KubeSystem))
+			Expect(mergedOpts.AllowedLakomScopes[1]).To(Equal(lakomapi.Cluster))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options1003{
+				AllowedLakomScopes: []lakomapi.ScopeType{lakomapi.KubeSystem},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options1003", func() {
+			base := &rules.Options1003{}
+			other := &rules.Options1003{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options1003)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AllowedLakomScopes).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different type", func() {
+			base := &rules.Options1003{
+				AllowedLakomScopes: []lakomapi.ScopeType{lakomapi.KubeSystem},
+			}
+
+			_, err := base.Merge(&rules.Options2000{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		})
+	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2000{}
-	_ rule.Severity = &Rule2000{}
-	_ option.Option = &Options2000{}
+	_ rule.Rule              = &Rule2000{}
+	_ rule.Severity          = &Rule2000{}
+	_ option.Option          = &Options2000{}
+	_ option.MergeableOption = &Options2000{}
 )
 
 type Rule2000 struct {
@@ -41,6 +42,25 @@ type Options2000 struct {
 
 type AcceptedEndpoint struct {
 	Path string `yaml:"path" json:"path"`
+}
+
+func (o *Options2000) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2000)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2000", other)
+	}
+
+	merged := &Options2000{
+		AcceptedEndpoints: make([]AcceptedEndpoint, 0, len(o.AcceptedEndpoints)+len(otherOpts.AcceptedEndpoints)),
+	}
+	merged.AcceptedEndpoints = append(merged.AcceptedEndpoints, o.AcceptedEndpoints...)
+	merged.AcceptedEndpoints = append(merged.AcceptedEndpoints, otherOpts.AcceptedEndpoints...)
+
+	return merged, nil
 }
 
 func (o Options2000) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -416,4 +416,64 @@ kind: AuthenticationConfiguration
 			))
 		})
 	})
+
+	Describe("#Merge Options2000", func() {
+		It("should merge two Options2000 by appending AcceptedEndpoints", func() {
+			base := &rules.Options2000{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
+					{Path: "/healthz"},
+				},
+			}
+			other := &rules.Options2000{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
+					{Path: "/readyz"},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2000)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedEndpoints).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedEndpoints[0].Path).To(Equal("/healthz"))
+			Expect(mergedOpts.AcceptedEndpoints[1].Path).To(Equal("/readyz"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2000{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
+					{Path: "/healthz"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should handle merging two empty Options2000", func() {
+			base := &rules.Options2000{}
+			other := &rules.Options2000{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2000)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedEndpoints).To(BeEmpty())
+		})
+
+		It("should return an error when merging with a different type", func() {
+			base := &rules.Options2000{
+				AcceptedEndpoints: []rules.AcceptedEndpoint{
+					{Path: "/healthz"},
+				},
+			}
+
+			_, err := base.Merge(&rules.Options1000{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		})
+	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
@@ -25,13 +25,35 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule2007{}
-	_ rule.Severity = &Rule2007{}
-	_ option.Option = &Options2007{}
+	_ rule.Rule              = &Rule2007{}
+	_ rule.Severity          = &Rule2007{}
+	_ option.Option          = &Options2007{}
+	_ option.MergeableOption = &Options2007{}
 )
 
 type Options2007 struct {
 	MinPodSecurityStandardsProfile intkubeutils.PodSecurityStandardProfile `json:"minPodSecurityStandardsProfile" yaml:"minPodSecurityStandardsProfile"`
+}
+
+func (o *Options2007) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options2007)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options2007", other)
+	}
+
+	merged := &Options2007{
+		MinPodSecurityStandardsProfile: o.MinPodSecurityStandardsProfile,
+	}
+
+	if len(otherOpts.MinPodSecurityStandardsProfile) != 0 {
+		merged.MinPodSecurityStandardsProfile = otherOpts.MinPodSecurityStandardsProfile
+	}
+
+	return merged, nil
 }
 
 func (o Options2007) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
@@ -290,4 +290,56 @@ var _ = Describe("#2007", func() {
 			}))
 		})
 	})
+
+	Describe("#Merge Options2007", func() {
+		It("should use the other value when it is non-empty", func() {
+			base := &rules.Options2007{
+				MinPodSecurityStandardsProfile: intkubeutils.PSSProfileBaseline,
+			}
+			other := &rules.Options2007{
+				MinPodSecurityStandardsProfile: intkubeutils.PSSProfileRestricted,
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2007)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.MinPodSecurityStandardsProfile).To(Equal(intkubeutils.PSSProfileRestricted))
+		})
+
+		It("should keep the base value when the other value is empty", func() {
+			base := &rules.Options2007{
+				MinPodSecurityStandardsProfile: intkubeutils.PSSProfileBaseline,
+			}
+			other := &rules.Options2007{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options2007)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.MinPodSecurityStandardsProfile).To(Equal(intkubeutils.PSSProfileBaseline))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options2007{
+				MinPodSecurityStandardsProfile: intkubeutils.PSSProfileRestricted,
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return an error when merging with a different type", func() {
+			base := &rules.Options2007{
+				MinPodSecurityStandardsProfile: intkubeutils.PSSProfileBaseline,
+			}
+
+			_, err := base.Merge(&rules.Options2000{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		})
+	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR implements the `MergeableOption` interface for all rules in the Security Hardened Shoot Cluster guide.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/687

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[Security Hardened Shoot Cluster] All rules can now me merged using the `config merge` command.
```
