### PR TITLE
Use type-assertion helpers for mergeable rules

### DIFF
--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
@@ -39,9 +39,9 @@ func (o *Options1000) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options1000)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options1000", other)
+	otherOpts, err := option.AssertSameType[*Options1000](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options1000{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#1000", func() {
@@ -307,18 +308,6 @@ var _ = Describe("#1000", func() {
 			Expect(mergedOpts.Extensions[1].Type).To(Equal("ext-b"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options1000{
-				Extensions: []rules.Extension{
-					{Type: "ext-a"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options1000", func() {
 			base := &rules.Options1000{}
 			other := &rules.Options1000{}
@@ -331,16 +320,9 @@ var _ = Describe("#1000", func() {
 			Expect(mergedOpts.Extensions).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different type", func() {
-			base := &rules.Options1000{
-				Extensions: []rules.Extension{
-					{Type: "ext-a"},
-				},
-			}
-
-			_, err := base.Merge(&rules.Options2000{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options1000{
+			Extensions: []rules.Extension{{Type: "ext-a"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options1000{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -43,9 +43,9 @@ func (o *Options1001) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options1001)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options1001", other)
+	otherOpts, err := option.AssertSameType[*Options1001](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options1001{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#1001", func() {
@@ -359,18 +360,6 @@ var _ = Describe("#1001", func() {
 			Expect(mergedOpts.AllowedClassifications[1]).To(Equal(gardencorev1beta1.ClassificationPreview))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options1001{
-				AllowedClassifications: []gardencorev1beta1.VersionClassification{
-					gardencorev1beta1.ClassificationSupported,
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options1001", func() {
 			base := &rules.Options1001{}
 			other := &rules.Options1001{}
@@ -383,16 +372,9 @@ var _ = Describe("#1001", func() {
 			Expect(mergedOpts.AllowedClassifications).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different type", func() {
-			base := &rules.Options1001{
-				AllowedClassifications: []gardencorev1beta1.VersionClassification{
-					gardencorev1beta1.ClassificationSupported,
-				},
-			}
-
-			_, err := base.Merge(&rules.Options2000{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options1001{
+			AllowedClassifications: []gardencorev1beta1.VersionClassification{gardencorev1beta1.ClassificationSupported},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options1001{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
@@ -48,9 +48,9 @@ func (o *Options1002) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options1002)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options1002", other)
+	otherOpts, err := option.AssertSameType[*Options1002](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options1002{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#1002", func() {
@@ -510,18 +511,6 @@ var _ = Describe("#1002", func() {
 			Expect(mergedOpts.MachineImages[1].Name).To(Equal("gardenlinux"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options1002{
-				MachineImages: []rules.MachineImage{
-					{Name: "ubuntu"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options1002", func() {
 			base := &rules.Options1002{}
 			other := &rules.Options1002{}
@@ -534,16 +523,9 @@ var _ = Describe("#1002", func() {
 			Expect(mergedOpts.MachineImages).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different type", func() {
-			base := &rules.Options1002{
-				MachineImages: []rules.MachineImage{
-					{Name: "ubuntu"},
-				},
-			}
-
-			_, err := base.Merge(&rules.Options2000{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options1002{
+			MachineImages: []rules.MachineImage{{Name: "ubuntu"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options1002{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
@@ -47,9 +47,9 @@ func (o *Options1003) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options1003)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options1003", other)
+	otherOpts, err := option.AssertSameType[*Options1003](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options1003{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#1003", func() {
@@ -317,16 +318,6 @@ var _ = Describe("#1003", func() {
 			Expect(mergedOpts.AllowedLakomScopes[1]).To(Equal(lakomapi.Cluster))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options1003{
-				AllowedLakomScopes: []lakomapi.ScopeType{lakomapi.KubeSystem},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options1003", func() {
 			base := &rules.Options1003{}
 			other := &rules.Options1003{}
@@ -339,14 +330,9 @@ var _ = Describe("#1003", func() {
 			Expect(mergedOpts.AllowedLakomScopes).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different type", func() {
-			base := &rules.Options1003{
-				AllowedLakomScopes: []lakomapi.ScopeType{lakomapi.KubeSystem},
-			}
-
-			_, err := base.Merge(&rules.Options2000{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options1003{
+			AllowedLakomScopes: []lakomapi.ScopeType{lakomapi.KubeSystem},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options1003{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -49,9 +49,9 @@ func (o *Options2000) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2000)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2000", other)
+	otherOpts, err := option.AssertSameType[*Options2000](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2000{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2000", func() {
@@ -440,18 +441,6 @@ kind: AuthenticationConfiguration
 			Expect(mergedOpts.AcceptedEndpoints[1].Path).To(Equal("/readyz"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2000{
-				AcceptedEndpoints: []rules.AcceptedEndpoint{
-					{Path: "/healthz"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2000", func() {
 			base := &rules.Options2000{}
 			other := &rules.Options2000{}
@@ -464,16 +453,9 @@ kind: AuthenticationConfiguration
 			Expect(mergedOpts.AcceptedEndpoints).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different type", func() {
-			base := &rules.Options2000{
-				AcceptedEndpoints: []rules.AcceptedEndpoint{
-					{Path: "/healthz"},
-				},
-			}
-
-			_, err := base.Merge(&rules.Options1000{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2000{
+			AcceptedEndpoints: []rules.AcceptedEndpoint{{Path: "/healthz"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2000{}, &rules.Options1000{})
 	})
 })

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
@@ -40,9 +40,9 @@ func (o *Options2007) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2007)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2007", other)
+	otherOpts, err := option.AssertSameType[*Options2007](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2007{

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
@@ -23,6 +23,7 @@ import (
 	intkubeutils "github.com/gardener/diki/pkg/internal/kubernetes/utils"
 	"github.com/gardener/diki/pkg/provider/garden/ruleset/securityhardenedshoot/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2007", func() {
@@ -322,24 +323,9 @@ var _ = Describe("#2007", func() {
 			Expect(mergedOpts.MinPodSecurityStandardsProfile).To(Equal(intkubeutils.PSSProfileBaseline))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2007{
-				MinPodSecurityStandardsProfile: intkubeutils.PSSProfileRestricted,
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2007{
+			MinPodSecurityStandardsProfile: intkubeutils.PSSProfileRestricted,
 		})
-
-		It("should return an error when merging with a different type", func() {
-			base := &rules.Options2007{
-				MinPodSecurityStandardsProfile: intkubeutils.PSSProfileBaseline,
-			}
-
-			_, err := base.Merge(&rules.Options2000{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cannot merge options of type"))
-		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2007{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2000", func() {
@@ -1229,22 +1230,6 @@ var _ = Describe("#2000", func() {
 			Expect(mergedOpts.AcceptedNamespaces[1].Justification).To(Equal("override justification"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2000{
-				AcceptedNamespaces: []rules.AcceptedNamespaces2000{
-					{
-						AcceptedClusterObject: option.AcceptedClusterObject{
-							Justification: "base",
-						},
-					},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2000", func() {
 			base := &rules.Options2000{}
 			other := &rules.Options2000{}
@@ -1257,13 +1242,11 @@ var _ = Describe("#2000", func() {
 			Expect(mergedOpts.AcceptedNamespaces).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2000{}
-			other := &rules.Options2001{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2000{
+			AcceptedNamespaces: []rules.AcceptedNamespaces2000{
+				{AcceptedClusterObject: option.AcceptedClusterObject{Justification: "base"}},
+			},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2000{}, &rules.Options2001{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -7,7 +7,6 @@ package rules
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -59,9 +58,9 @@ func (o *Options2001) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2001)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2001", other)
+	otherOpts, err := option.AssertSameType[*Options2001](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2001{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2001", func() {
@@ -245,18 +246,6 @@ var _ = Describe("#2001", func() {
 			Expect(mergedOpts.AcceptedPods[1].Justification).To(Equal("override justification"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2001{
-				AcceptedPods: []option.AcceptedNamespacedObject{
-					{Justification: "base"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2001", func() {
 			base := &rules.Options2001{}
 			other := &rules.Options2001{}
@@ -269,13 +258,9 @@ var _ = Describe("#2001", func() {
 			Expect(mergedOpts.AcceptedPods).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2001{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2001{
+			AcceptedPods: []option.AcceptedNamespacedObject{{Justification: "base"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2001{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
@@ -7,7 +7,6 @@ package rules
 import (
 	"cmp"
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,9 +55,9 @@ func (o *Options2002) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2002)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2002", other)
+	otherOpts, err := option.AssertSameType[*Options2002](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2002{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2002", func() {
@@ -191,18 +192,6 @@ var _ = Describe("#2002", func() {
 			Expect(mergedOpts.AcceptedStorageClasses[1].Justification).To(Equal("override justification"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2002{
-				AcceptedStorageClasses: []option.AcceptedClusterObject{
-					{Justification: "base"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2002", func() {
 			base := &rules.Options2002{}
 			other := &rules.Options2002{}
@@ -215,13 +204,9 @@ var _ = Describe("#2002", func() {
 			Expect(mergedOpts.AcceptedStorageClasses).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2002{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2002{
+			AcceptedStorageClasses: []option.AcceptedClusterObject{{Justification: "base"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2002{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -6,7 +6,6 @@ package rules
 
 import (
 	"context"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -49,9 +48,9 @@ func (o *Options2003) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2003)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2003", other)
+	otherOpts, err := option.AssertSameType[*Options2003](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2003{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2003", func() {
@@ -689,21 +690,6 @@ var _ = Describe("#2003", func() {
 			Expect(mergedOpts.AcceptedPods[1].Justification).To(Equal("override justification"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2003{
-				AcceptedPods: []option.AcceptedPodVolumes{
-					{
-						AcceptedNamespacedObject: option.AcceptedNamespacedObject{Justification: "base"},
-						VolumeNames:              []string{"vol1"},
-					},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2003", func() {
 			base := &rules.Options2003{}
 			other := &rules.Options2003{}
@@ -716,13 +702,14 @@ var _ = Describe("#2003", func() {
 			Expect(mergedOpts.AcceptedPods).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2003{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2003{
+			AcceptedPods: []option.AcceptedPodVolumes{
+				{
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{Justification: "base"},
+					VolumeNames:              []string{"vol1"},
+				},
+			},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2003{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
@@ -7,7 +7,6 @@ package rules
 import (
 	"cmp"
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,9 +55,9 @@ func (o *Options2004) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2004)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2004", other)
+	otherOpts, err := option.AssertSameType[*Options2004](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2004{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2004", func() {
@@ -151,18 +152,6 @@ var _ = Describe("#2004", func() {
 			Expect(mergedOpts.AcceptedServices[1].Justification).To(Equal("override justification"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2004{
-				AcceptedServices: []option.AcceptedNamespacedObject{
-					{Justification: "base"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2004", func() {
 			base := &rules.Options2004{}
 			other := &rules.Options2004{}
@@ -175,13 +164,9 @@ var _ = Describe("#2004", func() {
 			Expect(mergedOpts.AcceptedServices).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2004{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2004{
+			AcceptedServices: []option.AcceptedNamespacedObject{{Justification: "base"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2004{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -6,7 +6,6 @@ package rules
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -47,9 +46,9 @@ func (o *Options2005) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2005)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2005", other)
+	otherOpts, err := option.AssertSameType[*Options2005](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2005{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2005", func() {
@@ -336,18 +337,6 @@ var _ = Describe("#2005", func() {
 			Expect(mergedOpts.AllowedImages[1].Prefix).To(Equal("docker.io/library/"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2005{
-				AllowedImages: []rules.AllowedImage{
-					{Prefix: "registry.example.com/"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2005", func() {
 			base := &rules.Options2005{}
 			other := &rules.Options2005{}
@@ -360,13 +349,9 @@ var _ = Describe("#2005", func() {
 			Expect(mergedOpts.AllowedImages).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2005{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2005{
+			AllowedImages: []rules.AllowedImage{{Prefix: "registry.example.com/"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2005{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
@@ -7,7 +7,6 @@ package rules
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -60,9 +59,9 @@ func (o *Options2006) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2006)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2006", other)
+	otherOpts, err := option.AssertSameType[*Options2006](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2006{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2006", func() {
@@ -287,18 +288,6 @@ var _ = Describe("#2006", func() {
 			Expect(mergedOpts.AcceptedClusterRoles[1].Justification).To(Equal("override cluster role"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2006{
-				AcceptedRoles: []option.AcceptedNamespacedObject{
-					{Justification: "base"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2006", func() {
 			base := &rules.Options2006{}
 			other := &rules.Options2006{}
@@ -312,13 +301,9 @@ var _ = Describe("#2006", func() {
 			Expect(mergedOpts.AcceptedClusterRoles).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2006{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2006{
+			AcceptedRoles: []option.AcceptedNamespacedObject{{Justification: "base"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2006{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
@@ -7,7 +7,6 @@ package rules
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -60,9 +59,9 @@ func (o *Options2007) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2007)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2007", other)
+	otherOpts, err := option.AssertSameType[*Options2007](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2007{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2007", func() {
@@ -287,18 +288,6 @@ var _ = Describe("#2007", func() {
 			Expect(mergedOpts.AcceptedClusterRoles[1].Justification).To(Equal("override cluster role"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2007{
-				AcceptedRoles: []option.AcceptedNamespacedObject{
-					{Justification: "base"},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2007", func() {
 			base := &rules.Options2007{}
 			other := &rules.Options2007{}
@@ -312,13 +301,9 @@ var _ = Describe("#2007", func() {
 			Expect(mergedOpts.AcceptedClusterRoles).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2007{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2007{
+			AcceptedRoles: []option.AcceptedNamespacedObject{{Justification: "base"}},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2007{}, &rules.Options2000{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -7,7 +7,6 @@ package rules
 import (
 	"cmp"
 	"context"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -55,9 +54,9 @@ func (o *Options2008) Merge(other option.MergeableOption) (option.MergeableOptio
 		return o, nil
 	}
 
-	otherOpts, ok := other.(*Options2008)
-	if !ok {
-		return nil, fmt.Errorf("cannot merge options of type %T into *Options2008", other)
+	otherOpts, err := option.AssertSameType[*Options2008](other)
+	if err != nil {
+		return nil, err
 	}
 
 	merged := &Options2008{

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 )
 
 var _ = Describe("#2008", func() {
@@ -585,21 +586,6 @@ var _ = Describe("#2008", func() {
 			Expect(mergedOpts.AcceptedPods[1].Justification).To(Equal("override justification"))
 		})
 
-		It("should return the receiver when merging with nil", func() {
-			base := &rules.Options2008{
-				AcceptedPods: []option.AcceptedPodVolumes{
-					{
-						AcceptedNamespacedObject: option.AcceptedNamespacedObject{Justification: "base"},
-						VolumeNames:              []string{"vol1"},
-					},
-				},
-			}
-
-			merged, err := base.Merge(nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(merged).To(Equal(base))
-		})
-
 		It("should handle merging two empty Options2008", func() {
 			base := &rules.Options2008{}
 			other := &rules.Options2008{}
@@ -612,13 +598,14 @@ var _ = Describe("#2008", func() {
 			Expect(mergedOpts.AcceptedPods).To(BeEmpty())
 		})
 
-		It("should return an error when merging with a different option type", func() {
-			base := &rules.Options2008{}
-			other := &rules.Options2000{}
-
-			merged, err := base.Merge(other)
-			Expect(err).To(MatchError(ContainSubstring("cannot merge options of type")))
-			Expect(merged).To(BeNil())
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options2008{
+			AcceptedPods: []option.AcceptedPodVolumes{
+				{
+					AcceptedNamespacedObject: option.AcceptedNamespacedObject{Justification: "base"},
+					VolumeNames:              []string{"vol1"},
+				},
+			},
 		})
+		mergetest.AssertWrongTypeErrors(&rules.Options2008{}, &rules.Options2000{})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
This PR adapt all current mergeable rule options to use the type-assertion helpers introduced with https://github.com/gardener/diki/pull/748

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/687

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
