### PR TITLE
Introduce the Gardenlinux Testing Framework ruleset

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -318,6 +318,15 @@ providers:                   # contains information about known providers
     #       justification: "justification"
     #       volumeNames:
     #       - "*" # a wildcard can be used to match against all volumes in an accepted pod
+  - id: gardenlinux
+    name: Gardenlinux Testing Framework
+    # TODO(georgibaltiev): replace with a real version once implementation for the gardenlinux support is added.
+    version: v0.1.0
+    # args:
+    #   # node labels used to group nodes by specified label value combinations. 
+    #   # Only one node per combination will be tested
+    #   nodeGroupByLabels: 
+    #   - foo
 # metadata: # optional, additional metadata to be added to summary json report
 #   foo: bar
 #   bar:

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gardener/diki/pkg/provider"
 	"github.com/gardener/diki/pkg/provider/managedk8s"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig"
+	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/gardenlinux"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s"
 	"github.com/gardener/diki/pkg/ruleset"
 )
@@ -51,6 +52,14 @@ func ManagedK8SProviderFromConfig(conf config.ProviderConfig, fldPath *field.Pat
 			setLoggerHardened := securityhardenedk8s.WithLogger(providerLogger.With("ruleset", ruleset.ID(), "version", ruleset.Version()))
 			setLoggerHardened(ruleset)
 			rulesets = append(rulesets, ruleset)
+		case gardenlinux.RulesetID:
+			ruleset, err := gardenlinux.FromGenericConfig(rulesetConfig, p.Config, rulesetsPath.Index(rulesetIdx))
+			if err != nil {
+				return nil, err
+			}
+			setLoggerGardenlinux := gardenlinux.WithLogger(providerLogger.With("ruleset", ruleset.ID(), "version", ruleset.Version()))
+			setLoggerGardenlinux(ruleset)
+			rulesets = append(rulesets, ruleset)
 		default:
 			return nil, fmt.Errorf("unknown ruleset identifier: %s - use 'diki show provider managedk8s' to see the provider's supported rulesets", rulesetConfig.ID)
 		}
@@ -70,6 +79,8 @@ func managedK8SGetSupportedVersions(ruleset string) []string {
 		return securityhardenedk8s.SupportedVersions
 	case disak8sstig.RulesetID:
 		return disak8sstig.SupportedVersions
+	case gardenlinux.RulesetID:
+		return gardenlinux.SupportedVersions
 	default:
 		return nil
 	}

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -102,6 +102,10 @@ func ManagedK8SProviderMetadata() metadata.ProviderDetailed {
 				ID:   disak8sstig.RulesetID,
 				Name: disak8sstig.RulesetName,
 			},
+			{
+				ID:   gardenlinux.RulesetID,
+				Name: gardenlinux.RulesetName,
+			},
 		},
 	}
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardenlinux
+
+import (
+	"log/slog"
+
+	"k8s.io/client-go/rest"
+)
+
+// CreateOption is a function that acts on a [Ruleset]
+// and is used to construct such objects.
+type CreateOption func(*Ruleset)
+
+// WithVersion sets the version of a [Ruleset].
+func WithVersion(version string) CreateOption {
+	return func(r *Ruleset) {
+		r.version = version
+	}
+}
+
+// WithConfig sets the Config of a [Ruleset].
+func WithConfig(config *rest.Config) CreateOption {
+	return func(r *Ruleset) {
+		r.Config = config
+	}
+}
+
+// WithArgs sets the args of a [Ruleset].
+func WithArgs(args Args) CreateOption {
+	return func(r *Ruleset) {
+		r.args = args
+	}
+}
+
+// WithNumberOfWorkers sets the max number of workers (concurrent test pods) of a [Ruleset].
+// A worker corresponds to one gardenlinux test pod running on one selected node; the ruleset
+// will never schedule more than this many pods at once.
+func WithNumberOfWorkers(numWorkers int) CreateOption {
+	return func(r *Ruleset) {
+		if numWorkers <= 0 {
+			panic("number of workers should be a positive number")
+		}
+		r.numWorkers = numWorkers
+	}
+}
+
+// WithLogger sets the logger of a [Ruleset].
+func WithLogger(logger *slog.Logger) CreateOption {
+	return func(r *Ruleset) {
+		r.logger = logger
+	}
+}

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
@@ -35,18 +35,6 @@ func WithArgs(args Args) CreateOption {
 	}
 }
 
-// WithNumberOfWorkers sets the max number of workers (concurrent test pods) of a [Ruleset].
-// A worker corresponds to one gardenlinux test pod running on one selected node; the ruleset
-// will never schedule more than this many pods at once.
-func WithNumberOfWorkers(numWorkers int) CreateOption {
-	return func(r *Ruleset) {
-		if numWorkers <= 0 {
-			panic("number of workers should be a positive number")
-		}
-		r.numWorkers = numWorkers
-	}
-}
-
 // WithLogger sets the logger of a [Ruleset].
 func WithLogger(logger *slog.Logger) CreateOption {
 	return func(r *Ruleset) {

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardenlinux
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/rest"
+
+	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/rule"
+	"github.com/gardener/diki/pkg/ruleset"
+	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+)
+
+const (
+	// RulesetID is a constant containing the id of the Gardenlinux Ruleset.
+	RulesetID = "gardenlinux"
+	// RulesetName is a constant containing the user-friendly name of the Gardenlinux ruleset.
+	RulesetName = "Gardenlinux Testing Framework"
+)
+
+var (
+	_ ruleset.Ruleset = &Ruleset{}
+	// SupportedVersions is a list of available versions for the Gardenlinux Ruleset.
+	// Versions are sorted from newest to oldest.
+	// TODO(georgibaltiev): introduce support for actual gardenlinux versions and remove dummy values
+	SupportedVersions = []string{"v0.1.0"}
+)
+
+// Ruleset implements the Gardenlinux Testing Framework ruleset.
+type Ruleset struct {
+	version    string
+	Config     *rest.Config
+	numWorkers int
+	args       Args
+	instanceID string
+	logger     *slog.Logger
+}
+
+// Args are Ruleset specific arguments.
+type Args struct {
+	NodeGroupByLabels []string `json:"nodeGroupByLabels" yaml:"nodeGroupByLabels"`
+}
+
+// New creates a new Ruleset.
+func New(options ...CreateOption) (*Ruleset, error) {
+	r := &Ruleset{
+		numWorkers: 5,
+		instanceID: uuid.New().String(),
+	}
+
+	for _, o := range options {
+		o(r)
+	}
+
+	return r, nil
+}
+
+// ID returns the id of the Ruleset.
+func (r *Ruleset) ID() string {
+	return RulesetID
+}
+
+// Name returns the name of the Ruleset.
+func (r *Ruleset) Name() string {
+	return RulesetName
+}
+
+// Version returns the version of the Ruleset.
+func (r *Ruleset) Version() string {
+	return r.version
+}
+
+// FromGenericConfig creates a Ruleset from a RulesetConfig
+func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.Config, fldPath *field.Path) (*Ruleset, error) {
+	if errs := ValidateRulesetConfig(rulesetConfig, fldPath); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+
+	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
+	if err != nil {
+		return nil, err
+	}
+
+	var rulesetArgs Args
+	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
+		return nil, err
+	}
+
+	ruleset, err := New(
+		WithVersion(rulesetConfig.Version),
+		WithConfig(managedConfig),
+		WithArgs(rulesetArgs),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ruleset, nil
+}
+
+// ValidateRulesetConfig validates a [config.RulesetConfig].
+func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if !slices.Contains(SupportedVersions, rulesetConfig.Version) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, SupportedVersions))
+	}
+
+	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
+	}
+
+	var rulesetArgs Args
+	if err := json.Unmarshal(rulesetArgsByte, &rulesetArgs); err != nil {
+		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
+	}
+
+	allErrs = append(allErrs, disaoption.ValidateLabelNames(rulesetArgs.NodeGroupByLabels, fldPath.Child("args", "nodeGroupByLabels"))...)
+
+	if len(rulesetConfig.RuleOptions) > 0 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("ruleOptions"), "the gardenlinux ruleset does not accept per-rule options"))
+	}
+
+	return allErrs
+}
+
+// Run executes the gardenlinux test Pods and collects the test results.
+// TODO(georgibaltiev): add implementation for the integration of the Gardenlinux ruleset here.
+func (r *Ruleset) Run(_ context.Context) (ruleset.RulesetResult, error) {
+	r.Logger().Warn("the gardenlinux ruleset is not yet supported")
+	return ruleset.RulesetResult{}, nil
+}
+
+// RunRule executes specific Rule of a known Ruleset.
+// The function is not supported for this ruleset, since the implementation of the framework is external
+func (r *Ruleset) RunRule(_ context.Context, _ string) (rule.RuleResult, error) {
+	return rule.RuleResult{}, fmt.Errorf("the gardenlinux ruleset does not support running rules individually")
+}
+
+// Logger returns the Ruleset's logger.
+// If not set, set it to slog.Default().With("ruleset", r.ID(), "version", r.Version() then return it.
+func (r *Ruleset) Logger() *slog.Logger {
+	if r.logger == nil {
+		r.logger = slog.Default().With("ruleset", r.ID(), "version", r.Version())
+	}
+	return r.logger
+}

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -40,7 +40,6 @@ var (
 type Ruleset struct {
 	version    string
 	Config     *rest.Config
-	numWorkers int
 	args       Args
 	instanceID string
 	logger     *slog.Logger
@@ -54,7 +53,6 @@ type Args struct {
 // New creates a new Ruleset.
 func New(options ...CreateOption) (*Ruleset, error) {
 	r := &Ruleset{
-		numWorkers: 5,
 		instanceID: uuid.New().String(),
 	}
 

--- a/pkg/provider/managedk8s/validate.go
+++ b/pkg/provider/managedk8s/validate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gardener/diki/pkg/config"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/disak8sstig"
+	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/gardenlinux"
 	"github.com/gardener/diki/pkg/provider/managedk8s/ruleset/securityhardenedk8s"
 )
 
@@ -45,8 +46,10 @@ func ValidateProviderConfig(conf config.ProviderConfig, fldPath *field.Path) fie
 			allErrs = append(allErrs, disak8sstig.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
 		case securityhardenedk8s.RulesetID:
 			allErrs = append(allErrs, securityhardenedk8s.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
+		case gardenlinux.RulesetID:
+			allErrs = append(allErrs, gardenlinux.ValidateRulesetConfig(rulesetConfig, rulesetPath)...)
 		default:
-			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID, securityhardenedk8s.RulesetID}))
+			allErrs = append(allErrs, field.NotSupported(rulesetPath.Child("id"), rulesetConfig.ID, []string{disak8sstig.RulesetID, securityhardenedk8s.RulesetID, gardenlinux.RulesetID}))
 		}
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR introduces support for the `gardenlinux` ruleset, implemented explictly for the `managedk8s` provider. The PR also introduces a validation for the ruleset configuration, as well as configurable arguments, such as a label selector for Nodes, which will be used in a follow-up PR to select nodes for evaluation by the ruleset.

**Which issue(s) this PR fixes**:
Part of #752 

**Special notes for your reviewer**:
An actual version of the gardenlinux testing image will be introduced with a follow-up PR, which will replace the current dummy version.
Documentation will be added in a separate PR

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A new ruleset, called `gardenlinux`, based on the Gardenlinux Testing Framework has been registered for the `managedk8s` provider
```
