### PR TITLE
Update Diki's documentation to include support for DISA STIG's version V2R6

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ diki run \
     --config=config.yaml \
     --provider=gardener \
     --ruleset-id=disa-kubernetes-stig \
-    --ruleset-version=v2r5
+    --ruleset-version=v2r6
 ```
 
 - Run a specific rule defined in a ruleset for a known provider
@@ -106,7 +106,7 @@ diki run \
     --config=config.yaml \
     --provider=gardener \
     --ruleset-id=disa-kubernetes-stig \
-    --ruleset-version=v2r5 \
+    --ruleset-version=v2r6 \
     --rule-id=242414
 ```
 

--- a/docs/providers/gardener.md
+++ b/docs/providers/gardener.md
@@ -8,8 +8,8 @@ The `Gardener` provider is capable of accessing a `seed/shoot` environment and r
 
 The `Gardener` provider implements the following `rulesets`:
 - [DISA Kubernetes Security Technical Implementation Guide](../rulesets/disa-k8s-stig/ruleset.md)
+  - v2r6
   - v2r5
-  - v2r4
 
 ### Configuration
 

--- a/docs/providers/managedk8s.md
+++ b/docs/providers/managedk8s.md
@@ -10,8 +10,8 @@ The `Managed Kubernetes` provider is capable of accessing a managed Kubernetes e
 The `Managed Kubernetes` provider implements the following `rulesets`:
 
 - [DISA Kubernetes Security Technical Implementation Guide](../rulesets/disa-k8s-stig/ruleset.md)
+  - v2r6
   - v2r5
-  - v2r4
 
 - [Security Hardened Kubernetes Cluster](../rulesets/security-hardened-k8s/ruleset.md)
   - v0.1.0

--- a/docs/providers/virtualgarden.md
+++ b/docs/providers/virtualgarden.md
@@ -8,8 +8,8 @@ The `Virtual Garden` provider is capable of accessing a `runtime/virtual garden`
 
 The `Gardener` provider implements the following `rulesets`:
 - [DISA Kubernetes Security Technical Implementation Guide](../rulesets/disa-k8s-stig/ruleset.md)
+  - v2r6
   - v2r5
-  - v2r4
 
 ### Configuration
 

--- a/example/config/gardener.yaml
+++ b/example/config/gardener.yaml
@@ -15,7 +15,7 @@ providers:             # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r5
+    version: v2r6
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:

--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -11,7 +11,7 @@ providers:                   # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r5
+    version: v2r6
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1
     ruleOptions:

--- a/example/config/virtualgarden.yaml
+++ b/example/config/virtualgarden.yaml
@@ -10,7 +10,7 @@ providers:               # contains information about known providers
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r5
+    version: v2r6
     # args:
     #   maxRetries: 1 # number of maximum rule run retries. Defaults to 1 
     ruleOptions:

--- a/example/guides/disa-k8s-stig-shoot.yaml
+++ b/example/guides/disa-k8s-stig-shoot.yaml
@@ -9,7 +9,7 @@ providers:
   rulesets:
   - id: disa-kubernetes-stig
     name: DISA Kubernetes Security Technical Implementation Guide
-    version: v2r5
+    version: v2r6
     ruleOptions:
     - ruleID: "242393"
       args:

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -9,7 +9,7 @@ set -e
 rule_id=""
 provider="gardener"
 ruleset_id="disa-kubernetes-stig"
-ruleset_version="v2r5"
+ruleset_version="v2r6"
 run_all="false"
 
 
@@ -29,7 +29,7 @@ This command runs diki with a specified config file.
                       specified ruleset are executed.
     --provider        Ruleset provider. Defaults to "gardener".
     --ruleset-id      ID of ruleset that will be ran. Defaults to "disa-kubernetes-stig".
-    --ruleset-version Version of ruleset that will be ran. Defaults to "v2r5".
+    --ruleset-version Version of ruleset that will be ran. Defaults to "v2r6".
     
   environment variables:
     IMAGEVECTOR_OVERWRITE Overwrites diki/imagesvector/images.yaml file with specified file path.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates Diki's documentation and configuration files to use version V2R6 of the DISA STIG ruleset.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR should be merged after https://github.com/gardener/diki/pull/749 and right before a diki release.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
