### PR TITLE
[DISA K8s STIG] Implement `MergeableOption` for rule options in the `managedk8s` provider

### DIFF
--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -69,21 +69,14 @@ func (o *Options242451) Merge(other option.MergeableOption) (option.MergeableOpt
 		KubeProxy: otherOpts.KubeProxy,
 	}
 
-	switch {
-	case o.FileOwnerOptions != nil && otherOpts.FileOwnerOptions != nil:
+	if o.FileOwnerOptions != nil {
 		mergedFileOwner, err := o.FileOwnerOptions.Merge(otherOpts.FileOwnerOptions)
 		if err != nil {
 			return nil, err
 		}
-		typedFileOwner, err := option.AssertSameType[*disaoption.FileOwnerOptions](mergedFileOwner)
-		if err != nil {
-			return nil, err
-		}
-		merged.FileOwnerOptions = typedFileOwner
-	case otherOpts.FileOwnerOptions != nil:
+		merged.FileOwnerOptions = mergedFileOwner.(*disaoption.FileOwnerOptions)
+	} else {
 		merged.FileOwnerOptions = otherOpts.FileOwnerOptions
-	case o.FileOwnerOptions != nil:
-		merged.FileOwnerOptions = o.FileOwnerOptions
 	}
 
 	return merged, nil

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -56,7 +56,7 @@ type Options242451 struct {
 }
 
 func (o *Options242451) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -55,7 +55,7 @@ type Options242400 struct {
 }
 
 func (o *Options242400) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -35,8 +35,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242400{}
-	_ rule.Severity = &Rule242400{}
+	_ rule.Rule              = &Rule242400{}
+	_ rule.Severity          = &Rule242400{}
+	_ option.Option          = &Options242400{}
+	_ option.MergeableOption = &Options242400{}
 )
 
 type Rule242400 struct {
@@ -52,7 +54,25 @@ type Options242400 struct {
 	KubeProxy disaoption.KubeProxyOptions `json:"kubeProxy" yaml:"kubeProxy"`
 }
 
-var _ option.Option = (*Options242400)(nil)
+func (o *Options242400) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, err := option.AssertSameType[*Options242400](other)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedKubeProxy, err := o.KubeProxy.Merge(&otherOpts.KubeProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Options242400{
+		KubeProxy: *mergedKubeProxy.(*disaoption.KubeProxyOptions),
+	}, nil
+}
 
 func (o Options242400) Validate(fldPath *field.Path) field.ErrorList {
 	return o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
@@ -450,5 +451,28 @@ var _ = Describe("#242400", func() {
 
 		Expect(err).To(BeNil())
 		Expect(ruleResult.CheckResults).To(ConsistOf(expectedCheckResults))
+	})
+
+	Describe("#Merge Options242400", func() {
+		It("should override KubeProxy with other's value", func() {
+			base := &rules.Options242400{
+				KubeProxy: disaoption.KubeProxyOptions{Disabled: false},
+			}
+			other := &rules.Options242400{
+				KubeProxy: disaoption.KubeProxyOptions{Disabled: true},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242400)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+		})
+
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242400{
+			KubeProxy: disaoption.KubeProxyOptions{Disabled: true},
+		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242400{}, &rules.Options242451{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -23,8 +23,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242442{}
-	_ rule.Severity = &Rule242442{}
+	_ rule.Rule              = &Rule242442{}
+	_ rule.Severity          = &Rule242442{}
+	_ option.Option          = &Options242442{}
+	_ option.MergeableOption = &Options242442{}
 )
 
 type Rule242442 struct {
@@ -37,7 +39,36 @@ type Options242442 struct {
 	ImageSelector *disaoption.Options242442
 }
 
-var _ option.Option = (*Options242442)(nil)
+func (o *Options242442) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, err := option.AssertSameType[*Options242442](other)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := &Options242442{}
+
+	if otherOpts.KubeProxy != nil {
+		merged.KubeProxy = otherOpts.KubeProxy
+	} else {
+		merged.KubeProxy = o.KubeProxy
+	}
+
+	if o.ImageSelector != nil {
+		mergedImageSelector, err := o.ImageSelector.Merge(otherOpts.ImageSelector)
+		if err != nil {
+			return nil, err
+		}
+		merged.ImageSelector = mergedImageSelector.(*disaoption.Options242442)
+	} else {
+		merged.ImageSelector = otherOpts.ImageSelector
+	}
+
+	return merged, nil
+}
 
 func (o Options242442) Validate(fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -51,10 +51,14 @@ func (o *Options242442) Merge(other option.MergeableOption) (option.MergeableOpt
 
 	merged := &Options242442{}
 
-	if otherOpts.KubeProxy != nil {
-		merged.KubeProxy = otherOpts.KubeProxy
+	if o.KubeProxy != nil {
+		mergedKubeProxy, err := o.KubeProxy.Merge(otherOpts.KubeProxy)
+		if err != nil {
+			return nil, err
+		}
+		merged.KubeProxy = mergedKubeProxy.(*option.ClusterObjectSelector)
 	} else {
-		merged.KubeProxy = o.KubeProxy
+		merged.KubeProxy = otherOpts.KubeProxy
 	}
 
 	if o.ImageSelector != nil {

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -40,7 +40,7 @@ type Options242442 struct {
 }
 
 func (o *Options242442) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
@@ -403,6 +403,28 @@ var _ = Describe("#242442", func() {
 			Expect(mergedOpts.ImageSelector.ExpectedVersionedImages[1].Name).To(Equal("image-b"))
 		})
 
+		It("should use other's fields when base has nil fields", func() {
+			base := &rules.Options242442{}
+			other := &rules.Options242442{
+				KubeProxy: &option.ClusterObjectSelector{
+					MatchLabels: map[string]string{"other": "selector"},
+				},
+				ImageSelector: &disaoption.Options242442{
+					ExpectedVersionedImages: []disaoption.ExpectedVersionedImage{
+						{Name: "image-b"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242442)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy).To(Equal(other.KubeProxy))
+			Expect(mergedOpts.ImageSelector).To(Equal(other.ImageSelector))
+		})
+
 		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242442{
 			KubeProxy: &option.ClusterObjectSelector{
 				MatchLabels: map[string]string{"base": "selector"},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 )
 
@@ -366,5 +367,47 @@ var _ = Describe("#242442", func() {
 		}
 
 		Expect(ruleResult.CheckResults).To(Equal(expectedCheckResults))
+	})
+
+	Describe("#Merge Options242442", func() {
+		It("should override KubeProxy and merge ImageSelector", func() {
+			base := &rules.Options242442{
+				KubeProxy: &option.ClusterObjectSelector{
+					MatchLabels: map[string]string{"base": "selector"},
+				},
+				ImageSelector: &disaoption.Options242442{
+					ExpectedVersionedImages: []disaoption.ExpectedVersionedImage{
+						{Name: "image-a"},
+					},
+				},
+			}
+			other := &rules.Options242442{
+				KubeProxy: &option.ClusterObjectSelector{
+					MatchLabels: map[string]string{"other": "selector"},
+				},
+				ImageSelector: &disaoption.Options242442{
+					ExpectedVersionedImages: []disaoption.ExpectedVersionedImage{
+						{Name: "image-b"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242442)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.MatchLabels).To(Equal(map[string]string{"other": "selector"}))
+			Expect(mergedOpts.ImageSelector.ExpectedVersionedImages).To(HaveLen(2))
+			Expect(mergedOpts.ImageSelector.ExpectedVersionedImages[0].Name).To(Equal("image-a"))
+			Expect(mergedOpts.ImageSelector.ExpectedVersionedImages[1].Name).To(Equal("image-b"))
+		})
+
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242442{
+			KubeProxy: &option.ClusterObjectSelector{
+				MatchLabels: map[string]string{"base": "selector"},
+			},
+		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242442{}, &rules.Options242400{})
 	})
 })

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
@@ -54,7 +54,7 @@ type Options242451 struct {
 }
 
 func (o *Options242451) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
@@ -33,8 +33,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242451{}
-	_ rule.Severity = &Rule242451{}
+	_ rule.Rule              = &Rule242451{}
+	_ rule.Severity          = &Rule242451{}
+	_ option.Option          = &Options242451{}
+	_ option.MergeableOption = &Options242451{}
 )
 
 type Rule242451 struct {
@@ -51,7 +53,38 @@ type Options242451 struct {
 	*disaoption.FileOwnerOptions
 }
 
-var _ option.Option = (*Options242451)(nil)
+func (o *Options242451) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, err := option.AssertSameType[*Options242451](other)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedKubeProxy, err := o.KubeProxy.Merge(&otherOpts.KubeProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := &Options242451{
+		KubeProxy:         *mergedKubeProxy.(*disaoption.KubeProxyOptions),
+		NodeGroupByLabels: intutils.MergeStringSlices(o.NodeGroupByLabels, otherOpts.NodeGroupByLabels),
+	}
+
+	if o.FileOwnerOptions != nil {
+		mergedFileOwner, err := o.FileOwnerOptions.Merge(otherOpts.FileOwnerOptions)
+		if err != nil {
+			return nil, err
+		}
+		merged.FileOwnerOptions = mergedFileOwner.(*disaoption.FileOwnerOptions)
+	} else {
+		merged.FileOwnerOptions = otherOpts.FileOwnerOptions
+	}
+
+	return merged, nil
+}
 
 func (o Options242451) Validate(fldPath *field.Path) field.ErrorList {
 	allErrs := o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
@@ -380,6 +380,32 @@ tlsCertFile: /var/lib/certs/tls.crt`
 			Expect(mergedOpts.FileOwnerOptions.ExpectedFileOwner.Groups).To(ConsistOf("0", "1000"))
 		})
 
+		It("should use other's FileOwnerOptions when base has nil FileOwnerOptions", func() {
+			base := &rules.Options242451{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: false},
+				NodeGroupByLabels: []string{"label1"},
+			}
+			other := &rules.Options242451{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
+				NodeGroupByLabels: []string{"label2"},
+				FileOwnerOptions: &disaoption.FileOwnerOptions{
+					ExpectedFileOwner: disaoption.ExpectedOwner{
+						Users:  []string{"1000"},
+						Groups: []string{"2000"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242451)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+			Expect(mergedOpts.NodeGroupByLabels).To(ConsistOf("label1", "label2"))
+			Expect(mergedOpts.FileOwnerOptions).To(Equal(other.FileOwnerOptions))
+		})
+
 		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242451{
 			KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
 			NodeGroupByLabels: []string{"label1"},

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
@@ -344,4 +345,45 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("name", "diki-242451-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
 			}),
 	)
+
+	Describe("#Merge Options242451", func() {
+		It("should override KubeProxy, concat NodeGroupByLabels, and merge FileOwnerOptions", func() {
+			base := &rules.Options242451{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: false},
+				NodeGroupByLabels: []string{"label1"},
+				FileOwnerOptions: &disaoption.FileOwnerOptions{
+					ExpectedFileOwner: disaoption.ExpectedOwner{
+						Users:  []string{"0"},
+						Groups: []string{"0"},
+					},
+				},
+			}
+			other := &rules.Options242451{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
+				NodeGroupByLabels: []string{"label2"},
+				FileOwnerOptions: &disaoption.FileOwnerOptions{
+					ExpectedFileOwner: disaoption.ExpectedOwner{
+						Users:  []string{"1000"},
+						Groups: []string{"1000"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242451)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+			Expect(mergedOpts.NodeGroupByLabels).To(ConsistOf("label1", "label2"))
+			Expect(mergedOpts.FileOwnerOptions.ExpectedFileOwner.Users).To(ConsistOf("0", "1000"))
+			Expect(mergedOpts.FileOwnerOptions.ExpectedFileOwner.Groups).To(ConsistOf("0", "1000"))
+		})
+
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242451{
+			KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
+			NodeGroupByLabels: []string{"label1"},
+		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242451{}, &rules.Options242400{})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
@@ -53,7 +53,7 @@ type Options242466 struct {
 }
 
 func (o *Options242466) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
@@ -33,8 +33,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242466{}
-	_ rule.Severity = &Rule242466{}
+	_ rule.Rule              = &Rule242466{}
+	_ rule.Severity          = &Rule242466{}
+	_ option.Option          = &Options242466{}
+	_ option.MergeableOption = &Options242466{}
 )
 
 type Rule242466 struct {
@@ -50,7 +52,28 @@ type Options242466 struct {
 	NodeGroupByLabels []string                    `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
-var _ option.Option = (*Options242466)(nil)
+func (o *Options242466) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, err := option.AssertSameType[*Options242466](other)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedKubeProxy, err := o.KubeProxy.Merge(&otherOpts.KubeProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := &Options242466{
+		KubeProxy:         *mergedKubeProxy.(*disaoption.KubeProxyOptions),
+		NodeGroupByLabels: intutils.MergeStringSlices(o.NodeGroupByLabels, otherOpts.NodeGroupByLabels),
+	}
+
+	return merged, nil
+}
 
 func (o Options242466) Validate(fldPath *field.Path) field.ErrorList {
 	allErrs := o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
@@ -305,4 +306,31 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("name", "diki-242466-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
 			}),
 	)
+
+	Describe("#Merge Options242466", func() {
+		It("should override KubeProxy and concat NodeGroupByLabels", func() {
+			base := &rules.Options242466{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: false},
+				NodeGroupByLabels: []string{"label1"},
+			}
+			other := &rules.Options242466{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
+				NodeGroupByLabels: []string{"label2"},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242466)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+			Expect(mergedOpts.NodeGroupByLabels).To(ConsistOf("label1", "label2"))
+		})
+
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242466{
+			KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
+			NodeGroupByLabels: []string{"label1"},
+		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242466{}, &rules.Options242400{})
+	})
 })

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
@@ -53,7 +53,7 @@ type Options242467 struct {
 }
 
 func (o *Options242467) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
@@ -33,8 +33,10 @@ import (
 )
 
 var (
-	_ rule.Rule     = &Rule242467{}
-	_ rule.Severity = &Rule242467{}
+	_ rule.Rule              = &Rule242467{}
+	_ rule.Severity          = &Rule242467{}
+	_ option.Option          = &Options242467{}
+	_ option.MergeableOption = &Options242467{}
 )
 
 type Rule242467 struct {
@@ -50,7 +52,28 @@ type Options242467 struct {
 	NodeGroupByLabels []string                    `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
 }
 
-var _ option.Option = (*Options242467)(nil)
+func (o *Options242467) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, err := option.AssertSameType[*Options242467](other)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedKubeProxy, err := o.KubeProxy.Merge(&otherOpts.KubeProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := &Options242467{
+		KubeProxy:         *mergedKubeProxy.(*disaoption.KubeProxyOptions),
+		NodeGroupByLabels: intutils.MergeStringSlices(o.NodeGroupByLabels, otherOpts.NodeGroupByLabels),
+	}
+
+	return merged, nil
+}
 
 func (o Options242467) Validate(fldPath *field.Path) field.ErrorList {
 	allErrs := o.KubeProxy.Validate(fldPath.Child("kubeProxy"))

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig/rules"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/shared/kubernetes/option"
+	"github.com/gardener/diki/pkg/shared/kubernetes/option/mergetest"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
@@ -303,4 +304,31 @@ tlsCertFile: /var/lib/certs/tls.crt`
 				rule.ErroredCheckResult("could not retrieve kubelet config: bar", rule.NewTarget("name", "diki-242467-aaaaaaaaaa", "namespace", "kube-system", "kind", "Pod")),
 			}),
 	)
+
+	Describe("#Merge Options242467", func() {
+		It("should override KubeProxy and concat NodeGroupByLabels", func() {
+			base := &rules.Options242467{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: false},
+				NodeGroupByLabels: []string{"label1"},
+			}
+			other := &rules.Options242467{
+				KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
+				NodeGroupByLabels: []string{"label2", "label3"},
+			}
+
+			merged, err := base.Merge(other)
+			Expect(err).ToNot(HaveOccurred())
+
+			mergedOpts, ok := merged.(*rules.Options242467)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.KubeProxy.Disabled).To(BeTrue())
+			Expect(mergedOpts.NodeGroupByLabels).To(ConsistOf("label1", "label2", "label3"))
+		})
+
+		mergetest.AssertNilOtherReturnsReceiver(&rules.Options242467{
+			KubeProxy:         disaoption.KubeProxyOptions{Disabled: true},
+			NodeGroupByLabels: []string{"label1"},
+		})
+		mergetest.AssertWrongTypeErrors(&rules.Options242467{}, &rules.Options242400{})
+	})
 })

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -7,6 +7,7 @@ package option
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,11 @@ func AssertSameType[T MergeableOption](other MergeableOption) (T, error) {
 		return zero, fmt.Errorf("cannot merge options of type %T into %T", other, zero)
 	}
 	return typed, nil
+}
+
+// IsNilValue reports whether a MergeableOption is nil or holds a nil pointer.
+func IsNilValue(v MergeableOption) bool {
+	return v == nil || reflect.ValueOf(v).IsNil()
 }
 
 // ClusterObjectSelector contains generalized options for matching entities by their attribute labels.

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -62,7 +62,7 @@ var (
 
 // Merge implements MergeableOption using current-overrides-base semantics.
 func (s *ClusterObjectSelector) Merge(other MergeableOption) (MergeableOption, error) {
-	if other == nil {
+	if IsNilValue(other) {
 		return s, nil
 	}
 

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -688,4 +688,24 @@ var _ = Describe("options", func() {
 			Expect(err.Error()).To(ContainSubstring("*option.ClusterObjectSelector"))
 		})
 	})
+
+	Describe("#IsNilValue", func() {
+		It("should return true for untyped nil", func() {
+			Expect(option.IsNilValue(nil)).To(BeTrue())
+		})
+
+		It("should return true for typed nil pointer", func() {
+			var sel *option.ClusterObjectSelector
+			Expect(option.IsNilValue(sel)).To(BeTrue())
+		})
+
+		It("should return false for non-nil pointer", func() {
+			sel := &option.ClusterObjectSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				},
+			}
+			Expect(option.IsNilValue(sel)).To(BeFalse())
+		})
+	})
 })

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -276,7 +276,33 @@ type KubeProxyOptions struct {
 	Disabled bool `json:"disabled" yaml:"disabled"`
 }
 
-var _ option.Option = (*KubeProxyOptions)(nil)
+var (
+	_ option.Option          = &KubeProxyOptions{}
+	_ option.MergeableOption = &KubeProxyOptions{}
+)
+
+// Merge implements MergeableOption. The Disabled field is always taken
+// from other. ClusterObjectSelector is taken from other only if non-nil.
+func (o *KubeProxyOptions) Merge(other option.MergeableOption) (option.MergeableOption, error) {
+	if other == nil {
+		return o, nil
+	}
+
+	otherOpts, err := option.AssertSameType[*KubeProxyOptions](other)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := &KubeProxyOptions{
+		Disabled: otherOpts.Disabled,
+	}
+	if otherOpts.ClusterObjectSelector != nil {
+		merged.ClusterObjectSelector = otherOpts.ClusterObjectSelector
+	} else {
+		merged.ClusterObjectSelector = o.ClusterObjectSelector
+	}
+	return merged, nil
+}
 
 // Validate validates that option configurations are correctly defined.
 func (o KubeProxyOptions) Validate(fldPath *field.Path) field.ErrorList {

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -282,7 +282,7 @@ var (
 )
 
 // Merge implements MergeableOption. The Disabled field is always taken
-// from other. ClusterObjectSelector is taken from other only if non-nil.
+// from other. ClusterObjectSelector is merged using its own Merge method.
 func (o *KubeProxyOptions) Merge(other option.MergeableOption) (option.MergeableOption, error) {
 	if other == nil {
 		return o, nil
@@ -296,11 +296,17 @@ func (o *KubeProxyOptions) Merge(other option.MergeableOption) (option.Mergeable
 	merged := &KubeProxyOptions{
 		Disabled: otherOpts.Disabled,
 	}
-	if otherOpts.ClusterObjectSelector != nil {
-		merged.ClusterObjectSelector = otherOpts.ClusterObjectSelector
+
+	if o.ClusterObjectSelector != nil {
+		mergedSelector, err := o.ClusterObjectSelector.Merge(otherOpts.ClusterObjectSelector)
+		if err != nil {
+			return nil, err
+		}
+		merged.ClusterObjectSelector = mergedSelector.(*option.ClusterObjectSelector)
 	} else {
-		merged.ClusterObjectSelector = o.ClusterObjectSelector
+		merged.ClusterObjectSelector = otherOpts.ClusterObjectSelector
 	}
+
 	return merged, nil
 }
 

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -33,7 +33,7 @@ type ExpectedOwner struct {
 
 // Merge implements MergeableOption by performing a set union on Users and Groups.
 func (o *FileOwnerOptions) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 
@@ -211,7 +211,7 @@ type ExpectedVersionedImage struct {
 
 // Merge implements MergeableOption by concatenating ExpectedVersionedImages from both options.
 func (o *Options242442) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 
@@ -284,7 +284,7 @@ var (
 // Merge implements MergeableOption. The Disabled field is always taken
 // from other. ClusterObjectSelector is merged using its own Merge method.
 func (o *KubeProxyOptions) Merge(other option.MergeableOption) (option.MergeableOption, error) {
-	if other == nil {
+	if option.IsNilValue(other) {
 		return o, nil
 	}
 

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -248,6 +248,82 @@ var _ = Describe("options", func() {
 		})
 	})
 
+	Describe("#Merge KubeProxyOptions", func() {
+		It("should take ClusterObjectSelector from other when non-nil", func() {
+			base := &option.KubeProxyOptions{
+				Disabled: false,
+				ClusterObjectSelector: &k8soption.ClusterObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"role": "proxy"},
+					},
+				},
+			}
+			other := &option.KubeProxyOptions{
+				Disabled: true,
+				ClusterObjectSelector: &k8soption.ClusterObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"component": "kube-proxy"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(other)
+
+			Expect(err).ToNot(HaveOccurred())
+			mergedOpts, ok := merged.(*option.KubeProxyOptions)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.Disabled).To(BeTrue())
+			Expect(mergedOpts.ClusterObjectSelector).ToNot(BeNil())
+			Expect(mergedOpts.ClusterObjectSelector.LabelSelector.MatchLabels).To(Equal(map[string]string{"component": "kube-proxy"}))
+		})
+
+		It("should keep ClusterObjectSelector from base when other has nil", func() {
+			base := &option.KubeProxyOptions{
+				Disabled: false,
+				ClusterObjectSelector: &k8soption.ClusterObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"role": "proxy"},
+					},
+				},
+			}
+			other := &option.KubeProxyOptions{
+				Disabled: true,
+			}
+
+			merged, err := base.Merge(other)
+
+			Expect(err).ToNot(HaveOccurred())
+			mergedOpts, ok := merged.(*option.KubeProxyOptions)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.Disabled).To(BeTrue())
+			Expect(mergedOpts.ClusterObjectSelector).ToNot(BeNil())
+			Expect(mergedOpts.ClusterObjectSelector.LabelSelector.MatchLabels).To(Equal(map[string]string{"role": "proxy"}))
+		})
+
+		It("should return nil ClusterObjectSelector when both have nil", func() {
+			base := &option.KubeProxyOptions{Disabled: false}
+			other := &option.KubeProxyOptions{Disabled: true}
+
+			merged, err := base.Merge(other)
+
+			Expect(err).ToNot(HaveOccurred())
+			mergedOpts, ok := merged.(*option.KubeProxyOptions)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.Disabled).To(BeTrue())
+			Expect(mergedOpts.ClusterObjectSelector).To(BeNil())
+		})
+
+		mergetest.AssertNilOtherReturnsReceiver(&option.KubeProxyOptions{
+			Disabled: true,
+			ClusterObjectSelector: &k8soption.ClusterObjectSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"role": "proxy"},
+				},
+			},
+		})
+		mergetest.AssertWrongTypeErrors(&option.KubeProxyOptions{}, &option.FileOwnerOptions{})
+	})
+
 	Describe("#Merge FileOwnerOptions", func() {
 		It("should merge by appending Users and Groups", func() {
 			base := &option.FileOwnerOptions{

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -300,6 +300,27 @@ var _ = Describe("options", func() {
 			Expect(mergedOpts.ClusterObjectSelector.LabelSelector.MatchLabels).To(Equal(map[string]string{"role": "proxy"}))
 		})
 
+		It("should use other's ClusterObjectSelector when base has nil", func() {
+			base := &option.KubeProxyOptions{Disabled: false}
+			other := &option.KubeProxyOptions{
+				Disabled: true,
+				ClusterObjectSelector: &k8soption.ClusterObjectSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"component": "kube-proxy"},
+					},
+				},
+			}
+
+			merged, err := base.Merge(other)
+
+			Expect(err).ToNot(HaveOccurred())
+			mergedOpts, ok := merged.(*option.KubeProxyOptions)
+			Expect(ok).To(BeTrue())
+			Expect(mergedOpts.Disabled).To(BeTrue())
+			Expect(mergedOpts.ClusterObjectSelector).ToNot(BeNil())
+			Expect(mergedOpts.ClusterObjectSelector.LabelSelector.MatchLabels).To(Equal(map[string]string{"component": "kube-proxy"}))
+		})
+
 		It("should return nil ClusterObjectSelector when both have nil", func() {
 			base := &option.KubeProxyOptions{Disabled: false}
 			other := &option.KubeProxyOptions{Disabled: true}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR implements the `MergeableOption` for all rule options in the `managedk8s` provider in DISA K8s STIG.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/diki/issues/687

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[DISA K8s STIG] All rules in the `managedk8s` provider can now be merged using the `config merge` command.
```
