### PR TITLE
Update the `PodExecutor`'s REST request builder

### DIFF
--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -20,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -143,13 +144,16 @@ func (spe *SimplePodExecutor) Execute(ctx context.Context, command string, comma
 		Resource("pods").
 		Name(spe.name).
 		Namespace(spe.namespace).
-		SubResource("exec").
-		Param("container", "container").
-		Param("command", command).
-		Param("stdin", "true").
-		Param("stdout", "true").
-		Param("stderr", "true").
-		Param("tty", "false")
+		SubResource("exec")
+
+	request.VersionedParams(&corev1.PodExecOptions{
+		Stdin:     true,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+		Container: "container",
+		Command:   strings.Fields(command),
+	}, scheme.ParameterCodec)
 
 	// Use a fallback executor with websocket as primary and spdy as fallback similar to kubectl.
 	// https://github.com/kubernetes/kubectl/blob/2e38fc220409bbc92f8270c49612f0f9d8e36c89/pkg/cmd/exec/exec.go#L143-L155


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
This PR refactors the `SimplePodExecutor.`'s Execute() interface implementation, by changing the REST client's parameter initialization. Additionally, the `command` field in the method gets split up via `strings.Fields()`, which in return enables the passing of multi-string commands in the Execute() call. This refactoring is backwards-compatible with the existing `SimplePodExecutor.Execute()` function calls and does not require a revision.

This is done partly in order to support calling the `/bin/busybox` applet in the `diki-ops image` with it's available toolkit subcommands via the Execute().

**Which issue(s) this PR fixes**:
Part of #752

**Special notes for your reviewer**:
The Execute command can also accept an empty `commandArg` string as a result of this.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The PodExecutor's REST client now uses `PodExecOptions` instead of plain fields. Therefore, a multi-string command could be passed in the `Execute()` method.
```
