### PR TITLE
[DISA K8s STIG] Implement `MergeableOption` for rule options in the `gardener` provider

### DIFF
--- a/pkg/internal/utils/set.go
+++ b/pkg/internal/utils/set.go
@@ -6,6 +6,8 @@ package utils
 
 import (
 	"slices"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // EqualSets checks if two slices contain exactly the same elements independent of the ordering.
@@ -64,4 +66,9 @@ func MatchLabels(m1, m2 map[string]string) bool {
 	}
 
 	return true
+}
+
+// MergeStringSlices merges two string slices and removes duplicates.
+func MergeStringSlices(s1, s2 []string) []string {
+	return sets.New(s1...).Insert(s2...).UnsortedList()
 }

--- a/pkg/internal/utils/set.go
+++ b/pkg/internal/utils/set.go
@@ -6,8 +6,6 @@ package utils
 
 import (
 	"slices"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // EqualSets checks if two slices contain exactly the same elements independent of the ordering.
@@ -68,7 +66,24 @@ func MatchLabels(m1, m2 map[string]string) bool {
 	return true
 }
 
-// MergeStringSlices merges two string slices and removes duplicates.
+// MergeStringSlices merges two string slices and removes duplicates, preserving the order of s1 followed by s2.
 func MergeStringSlices(s1, s2 []string) []string {
-	return sets.New(s1...).Insert(s2...).UnsortedList()
+	var (
+		result []string
+		seen   = map[string]struct{}{}
+	)
+
+	for _, s := range s1 {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+	for _, s := range s2 {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+	return result
 }

--- a/pkg/internal/utils/set_test.go
+++ b/pkg/internal/utils/set_test.go
@@ -93,25 +93,30 @@ var _ = Describe("utils", func() {
 	)
 
 	Describe("#MergeStringSlices", func() {
-		It("should concatenate two slices", func() {
+		It("should concatenate two slices preserving order", func() {
 			result := utils.MergeStringSlices([]string{"a", "b"}, []string{"c", "d"})
-			Expect(result).To(ConsistOf("a", "b", "c", "d"))
+			Expect(result).To(Equal([]string{"a", "b", "c", "d"}))
 		})
 
-		It("should deduplicate elements", func() {
+		It("should deduplicate elements preserving order of first occurrence", func() {
 			result := utils.MergeStringSlices([]string{"a", "b", "c"}, []string{"b", "c", "d"})
-			Expect(result).To(ConsistOf("a", "b", "c", "d"))
+			Expect(result).To(Equal([]string{"a", "b", "c", "d"}))
 		})
 
 		It("should handle empty slices", func() {
-			Expect(utils.MergeStringSlices(nil, []string{"a"})).To(ConsistOf("a"))
-			Expect(utils.MergeStringSlices([]string{"a"}, nil)).To(ConsistOf("a"))
+			Expect(utils.MergeStringSlices(nil, []string{"a"})).To(Equal([]string{"a"}))
+			Expect(utils.MergeStringSlices([]string{"a"}, nil)).To(Equal([]string{"a"}))
 			Expect(utils.MergeStringSlices(nil, nil)).To(BeEmpty())
 		})
 
-		It("should handle fully overlapping slices", func() {
+		It("should handle fully overlapping slices preserving s1 order", func() {
 			result := utils.MergeStringSlices([]string{"a", "b"}, []string{"a", "b"})
-			Expect(result).To(ConsistOf("a", "b"))
+			Expect(result).To(Equal([]string{"a", "b"}))
+		})
+
+		It("should preserve s1 order followed by new s2 elements", func() {
+			result := utils.MergeStringSlices([]string{"c", "a"}, []string{"b", "a", "d"})
+			Expect(result).To(Equal([]string{"c", "a", "b", "d"}))
 		})
 	})
 })

--- a/pkg/internal/utils/set_test.go
+++ b/pkg/internal/utils/set_test.go
@@ -91,4 +91,27 @@ var _ = Describe("utils", func() {
 		Entry("should return false when m2 is nil",
 			map[string]string{"key1": "value1", "foo": "bar"}, nil, false),
 	)
+
+	Describe("#MergeStringSlices", func() {
+		It("should concatenate two slices", func() {
+			result := utils.MergeStringSlices([]string{"a", "b"}, []string{"c", "d"})
+			Expect(result).To(ConsistOf("a", "b", "c", "d"))
+		})
+
+		It("should deduplicate elements", func() {
+			result := utils.MergeStringSlices([]string{"a", "b", "c"}, []string{"b", "c", "d"})
+			Expect(result).To(ConsistOf("a", "b", "c", "d"))
+		})
+
+		It("should handle empty slices", func() {
+			Expect(utils.MergeStringSlices(nil, []string{"a"})).To(ConsistOf("a"))
+			Expect(utils.MergeStringSlices([]string{"a"}, nil)).To(ConsistOf("a"))
+			Expect(utils.MergeStringSlices(nil, nil)).To(BeEmpty())
+		})
+
+		It("should handle fully overlapping slices", func() {
+			result := utils.MergeStringSlices([]string{"a", "b"}, []string{"a", "b"})
+			Expect(result).To(ConsistOf("a", "b"))
+		})
+	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -35,8 +35,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242400{}
-	_ rule.Severity = &Rule242400{}
+	_ rule.Rule              = &Rule242400{}
+	_ rule.Severity          = &Rule242400{}
+	_ option.Option          = &Options242400{}
+	_ option.MergeableOption = &Options242400{}
 )
 
 type Rule242400 struct {
@@ -54,7 +56,20 @@ type Options242400 struct {
 	KubeProxy disaoption.KubeProxyOptionsWithoutSelectors `json:"kubeProxy" yaml:"kubeProxy"`
 }
 
-var _ option.Option = (*Options242400)(nil)
+func (o *Options242400) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options242400)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options242400", other)
+	}
+
+	return &Options242400{
+		KubeProxy: otherOpts.KubeProxy,
+	}, nil
+}
 
 func (o Options242400) Validate(fldPath *field.Path) field.ErrorList {
 	return o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -61,9 +61,9 @@ func (o *Options242400) Merge(other option.MergeableOption) (option.MergeableOpt
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options242400)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options242400", other)
+	otherOpts, err := option.AssertSameType[*Options242400](other)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Options242400{

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -29,6 +29,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
@@ -444,19 +445,9 @@ var _ = Describe("#242400", func() {
 			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options242400{
-				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242400{
+			KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &rules.Options242400{}
-			_, err := base.Merge(&rules.Options242451{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242400{}, &rules.Options242451{})
 	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -426,4 +426,37 @@ var _ = Describe("#242400", func() {
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
 	})
+
+	Describe("#Merge Options242400", func() {
+		It("should override KubeProxy with other's value", func() {
+			base := &rules.Options242400{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: false},
+			}
+			other := &rules.Options242400{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242400)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options242400{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &rules.Options242400{}
+			_, err := base.Merge(&rules.Options242451{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -60,9 +60,9 @@ func (o *Options242451) Merge(other option.MergeableOption) (option.MergeableOpt
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options242451)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options242451", other)
+	otherOpts, err := option.AssertSameType[*Options242451](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options242451{
@@ -75,7 +75,11 @@ func (o *Options242451) Merge(other option.MergeableOption) (option.MergeableOpt
 		if err != nil {
 			return nil, err
 		}
-		merged.FileOwnerOptions = mergedFileOwner.(*disaoption.FileOwnerOptions)
+		typedFileOwner, err := option.AssertSameType[*disaoption.FileOwnerOptions](mergedFileOwner)
+		if err != nil {
+			return nil, err
+		}
+		merged.FileOwnerOptions = typedFileOwner
 	case otherOpts.FileOwnerOptions != nil:
 		merged.FileOwnerOptions = otherOpts.FileOwnerOptions
 	case o.FileOwnerOptions != nil:

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -33,8 +33,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242451{}
-	_ rule.Severity = &Rule242451{}
+	_ rule.Rule              = &Rule242451{}
+	_ rule.Severity          = &Rule242451{}
+	_ option.Option          = &Options242451{}
+	_ option.MergeableOption = &Options242451{}
 )
 
 type Rule242451 struct {
@@ -53,7 +55,35 @@ type Options242451 struct {
 	*disaoption.FileOwnerOptions
 }
 
-var _ option.Option = (*Options242451)(nil)
+func (o *Options242451) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options242451)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options242451", other)
+	}
+
+	merged := &Options242451{
+		KubeProxy: otherOpts.KubeProxy,
+	}
+
+	switch {
+	case o.FileOwnerOptions != nil && otherOpts.FileOwnerOptions != nil:
+		mergedFileOwner, err := o.FileOwnerOptions.Merge(otherOpts.FileOwnerOptions)
+		if err != nil {
+			return nil, err
+		}
+		merged.FileOwnerOptions = mergedFileOwner.(*disaoption.FileOwnerOptions)
+	case otherOpts.FileOwnerOptions != nil:
+		merged.FileOwnerOptions = otherOpts.FileOwnerOptions
+	case o.FileOwnerOptions != nil:
+		merged.FileOwnerOptions = o.FileOwnerOptions
+	}
+
+	return merged, nil
+}
 
 func (o Options242451) Validate(fldPath *field.Path) field.ErrorList {
 	allErrors := o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
@@ -24,8 +24,8 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
-	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
+	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
@@ -541,4 +541,51 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("cluster", "shoot", "name", "diki-242451-bbbbbbbbbb", "namespace", "kube-system", "kind", "Pod")),
 			}),
 	)
+
+	Describe("#Merge Options242451", func() {
+		It("should override KubeProxy and merge FileOwnerOptions", func() {
+			base := &rules.Options242451{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: false},
+				FileOwnerOptions: &option.FileOwnerOptions{
+					ExpectedFileOwner: option.ExpectedOwner{
+						Users:  []string{"0"},
+						Groups: []string{"0"},
+					},
+				},
+			}
+			other := &rules.Options242451{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+				FileOwnerOptions: &option.FileOwnerOptions{
+					ExpectedFileOwner: option.ExpectedOwner{
+						Users:  []string{"1000"},
+						Groups: []string{"1000"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242451)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+			Expect(mergedOpts.FileOwnerOptions.ExpectedFileOwner.Users).To(ConsistOf("0", "1000"))
+			Expect(mergedOpts.FileOwnerOptions.ExpectedFileOwner.Groups).To(ConsistOf("0", "1000"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options242451{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &rules.Options242451{}
+			_, err := base.Merge(&rules.Options242400{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
 	option "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
@@ -573,19 +574,9 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			Expect(mergedOpts.FileOwnerOptions.ExpectedFileOwner.Groups).To(ConsistOf("0", "1000"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options242451{
-				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242451{
+			KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &rules.Options242451{}
-			_, err := base.Merge(&rules.Options242400{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242451{}, &rules.Options242400{})
 	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
@@ -59,9 +59,9 @@ func (o *Options242466) Merge(other option.MergeableOption) (option.MergeableOpt
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options242466)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options242466", other)
+	otherOpts, err := option.AssertSameType[*Options242466](other)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Options242466{

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
@@ -33,8 +33,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242466{}
-	_ rule.Severity = &Rule242466{}
+	_ rule.Rule              = &Rule242466{}
+	_ rule.Severity          = &Rule242466{}
+	_ option.Option          = &Options242466{}
+	_ option.MergeableOption = &Options242466{}
 )
 
 type Rule242466 struct {
@@ -52,7 +54,20 @@ type Options242466 struct {
 	KubeProxy disaoption.KubeProxyOptionsWithoutSelectors `json:"kubeProxy" yaml:"kubeProxy"`
 }
 
-var _ option.Option = (*Options242466)(nil)
+func (o *Options242466) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options242466)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options242466", other)
+	}
+
+	return &Options242466{
+		KubeProxy: otherOpts.KubeProxy,
+	}, nil
+}
 
 func (o Options242466) Validate(fldPath *field.Path) field.ErrorList {
 	return o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
@@ -500,4 +500,37 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("cluster", "shoot", "name", "diki-242466-bbbbbbbbbb", "namespace", "kube-system", "kind", "Pod")),
 			}),
 	)
+
+	Describe("#Merge Options242466", func() {
+		It("should override KubeProxy with other's value", func() {
+			base := &rules.Options242466{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: false},
+			}
+			other := &rules.Options242466{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242466)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options242466{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &rules.Options242466{}
+			_, err := base.Merge(&rules.Options242467{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
@@ -24,6 +24,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
@@ -518,19 +519,9 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options242466{
-				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242466{
+			KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &rules.Options242466{}
-			_, err := base.Merge(&rules.Options242467{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242466{}, &rules.Options242467{})
 	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
@@ -33,8 +33,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242467{}
-	_ rule.Severity = &Rule242467{}
+	_ rule.Rule              = &Rule242467{}
+	_ rule.Severity          = &Rule242467{}
+	_ option.Option          = &Options242467{}
+	_ option.MergeableOption = &Options242467{}
 )
 
 type Rule242467 struct {
@@ -52,7 +54,20 @@ type Options242467 struct {
 	KubeProxy disaoption.KubeProxyOptionsWithoutSelectors `json:"kubeProxy" yaml:"kubeProxy"`
 }
 
-var _ option.Option = (*Options242467)(nil)
+func (o *Options242467) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options242467)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options242467", other)
+	}
+
+	return &Options242467{
+		KubeProxy: otherOpts.KubeProxy,
+	}, nil
+}
 
 func (o Options242467) Validate(fldPath *field.Path) field.ErrorList {
 	return o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
@@ -59,9 +59,9 @@ func (o *Options242467) Merge(other option.MergeableOption) (option.MergeableOpt
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options242467)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options242467", other)
+	otherOpts, err := option.AssertSameType[*Options242467](other)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Options242467{

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
@@ -494,4 +494,37 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("cluster", "shoot", "name", "diki-242467-bbbbbbbbbb", "namespace", "kube-system", "kind", "Pod")),
 			}),
 	)
+
+	Describe("#Merge Options242467", func() {
+		It("should override KubeProxy with other's value", func() {
+			base := &rules.Options242467{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: false},
+			}
+			other := &rules.Options242467{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242467)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &rules.Options242467{
+				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &rules.Options242467{}
+			_, err := base.Merge(&rules.Options242466{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
@@ -24,6 +24,7 @@ import (
 	fakepod "github.com/gardener/diki/pkg/kubernetes/pod/fake"
 	"github.com/gardener/diki/pkg/provider/gardener/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
@@ -512,19 +513,9 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options242467{
-				KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242467{
+			KubeProxy: option.KubeProxyOptionsWithoutSelectors{Disabled: true},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &rules.Options242467{}
-			_, err := base.Merge(&rules.Options242466{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242467{}, &rules.Options242466{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -6,7 +6,6 @@ package rules
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"time"
 
@@ -85,9 +84,9 @@ func (o *Options2000) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2000)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2000", other)
+	otherOpts, err := option.AssertSameType[*Options2000](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2000{

--- a/pkg/shared/kubernetes/option/mergetest/mergetest.go
+++ b/pkg/shared/kubernetes/option/mergetest/mergetest.go
@@ -6,14 +6,11 @@
 // implementations, factoring out the three cases that repeat verbatim across every
 // per-type Merge test: nil-other returns the receiver, a wrong-type other returns
 // an error, and a non-nil other of the same type is accepted.
-//
-// Type-specific happy-path assertions (which fields are unioned, concatenated, or
-// overridden) stay inline in each Merge test because their expectations vary.
 package mergetest
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 )
@@ -21,10 +18,10 @@ import (
 // AssertNilOtherReturnsReceiver spawns an It that verifies base.Merge(nil) returns
 // base unchanged. Every MergeableOption implementation is expected to honour this.
 func AssertNilOtherReturnsReceiver(base option.MergeableOption) {
-	It("should return the receiver when merging with nil", func() {
+	ginkgo.It("should return the receiver when merging with nil", func() {
 		merged, err := base.Merge(nil)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(merged).To(BeIdenticalTo(base))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(merged).To(gomega.BeIdenticalTo(base))
 	})
 }
 
@@ -32,8 +29,8 @@ func AssertNilOtherReturnsReceiver(base option.MergeableOption) {
 // an error. Every MergeableOption implementation is expected to reject a mismatched
 // other rather than silently ignore it.
 func AssertWrongTypeErrors(base, wrongType option.MergeableOption) {
-	It("should return error when merging with wrong type", func() {
+	ginkgo.It("should return error when merging with wrong type", func() {
 		_, err := base.Merge(wrongType)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 }

--- a/pkg/shared/kubernetes/option/mergetest/mergetest.go
+++ b/pkg/shared/kubernetes/option/mergetest/mergetest.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mergetest provides shared Ginkgo assertions for [option.MergeableOption]
+// implementations, factoring out the three cases that repeat verbatim across every
+// per-type Merge test: nil-other returns the receiver, a wrong-type other returns
+// an error, and a non-nil other of the same type is accepted.
+//
+// Type-specific happy-path assertions (which fields are unioned, concatenated, or
+// overridden) stay inline in each Merge test because their expectations vary.
+package mergetest
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+)
+
+// AssertNilOtherReturnsReceiver spawns an It that verifies base.Merge(nil) returns
+// base unchanged. Every MergeableOption implementation is expected to honour this.
+func AssertNilOtherReturnsReceiver(base option.MergeableOption) {
+	It("should return the receiver when merging with nil", func() {
+		merged, err := base.Merge(nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(merged).To(BeIdenticalTo(base))
+	})
+}
+
+// AssertWrongTypeErrors spawns an It that verifies base.Merge(wrongType) returns
+// an error. Every MergeableOption implementation is expected to reject a mismatched
+// other rather than silently ignore it.
+func AssertWrongTypeErrors(base, wrongType option.MergeableOption) {
+	It("should return error when merging with wrong type", func() {
+		_, err := base.Merge(wrongType)
+		Expect(err).To(HaveOccurred())
+	})
+}

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -36,7 +36,34 @@ type ClusterObjectSelector struct {
 	LabelSelector *metav1.LabelSelector `json:"labelSelector" yaml:"labelSelector"`
 }
 
-var _ Option = (*ClusterObjectSelector)(nil)
+var (
+	_ Option          = &ClusterObjectSelector{}
+	_ MergeableOption = &ClusterObjectSelector{}
+)
+
+// Merge implements MergeableOption using current-overrides-base semantics.
+func (s *ClusterObjectSelector) Merge(other MergeableOption) (MergeableOption, error) {
+	if other == nil {
+		return s, nil
+	}
+
+	otherSelector, ok := other.(*ClusterObjectSelector)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *ClusterObjectSelector", other)
+	}
+
+	merged := &ClusterObjectSelector{
+		MatchLabels:   s.MatchLabels,
+		LabelSelector: s.LabelSelector,
+	}
+
+	if otherSelector.LabelSelector != nil || len(otherSelector.MatchLabels) > 0 {
+		merged.MatchLabels = otherSelector.MatchLabels
+		merged.LabelSelector = otherSelector.LabelSelector
+	}
+
+	return merged, nil
+}
 
 // Validate validates that option configurations are correctly defined.
 func (s *ClusterObjectSelector) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -28,6 +28,19 @@ type MergeableOption interface {
 	Merge(other MergeableOption) (MergeableOption, error)
 }
 
+// AssertSameType type-asserts other to T and returns a descriptive error when
+// the assertion fails. It is intended to be used at the top of MergeableOption.Merge
+// implementations, where the assertion result is required to be of the same concrete
+// type as the receiver.
+func AssertSameType[T MergeableOption](other MergeableOption) (T, error) {
+	typed, ok := other.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("cannot merge options of type %T into %T", other, zero)
+	}
+	return typed, nil
+}
+
 // ClusterObjectSelector contains generalized options for matching entities by their attribute labels.
 type ClusterObjectSelector struct {
 	// Deprecated: This field is deprecated and will be forbidden in a future release.
@@ -47,9 +60,9 @@ func (s *ClusterObjectSelector) Merge(other MergeableOption) (MergeableOption, e
 		return s, nil
 	}
 
-	otherSelector, ok := other.(*ClusterObjectSelector)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *ClusterObjectSelector", other)
+	otherSelector, err := AssertSameType[*ClusterObjectSelector](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &ClusterObjectSelector{

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
@@ -662,22 +663,29 @@ var _ = Describe("options", func() {
 			Expect(mergedSelector.LabelSelector.MatchLabels).To(Equal(map[string]string{"base": "selector"}))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &option.ClusterObjectSelector{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"base": "selector"},
-				},
-			}
+		mergetest.AssertNilOtherReturnsReceiver(&option.ClusterObjectSelector{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"base": "selector"},
+			},
+		})
+		mergetest.AssertWrongTypeErrors(&option.ClusterObjectSelector{}, &disaoption.FileOwnerOptions{})
+	})
 
-			merged, err := base.Merge(nil)
+	Describe("#AssertSameType", func() {
+		It("should return the typed value when types match", func() {
+			in := &option.ClusterObjectSelector{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			}
+			got, err := option.AssertSameType[*option.ClusterObjectSelector](in)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+			Expect(got).To(BeIdenticalTo(in))
 		})
 
-		It("should return error when merging with wrong type", func() {
-			base := &option.ClusterObjectSelector{}
-			_, err := base.Merge(&disaoption.FileOwnerOptions{})
+		It("should return a descriptive error when types differ", func() {
+			_, err := option.AssertSameType[*option.ClusterObjectSelector](&disaoption.FileOwnerOptions{})
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("*option.FileOwnerOptions"))
+			Expect(err.Error()).To(ContainSubstring("*option.ClusterObjectSelector"))
 		})
 	})
 })

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
 var _ = Describe("options", func() {
@@ -606,5 +607,77 @@ var _ = Describe("options", func() {
 			Expect(matches).To(BeFalse())
 		})
 
+	})
+
+	Describe("#Merge ClusterObjectSelector", func() {
+		It("should override with other's LabelSelector when set", func() {
+			base := &option.ClusterObjectSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"base": "selector"},
+				},
+			}
+			other := &option.ClusterObjectSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"other": "selector"},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedSelector, ok := merged.(*option.ClusterObjectSelector)
+			Expect(ok).To(BeTrue())
+			Expect(mergedSelector.LabelSelector.MatchLabels).To(Equal(map[string]string{"other": "selector"}))
+		})
+
+		It("should override with other's MatchLabels when set", func() {
+			base := &option.ClusterObjectSelector{
+				MatchLabels: map[string]string{"base": "selector"},
+			}
+			other := &option.ClusterObjectSelector{
+				MatchLabels: map[string]string{"other": "selector"},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedSelector, ok := merged.(*option.ClusterObjectSelector)
+			Expect(ok).To(BeTrue())
+			Expect(mergedSelector.MatchLabels).To(Equal(map[string]string{"other": "selector"}))
+		})
+
+		It("should keep base when other has no selector", func() {
+			base := &option.ClusterObjectSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"base": "selector"},
+				},
+			}
+			other := &option.ClusterObjectSelector{}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedSelector, ok := merged.(*option.ClusterObjectSelector)
+			Expect(ok).To(BeTrue())
+			Expect(mergedSelector.LabelSelector.MatchLabels).To(Equal(map[string]string{"base": "selector"}))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &option.ClusterObjectSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"base": "selector"},
+				},
+			}
+
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &option.ClusterObjectSelector{}
+			_, err := base.Merge(&disaoption.FileOwnerOptions{})
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -5,12 +5,14 @@
 package option
 
 import (
+	"fmt"
 	"strconv"
 
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	intutils "github.com/gardener/diki/pkg/internal/utils"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
 )
 
@@ -19,12 +21,35 @@ type FileOwnerOptions struct {
 	ExpectedFileOwner ExpectedOwner `json:"expectedFileOwner" yaml:"expectedFileOwner"`
 }
 
-var _ option.Option = (*FileOwnerOptions)(nil)
+var (
+	_ option.Option          = &FileOwnerOptions{}
+	_ option.MergeableOption = &FileOwnerOptions{}
+)
 
 // ExpectedOwner contains expected user and group owners
 type ExpectedOwner struct {
 	Users  []string `json:"users" yaml:"users"`
 	Groups []string `json:"groups" yaml:"groups"`
+}
+
+func (o *FileOwnerOptions) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*FileOwnerOptions)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *FileOwnerOptions", other)
+	}
+
+	merged := &FileOwnerOptions{
+		ExpectedFileOwner: ExpectedOwner{
+			Users:  intutils.MergeStringSlices(o.ExpectedFileOwner.Users, otherOpts.ExpectedFileOwner.Users),
+			Groups: intutils.MergeStringSlices(o.ExpectedFileOwner.Groups, otherOpts.ExpectedFileOwner.Groups),
+		},
+	}
+
+	return merged, nil
 }
 
 // Validate validates that option configurations are correctly defined.
@@ -62,12 +87,34 @@ type Options242414 struct {
 	AcceptedPods []AcceptedPods242414 `json:"acceptedPods" yaml:"acceptedPods"`
 }
 
-var _ option.Option = (*Options242414)(nil)
+var (
+	_ option.Option          = &Options242414{}
+	_ option.MergeableOption = &Options242414{}
+)
 
 // AcceptedPods242414 contains option specifications for accepted pods
 type AcceptedPods242414 struct {
 	option.AcceptedNamespacedObject
 	Ports []int32 `json:"ports" yaml:"ports"`
+}
+
+func (o *Options242414) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options242414)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options242414", other)
+	}
+
+	merged := &Options242414{
+		AcceptedPods: make([]AcceptedPods242414, 0, len(o.AcceptedPods)+len(otherOpts.AcceptedPods)),
+	}
+	merged.AcceptedPods = append(merged.AcceptedPods, o.AcceptedPods...)
+	merged.AcceptedPods = append(merged.AcceptedPods, otherOpts.AcceptedPods...)
+
+	return merged, nil
 }
 
 // Validate validates that option configurations are correctly defined.
@@ -95,12 +142,34 @@ type Options242415 struct {
 	AcceptedPods []AcceptedPods242415 `json:"acceptedPods" yaml:"acceptedPods"`
 }
 
-var _ option.Option = (*Options242415)(nil)
+var (
+	_ option.Option          = &Options242415{}
+	_ option.MergeableOption = &Options242415{}
+)
 
 // AcceptedPods242415 contains option specifications for accepted pods
 type AcceptedPods242415 struct {
 	option.AcceptedNamespacedObject
 	EnvironmentVariables []string `json:"environmentVariables" yaml:"environmentVariables"`
+}
+
+func (o *Options242415) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options242415)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options242415", other)
+	}
+
+	merged := &Options242415{
+		AcceptedPods: make([]AcceptedPods242415, 0, len(o.AcceptedPods)+len(otherOpts.AcceptedPods)),
+	}
+	merged.AcceptedPods = append(merged.AcceptedPods, o.AcceptedPods...)
+	merged.AcceptedPods = append(merged.AcceptedPods, otherOpts.AcceptedPods...)
+
+	return merged, nil
 }
 
 // Validate validates that option configurations are correctly defined.
@@ -123,7 +192,10 @@ func (o Options242415) Validate(fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-var _ option.Option = (*Options242442)(nil)
+var (
+	_ option.Option          = &Options242442{}
+	_ option.MergeableOption = &Options242442{}
+)
 
 // Options242442 defines a slice of expected container images for rule 242442.
 type Options242442 struct {
@@ -133,6 +205,25 @@ type Options242442 struct {
 // ExpectedVersionedImage contains option specifications for expected to be versioned container images.
 type ExpectedVersionedImage struct {
 	Name string `json:"name" yaml:"name"`
+}
+
+func (o *Options242442) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, ok := other.(*Options242442)
+	if !ok {
+		return nil, fmt.Errorf("cannot merge options of type %T into *Options242442", other)
+	}
+
+	merged := &Options242442{
+		ExpectedVersionedImages: make([]ExpectedVersionedImage, 0, len(o.ExpectedVersionedImages)+len(otherOpts.ExpectedVersionedImages)),
+	}
+	merged.ExpectedVersionedImages = append(merged.ExpectedVersionedImages, o.ExpectedVersionedImages...)
+	merged.ExpectedVersionedImages = append(merged.ExpectedVersionedImages, otherOpts.ExpectedVersionedImages...)
+
+	return merged, nil
 }
 
 // Validate validates that option configurations are correctly defined.

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -32,6 +32,7 @@ type ExpectedOwner struct {
 	Groups []string `json:"groups" yaml:"groups"`
 }
 
+// Merge implements MergeableOption by performing a set union on Users and Groups.
 func (o *FileOwnerOptions) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil
@@ -98,6 +99,7 @@ type AcceptedPods242414 struct {
 	Ports []int32 `json:"ports" yaml:"ports"`
 }
 
+// Merge implements MergeableOption by concatenating AcceptedPods from both options.
 func (o *Options242414) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil
@@ -153,6 +155,7 @@ type AcceptedPods242415 struct {
 	EnvironmentVariables []string `json:"environmentVariables" yaml:"environmentVariables"`
 }
 
+// Merge implements MergeableOption by concatenating AcceptedPods from both options.
 func (o *Options242415) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil
@@ -207,6 +210,7 @@ type ExpectedVersionedImage struct {
 	Name string `json:"name" yaml:"name"`
 }
 
+// Merge implements MergeableOption by concatenating ExpectedVersionedImages from both options.
 func (o *Options242442) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -5,7 +5,6 @@
 package option
 
 import (
-	"fmt"
 	"strconv"
 
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -38,9 +37,9 @@ func (o *FileOwnerOptions) Merge(other option.MergeableOption) (option.Mergeable
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*FileOwnerOptions)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *FileOwnerOptions", other)
+	otherOpts, err := option.AssertSameType[*FileOwnerOptions](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &FileOwnerOptions{
@@ -105,9 +104,9 @@ func (o *Options242414) Merge(other option.MergeableOption) (option.MergeableOpt
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options242414)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options242414", other)
+	otherOpts, err := option.AssertSameType[*Options242414](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options242414{
@@ -161,9 +160,9 @@ func (o *Options242415) Merge(other option.MergeableOption) (option.MergeableOpt
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options242415)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options242415", other)
+	otherOpts, err := option.AssertSameType[*Options242415](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options242415{
@@ -216,9 +215,9 @@ func (o *Options242442) Merge(other option.MergeableOption) (option.MergeableOpt
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options242442)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options242442", other)
+	otherOpts, err := option.AssertSameType[*Options242442](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options242442{

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	k8soption "github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	"github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
@@ -294,20 +295,10 @@ var _ = Describe("options", func() {
 			Expect(mergedOpts.ExpectedFileOwner.Groups).To(ConsistOf("0", "65534"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &option.FileOwnerOptions{
-				ExpectedFileOwner: option.ExpectedOwner{Users: []string{"0"}},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&option.FileOwnerOptions{
+			ExpectedFileOwner: option.ExpectedOwner{Users: []string{"0"}},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &option.FileOwnerOptions{}
-			_, err := base.Merge(&option.Options242414{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&option.FileOwnerOptions{}, &option.Options242414{})
 	})
 
 	Describe("#Merge Options242414", func() {
@@ -333,20 +324,10 @@ var _ = Describe("options", func() {
 			Expect(mergedOpts.AcceptedPods[1].Ports).To(Equal([]int32{443}))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &option.Options242414{
-				AcceptedPods: []option.AcceptedPods242414{{Ports: []int32{80}}},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&option.Options242414{
+			AcceptedPods: []option.AcceptedPods242414{{Ports: []int32{80}}},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &option.Options242414{}
-			_, err := base.Merge(&option.FileOwnerOptions{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&option.Options242414{}, &option.FileOwnerOptions{})
 	})
 
 	Describe("#Merge Options242415", func() {
@@ -372,20 +353,10 @@ var _ = Describe("options", func() {
 			Expect(mergedOpts.AcceptedPods[1].EnvironmentVariables).To(Equal([]string{"BAR"}))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &option.Options242415{
-				AcceptedPods: []option.AcceptedPods242415{{EnvironmentVariables: []string{"FOO"}}},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&option.Options242415{
+			AcceptedPods: []option.AcceptedPods242415{{EnvironmentVariables: []string{"FOO"}}},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &option.Options242415{}
-			_, err := base.Merge(&option.FileOwnerOptions{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&option.Options242415{}, &option.FileOwnerOptions{})
 	})
 
 	Describe("#Merge Options242442", func() {
@@ -411,19 +382,9 @@ var _ = Describe("options", func() {
 			Expect(mergedOpts.ExpectedVersionedImages[1].Name).To(Equal("image-b"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &option.Options242442{
-				ExpectedVersionedImages: []option.ExpectedVersionedImage{{Name: "image-a"}},
-			}
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&option.Options242442{
+			ExpectedVersionedImages: []option.ExpectedVersionedImage{{Name: "image-a"}},
 		})
-
-		It("should return error when merging with wrong type", func() {
-			base := &option.Options242442{}
-			_, err := base.Merge(&option.FileOwnerOptions{})
-			Expect(err).To(HaveOccurred())
-		})
+		mergetest.AssertWrongTypeErrors(&option.Options242442{}, &option.FileOwnerOptions{})
 	})
 })

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -246,4 +246,184 @@ var _ = Describe("options", func() {
 			Expect(result).To(BeEmpty())
 		})
 	})
+
+	Describe("#Merge FileOwnerOptions", func() {
+		It("should merge by appending Users and Groups", func() {
+			base := &option.FileOwnerOptions{
+				ExpectedFileOwner: option.ExpectedOwner{
+					Users:  []string{"0"},
+					Groups: []string{"0"},
+				},
+			}
+			other := &option.FileOwnerOptions{
+				ExpectedFileOwner: option.ExpectedOwner{
+					Users:  []string{"1000"},
+					Groups: []string{"1000"},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*option.FileOwnerOptions)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.ExpectedFileOwner.Users).To(ConsistOf("0", "1000"))
+			Expect(mergedOpts.ExpectedFileOwner.Groups).To(ConsistOf("0", "1000"))
+		})
+
+		It("should deduplicate Users and Groups", func() {
+			base := &option.FileOwnerOptions{
+				ExpectedFileOwner: option.ExpectedOwner{
+					Users:  []string{"0", "1000"},
+					Groups: []string{"0", "65534"},
+				},
+			}
+			other := &option.FileOwnerOptions{
+				ExpectedFileOwner: option.ExpectedOwner{
+					Users:  []string{"0", "65534"},
+					Groups: []string{"0"},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*option.FileOwnerOptions)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.ExpectedFileOwner.Users).To(ConsistOf("0", "1000", "65534"))
+			Expect(mergedOpts.ExpectedFileOwner.Groups).To(ConsistOf("0", "65534"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &option.FileOwnerOptions{
+				ExpectedFileOwner: option.ExpectedOwner{Users: []string{"0"}},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &option.FileOwnerOptions{}
+			_, err := base.Merge(&option.Options242414{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#Merge Options242414", func() {
+		It("should merge by appending AcceptedPods", func() {
+			base := &option.Options242414{
+				AcceptedPods: []option.AcceptedPods242414{
+					{Ports: []int32{80}},
+				},
+			}
+			other := &option.Options242414{
+				AcceptedPods: []option.AcceptedPods242414{
+					{Ports: []int32{443}},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*option.Options242414)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedPods[0].Ports).To(Equal([]int32{80}))
+			Expect(mergedOpts.AcceptedPods[1].Ports).To(Equal([]int32{443}))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &option.Options242414{
+				AcceptedPods: []option.AcceptedPods242414{{Ports: []int32{80}}},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &option.Options242414{}
+			_, err := base.Merge(&option.FileOwnerOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#Merge Options242415", func() {
+		It("should merge by appending AcceptedPods", func() {
+			base := &option.Options242415{
+				AcceptedPods: []option.AcceptedPods242415{
+					{EnvironmentVariables: []string{"FOO"}},
+				},
+			}
+			other := &option.Options242415{
+				AcceptedPods: []option.AcceptedPods242415{
+					{EnvironmentVariables: []string{"BAR"}},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*option.Options242415)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.AcceptedPods).To(HaveLen(2))
+			Expect(mergedOpts.AcceptedPods[0].EnvironmentVariables).To(Equal([]string{"FOO"}))
+			Expect(mergedOpts.AcceptedPods[1].EnvironmentVariables).To(Equal([]string{"BAR"}))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &option.Options242415{
+				AcceptedPods: []option.AcceptedPods242415{{EnvironmentVariables: []string{"FOO"}}},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &option.Options242415{}
+			_, err := base.Merge(&option.FileOwnerOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#Merge Options242442", func() {
+		It("should merge by appending ExpectedVersionedImages", func() {
+			base := &option.Options242442{
+				ExpectedVersionedImages: []option.ExpectedVersionedImage{
+					{Name: "image-a"},
+				},
+			}
+			other := &option.Options242442{
+				ExpectedVersionedImages: []option.ExpectedVersionedImage{
+					{Name: "image-b"},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*option.Options242442)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.ExpectedVersionedImages).To(HaveLen(2))
+			Expect(mergedOpts.ExpectedVersionedImages[0].Name).To(Equal("image-a"))
+			Expect(mergedOpts.ExpectedVersionedImages[1].Name).To(Equal("image-b"))
+		})
+
+		It("should return the receiver when merging with nil", func() {
+			base := &option.Options242442{
+				ExpectedVersionedImages: []option.ExpectedVersionedImage{{Name: "image-a"}},
+			}
+			merged, err := base.Merge(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(base))
+		})
+
+		It("should return error when merging with wrong type", func() {
+			base := &option.Options242442{}
+			_, err := base.Merge(&option.FileOwnerOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR implements the `MergeableOption` interface for all rules of the gardener provider in DISA K8s STIG.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/687

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[DISA K8s STIG] All rules in the `gardener` provider can now be merged using the `config merge` command.
```
