### PR TITLE
Add a Pod deployment mechanism for the Gardenlinux Ruleset

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -320,8 +320,7 @@ providers:                   # contains information about known providers
     #       - "*" # a wildcard can be used to match against all volumes in an accepted pod
   - id: gardenlinux
     name: Gardenlinux Testing Framework
-    # TODO(georgibaltiev): replace with a real version once implementation for the gardenlinux support is added.
-    version: v0.1.0
+    version: 2298.0.0
     # args:
     #   # node labels used to group nodes by specified label value combinations. 
     #   # Only one node per combination will be tested

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,3 +7,6 @@ images:
 - name: diki-ops
   sourceRepository: github.com/gardener/diki
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/diki-ops
+- name: gardenlinux-test
+  sourceRepository: github.com/gardenlinux/gardenlinux
+  repository: ghcr.io/gardenlinux/test

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -58,7 +58,7 @@ type SimplePodContext struct {
 	AdditionalPodLabels map[string]string
 	// WaitInterval is the time between wait API calls.
 	WaitInterval time.Duration
-	// WaitTimeout is the time waited for a pod to reach Running state or be deleted.
+	// WaitTimeout is the time waited for a pod to reach Running state.
 	WaitTimeout time.Duration
 }
 
@@ -252,6 +252,36 @@ func (spc *SimplePodContext) waitPodHealthy(ctx context.Context, name, namespace
 		}
 
 		return retry.Ok()
+	})
+}
+
+// WaitContainerTerminated waits for the container with the given name in the specified pod to reach a terminated state.
+func (spc *SimplePodContext) WaitContainerTerminated(ctx context.Context, name, namespace, containerName string) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, spc.WaitTimeout)
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return retry.Until(timeoutCtx, spc.WaitInterval, func(ctx context.Context) (done bool, err error) {
+		if err := spc.client.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+			return retry.SevereError(err)
+		}
+
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name == containerName {
+				if status.State.Terminated != nil {
+					return retry.Ok()
+				}
+				return retry.MinorError(fmt.Errorf("container %q of pod %s has not terminated yet", containerName, client.ObjectKeyFromObject(pod).String()))
+			}
+		}
+
+		return retry.MinorError(fmt.Errorf("container %q of pod %s not found", containerName, client.ObjectKeyFromObject(pod).String()))
 	})
 }
 

--- a/pkg/kubernetes/pod/privileged.go
+++ b/pkg/kubernetes/pod/privileged.go
@@ -22,13 +22,14 @@ const (
 	// LabelComplianceRolePrivPod is used as the label value for LabelComplianceRoleKey indicating privileged diki pods.
 	LabelComplianceRolePrivPod = "diki-privileged-pod"
 
-	maxNameLength = 63
+	// MaxPodNameLength is the maximum length of a Kubernetes pod name.
+	MaxPodNameLength = 63
 )
 
 // NewPrivilegedPod creates a new privileged Pod.
 func NewPrivilegedPod(name, namespace, image, nodeName string, additionalLabels map[string]string) func() *corev1.Pod {
-	if len(name) > maxNameLength {
-		name = name[:maxNameLength]
+	if len(name) > MaxPodNameLength {
+		name = name[:MaxPodNameLength]
 	}
 
 	labels := map[string]string{}

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
@@ -37,7 +37,7 @@ const (
 	// ReportMountPath is the in-pod path of the shared report volume.
 	ReportMountPath = "/tests/tests/output"
 	// ReportFilename is the name of the generated JUnit XML report inside the pod.
-	ReportFilename = "test.xml"
+	ReportFilename = "report.xml"
 	// ReportSizeLimitKi is the size limit of the report volume in kibibytes.
 	ReportSizeLimitKi = 500
 
@@ -74,6 +74,7 @@ func NewTestPod(name, namespace, gardenlinuxTestImage, reportReaderImage, nodeNa
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
+			ActiveDeadlineSeconds:        ptr.To[int64](300),
 			AutomountServiceAccountToken: ptr.To(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				// The FSGroup ensures that the written XML report is group-owned by 65532 - the reader will be able to get the report even if the "other" permission bits are dropped by the testing framework in a future release.
@@ -97,7 +98,7 @@ func NewTestPod(name, namespace, gardenlinuxTestImage, reportReaderImage, nodeNa
 						"-m",
 						"security_id",
 						"--junit-xml",
-						"output/test.xml",
+						"output/report.xml",
 						"--system-booted",
 						"--expected-users",
 						"gardener",
@@ -117,7 +118,7 @@ func NewTestPod(name, namespace, gardenlinuxTestImage, reportReaderImage, nodeNa
 					},
 					Args: []string{
 						"sleep",
-						"900",
+						"60",
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged:               ptr.To(false),

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pod
+
+import (
+	"maps"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubernetespod "github.com/gardener/diki/pkg/kubernetes/pod"
+)
+
+const (
+	// SystemNamespace is the namespace in which the test pods are created.
+	SystemNamespace = "kube-system"
+
+	// PodContextWaitInterval is the interval between pod status polls.
+	PodContextWaitInterval = 2 * time.Second
+	// PodContextWaitTimeout is the maximum time to wait for the test pod to reach Running.
+	// Both containers start immediately, so we only need enough time for image pull + scheduling.
+	PodContextWaitTimeout = 10 * time.Minute
+
+	// TestContainerName is the name of the container running the gardenlinux/tests suite.
+	TestContainerName = "gardenlinux-test"
+	// ReaderContainerName is the name of the container from which diki execs to read the completed report.
+	// TODO (georgibaltiev): change the name of this container once https://github.com/gardener/diki/issues/771 has been addressed.
+	// The container name coincides with the targeted container in the SimplePodExecutor.
+	ReaderContainerName = "container"
+
+	// ReportVolumeName is the name of the shared volume holding the JUnit report.
+	ReportVolumeName = "test-report"
+	// ReportMountPath is the in-pod path of the shared report volume.
+	ReportMountPath = "/tests/tests/output"
+	// ReportFilename is the name of the generated JUnit XML report inside the pod.
+	ReportFilename = "test.xml"
+	// ReportSizeLimitKi is the size limit of the report volume in kibibytes.
+	ReportSizeLimitKi = 500
+
+	// HostRootVolumeName is the name of the volume mounting the host root filesystem.
+	HostRootVolumeName = "host-root-volume"
+	// HostRootMountPath is the in-pod path at which the host root filesystem is mounted.
+	HostRootMountPath = "/host"
+	// HostRootPath is the host path mounted into the reader container.
+	HostRootPath = "/"
+
+	// LabelComplianceRoleGardenlinuxTestPod is used as the label value for LabelComplianceRoleKey indicating gardenlinux test pods.
+	LabelComplianceRoleGardenlinuxTestPod = "gardenlinux-test-pod"
+)
+
+// NewPodContext creates a new pod.PodContext tuned for the long-running gardenlinux/tests container.
+func NewPodContext(c client.Client, config *rest.Config, additionalPodLabels map[string]string) (*kubernetespod.SimplePodContext, error) {
+	podContext, err := kubernetespod.NewSimplePodContext(c, config, additionalPodLabels)
+	if err != nil {
+		return nil, err
+	}
+	podContext.WaitInterval = PodContextWaitInterval
+	podContext.WaitTimeout = PodContextWaitTimeout
+	return podContext, nil
+}
+
+// NewTestPod creates a new gardenlinux-test Pod.
+func NewTestPod(name, gardenlinuxTestImage, reportReaderImage, nodeName string, additionalLabels map[string]string) func() *corev1.Pod {
+	if len(name) > kubernetespod.MaxPodNameLength {
+		name = name[:kubernetespod.MaxPodNameLength]
+	}
+
+	labels := map[string]string{}
+	if additionalLabels != nil {
+		labels = maps.Clone(additionalLabels)
+	}
+
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: SystemNamespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: ptr.To(false),
+			SecurityContext: &corev1.PodSecurityContext{
+				// The FSGroup ensures that the written XML report is group-owned by 65532 - the reader will be able to get the report even if the "other" permission bits are dropped by the testing framework in a future release.
+				FSGroup: ptr.To(int64(65532)),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  TestContainerName,
+					Image: gardenlinuxTestImage,
+					// The gardenlinux testing container requires certain privileged access, as described in the official documentation - https://github.com/gardenlinux/gardenlinux/tree/main/tests#gardener--kubernetes-cluster-live-tests
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: ptr.To(true),
+					},
+					Args: []string{
+						"./run_tests",
+						"integration/security/compliance",
+						"-v",
+						"-m",
+						"security_id",
+						"--junit-xml",
+						"output/test.xml",
+						"--system-booted",
+						"--expected-users",
+						"gardener",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      ReportVolumeName,
+							MountPath: ReportMountPath,
+						},
+					},
+				},
+				{
+					Name:  ReaderContainerName,
+					Image: reportReaderImage,
+					Command: []string{
+						"/bin/busybox",
+					},
+					Args: []string{
+						"sleep",
+						"900",
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:               ptr.To(false),
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
+						RunAsUser:                ptr.To(int64(65532)),
+						RunAsGroup:               ptr.To(int64(65532)),
+						ReadOnlyRootFilesystem:   ptr.To(true),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      ReportVolumeName,
+							MountPath: ReportMountPath,
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			HostNetwork:   true,
+			HostPID:       true,
+			RestartPolicy: corev1.RestartPolicyNever,
+			Tolerations: []corev1.Toleration{
+				{
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Effect:   corev1.TaintEffectNoExecute,
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: ReportVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: resource.NewScaledQuantity(ReportSizeLimitKi, resource.Kilo),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if nodeName != "" {
+		testPod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+	}
+
+	// Labels that will always be applied to the pod and cannot be overwritten
+	testPod.Labels[kubernetespod.LabelComplianceRoleKey] = LabelComplianceRoleGardenlinuxTestPod
+
+	return func() *corev1.Pod {
+		return testPod
+	}
+}

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
@@ -19,14 +19,11 @@ import (
 )
 
 const (
-	// SystemNamespace is the namespace in which the test pods are created.
-	SystemNamespace = "kube-system"
-
 	// PodContextWaitInterval is the interval between pod status polls.
 	PodContextWaitInterval = 2 * time.Second
 	// PodContextWaitTimeout is the maximum time to wait for the test pod to reach Running.
 	// Both containers start immediately, so we only need enough time for image pull + scheduling.
-	PodContextWaitTimeout = 10 * time.Minute
+	PodContextWaitTimeout = 1 * time.Minute
 
 	// TestContainerName is the name of the container running the gardenlinux/tests suite.
 	TestContainerName = "gardenlinux-test"
@@ -44,13 +41,6 @@ const (
 	// ReportSizeLimitKi is the size limit of the report volume in kibibytes.
 	ReportSizeLimitKi = 500
 
-	// HostRootVolumeName is the name of the volume mounting the host root filesystem.
-	HostRootVolumeName = "host-root-volume"
-	// HostRootMountPath is the in-pod path at which the host root filesystem is mounted.
-	HostRootMountPath = "/host"
-	// HostRootPath is the host path mounted into the reader container.
-	HostRootPath = "/"
-
 	// LabelComplianceRoleGardenlinuxTestPod is used as the label value for LabelComplianceRoleKey indicating gardenlinux test pods.
 	LabelComplianceRoleGardenlinuxTestPod = "gardenlinux-test-pod"
 )
@@ -67,7 +57,7 @@ func NewPodContext(c client.Client, config *rest.Config, additionalPodLabels map
 }
 
 // NewTestPod creates a new gardenlinux-test Pod.
-func NewTestPod(name, gardenlinuxTestImage, reportReaderImage, nodeName string, additionalLabels map[string]string) func() *corev1.Pod {
+func NewTestPod(name, namespace, gardenlinuxTestImage, reportReaderImage, nodeName string, additionalLabels map[string]string) func() *corev1.Pod {
 	if len(name) > kubernetespod.MaxPodNameLength {
 		name = name[:kubernetespod.MaxPodNameLength]
 	}
@@ -80,7 +70,7 @@ func NewTestPod(name, gardenlinuxTestImage, reportReaderImage, nodeName string, 
 	testPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: SystemNamespace,
+			Namespace: namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
@@ -149,7 +139,6 @@ func NewTestPod(name, gardenlinuxTestImage, reportReaderImage, nodeName string, 
 					},
 				},
 			},
-			HostNetwork:   true,
 			HostPID:       true,
 			RestartPolicy: corev1.RestartPolicyNever,
 			Tolerations: []corev1.Toleration{

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pod_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPod(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenlinux Pod Test Suite")
+}

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
@@ -59,6 +59,7 @@ var _ = Describe("pod", func() {
 					},
 				},
 				Spec: corev1.PodSpec{
+					ActiveDeadlineSeconds:        ptr.To[int64](300),
 					AutomountServiceAccountToken: ptr.To(false),
 					NodeSelector:                 map[string]string{"kubernetes.io/hostname": nodeName},
 					SecurityContext: &corev1.PodSecurityContext{
@@ -81,7 +82,7 @@ var _ = Describe("pod", func() {
 								"-m",
 								"security_id",
 								"--junit-xml",
-								"output/test.xml",
+								"output/report.xml",
 								"--system-booted",
 								"--expected-users",
 								"gardener",
@@ -101,7 +102,7 @@ var _ = Describe("pod", func() {
 							},
 							Args: []string{
 								"sleep",
-								"900",
+								"60",
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               ptr.To(false),

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,35 +49,138 @@ var _ = Describe("pod", func() {
 			nodeName     = "worker-1"
 		)
 
-		It("should construct a pod with the given name, namespace and node selector", func() {
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
+		expectedPod := func() *corev1.Pod {
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-pod",
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						kubernetespod.LabelComplianceRoleKey: "gardenlinux-test-pod",
+					},
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: ptr.To(false),
+					NodeSelector:                 map[string]string{"kubernetes.io/hostname": nodeName},
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: ptr.To(int64(65532)),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  gardenlinuxpod.TestContainerName,
+							Image: testImage,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							Args: []string{
+								"./run_tests",
+								"integration/security/compliance",
+								"-v",
+								"-m",
+								"security_id",
+								"--junit-xml",
+								"output/test.xml",
+								"--system-booted",
+								"--expected-users",
+								"gardener",
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "test-report",
+									MountPath: "/tests/tests/output",
+								},
+							},
+						},
+						{
+							Name:  gardenlinuxpod.ReaderContainerName,
+							Image: sidecarImage,
+							Command: []string{
+								"/bin/busybox",
+							},
+							Args: []string{
+								"sleep",
+								"900",
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged:               ptr.To(false),
+								AllowPrivilegeEscalation: ptr.To(false),
+								RunAsNonRoot:             ptr.To(true),
+								RunAsUser:                ptr.To(int64(65532)),
+								RunAsGroup:               ptr.To(int64(65532)),
+								ReadOnlyRootFilesystem:   ptr.To(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "test-report",
+									MountPath: "/tests/tests/output",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					HostPID:       true,
+					RestartPolicy: corev1.RestartPolicyNever,
+					Tolerations: []corev1.Toleration{
+						{
+							Effect:   corev1.TaintEffectNoSchedule,
+							Operator: corev1.TolerationOpExists,
+						},
+						{
+							Effect:   corev1.TaintEffectNoExecute,
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: gardenlinuxpod.ReportVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewScaledQuantity(gardenlinuxpod.ReportSizeLimitKi, resource.Kilo),
+								},
+							},
+						},
+					},
+				},
+			}
+		}
 
-			Expect(p.Name).To(Equal("my-pod"))
-			Expect(p.Namespace).To(Equal(gardenlinuxpod.SystemNamespace))
-			Expect(p.Spec.NodeSelector).To(Equal(map[string]string{"kubernetes.io/hostname": nodeName}))
+		It("should construct the canonical pod spec", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", "kube-system", testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p).To(Equal(expectedPod()))
 		})
 
 		It("should truncate names longer than MaxPodNameLength", func() {
 			longName := strings.Repeat("a", kubernetespod.MaxPodNameLength+10)
 
-			p := gardenlinuxpod.NewTestPod(longName, testImage, sidecarImage, nodeName, nil)()
+			p := gardenlinuxpod.NewTestPod(longName, "kube-system", testImage, sidecarImage, nodeName, nil)()
 
-			Expect(p.Name).To(HaveLen(kubernetespod.MaxPodNameLength))
-			Expect(p.Name).To(Equal(strings.Repeat("a", kubernetespod.MaxPodNameLength)))
+			expected := expectedPod()
+			expected.Name = strings.Repeat("a", kubernetespod.MaxPodNameLength)
+			Expect(p).To(Equal(expected))
 		})
 
-		It("should not preserve names at or below MaxPodNameLength", func() {
+		It("should not truncate names at or below MaxPodNameLength", func() {
 			name := strings.Repeat("b", kubernetespod.MaxPodNameLength)
 
-			p := gardenlinuxpod.NewTestPod(name, testImage, sidecarImage, nodeName, nil)()
+			p := gardenlinuxpod.NewTestPod(name, "kube-system", testImage, sidecarImage, nodeName, nil)()
 
-			Expect(p.Name).To(Equal(name))
+			expected := expectedPod()
+			expected.Name = name
+			Expect(p).To(Equal(expected))
 		})
 
 		It("should omit the node selector when nodeName is empty", func() {
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, "", nil)()
+			p := gardenlinuxpod.NewTestPod("my-pod", "kube-system", testImage, sidecarImage, "", nil)()
 
-			Expect(p.Spec.NodeSelector).To(BeNil())
+			expected := expectedPod()
+			expected.Spec.NodeSelector = nil
+			Expect(p).To(Equal(expected))
 		})
 
 		It("should merge additional labels and always set the compliance role label", func() {
@@ -85,11 +189,12 @@ var _ = Describe("pod", func() {
 				"example": "value",
 			}
 
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, extra)()
+			p := gardenlinuxpod.NewTestPod("my-pod", "kube-system", testImage, sidecarImage, nodeName, extra)()
 
-			Expect(p.Labels).To(HaveKeyWithValue("foo", "bar"))
-			Expect(p.Labels).To(HaveKeyWithValue("example", "value"))
-			Expect(p.Labels).To(HaveKeyWithValue(kubernetespod.LabelComplianceRoleKey, gardenlinuxpod.LabelComplianceRoleGardenlinuxTestPod))
+			expected := expectedPod()
+			expected.Labels["foo"] = "bar"
+			expected.Labels["example"] = "value"
+			Expect(p).To(Equal(expected))
 		})
 
 		It("should overwrite an attempt to set the compliance role label from additionalLabels", func() {
@@ -97,123 +202,21 @@ var _ = Describe("pod", func() {
 				kubernetespod.LabelComplianceRoleKey: "attacker-value",
 			}
 
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, extra)()
+			p := gardenlinuxpod.NewTestPod("my-pod", "kube-system", testImage, sidecarImage, nodeName, extra)()
 
-			Expect(p.Labels).To(HaveKeyWithValue(kubernetespod.LabelComplianceRoleKey, gardenlinuxpod.LabelComplianceRoleGardenlinuxTestPod))
+			Expect(p).To(Equal(expectedPod()))
 		})
 
 		It("should not mutate the caller's additionalLabels map", func() {
 			extra := map[string]string{"foo": "bar"}
 
-			_ = gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, extra)()
+			_ = gardenlinuxpod.NewTestPod("my-pod", "kube-system", testImage, sidecarImage, nodeName, extra)()
 
 			Expect(extra).To(Equal(map[string]string{"foo": "bar"}))
 		})
 
-		It("should set pod-level security defaults", func() {
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
-
-			Expect(p.Spec.AutomountServiceAccountToken).To(Equal(ptr.To(false)))
-			Expect(p.Spec.HostNetwork).To(BeTrue())
-			Expect(p.Spec.HostPID).To(BeTrue())
-			Expect(p.Spec.HostIPC).To(BeFalse())
-			Expect(p.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
-			Expect(p.Spec.SecurityContext).NotTo(BeNil())
-			Expect(p.Spec.SecurityContext.FSGroup).To(Equal(ptr.To(int64(65532))))
-			Expect(p.Spec.SecurityContext.SeccompProfile).NotTo(BeNil())
-			Expect(p.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
-		})
-
-		It("should tolerate all NoSchedule and NoExecute taints", func() {
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
-
-			Expect(p.Spec.Tolerations).To(ConsistOf(
-				corev1.Toleration{Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpExists},
-				corev1.Toleration{Effect: corev1.TaintEffectNoExecute, Operator: corev1.TolerationOpExists},
-			))
-		})
-
-		It("should configure the privileged test container with the test image", func() {
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
-
-			Expect(p.Spec.InitContainers).To(BeEmpty())
-			Expect(p.Spec.Containers).To(HaveLen(2))
-			tc := p.Spec.Containers[0]
-			Expect(tc.Name).To(Equal("gardenlinux-test"))
-			Expect(tc.Image).To(Equal(testImage))
-			Expect(tc.SecurityContext).NotTo(BeNil())
-			Expect(tc.SecurityContext.Privileged).To(Equal(ptr.To(true)))
-			Expect(tc.Command).To(BeEmpty())
-			Expect(tc.Args).To(Equal([]string{
-				"./run_tests",
-				"integration/security/compliance",
-				"-v",
-				"-m",
-				"security_id",
-				"--junit-xml",
-				"output/test.xml",
-				"--system-booted",
-				"--expected-users",
-				"gardener",
-			}))
-			Expect(tc.VolumeMounts).To(ConsistOf(corev1.VolumeMount{
-				Name:      gardenlinuxpod.ReportVolumeName,
-				MountPath: gardenlinuxpod.ReportMountPath,
-			}))
-		})
-
-		It("should configure the reader container", func() {
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
-
-			Expect(p.Spec.Containers).To(HaveLen(2))
-			rc := p.Spec.Containers[1]
-			Expect(rc.Name).To(Equal("container"))
-			Expect(rc.Image).To(Equal(sidecarImage))
-			Expect(rc.Command).To(Equal([]string{
-				"/bin/busybox",
-			}))
-			Expect(rc.Args).To(Equal([]string{
-				"sleep",
-				"900",
-			}))
-
-			Expect(rc.SecurityContext).NotTo(BeNil())
-			Expect(rc.SecurityContext.Privileged).To(Equal(ptr.To(false)))
-			Expect(rc.SecurityContext.AllowPrivilegeEscalation).To(Equal(ptr.To(false)))
-			Expect(rc.SecurityContext.RunAsNonRoot).To(Equal(ptr.To(true)))
-			Expect(rc.SecurityContext.RunAsUser).To(Equal(ptr.To(int64(65532))))
-			Expect(rc.SecurityContext.RunAsGroup).To(Equal(ptr.To(int64(65532))))
-			Expect(rc.SecurityContext.ReadOnlyRootFilesystem).To(Equal(ptr.To(true)))
-			Expect(rc.SecurityContext.Capabilities.Drop).To(Equal([]corev1.Capability{"ALL"}))
-
-			Expect(rc.VolumeMounts).To(ConsistOf(
-				corev1.VolumeMount{
-					Name:      gardenlinuxpod.ReportVolumeName,
-					MountPath: gardenlinuxpod.ReportMountPath,
-					ReadOnly:  true,
-				},
-			))
-		})
-
-		It("should declare a bounded emptyDir volume for the JUnit report", func() {
-			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
-
-			Expect(p.Spec.Volumes).To(HaveLen(1))
-
-			var reportVolume corev1.Volume
-			for _, v := range p.Spec.Volumes {
-				if v.Name == gardenlinuxpod.ReportVolumeName {
-					reportVolume = v
-				}
-			}
-
-			Expect(reportVolume.EmptyDir).NotTo(BeNil())
-			Expect(reportVolume.EmptyDir.SizeLimit).NotTo(BeNil())
-			Expect(reportVolume.EmptyDir.SizeLimit.Equal(*resource.NewScaledQuantity(gardenlinuxpod.ReportSizeLimitKi, resource.Kilo))).To(BeTrue())
-		})
-
 		It("should return the same pod instance on repeated constructor invocations", func() {
-			ctor := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)
+			ctor := gardenlinuxpod.NewTestPod("my-pod", "kube-system", testImage, sidecarImage, nodeName, nil)
 
 			Expect(ctor()).To(BeIdenticalTo(ctor()))
 		})

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pod_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubernetespod "github.com/gardener/diki/pkg/kubernetes/pod"
+	gardenlinuxpod "github.com/gardener/diki/pkg/provider/managedk8s/ruleset/gardenlinux/pod"
+)
+
+var _ = Describe("pod", func() {
+	Describe("#NewPodContext", func() {
+		var (
+			fakeClient client.Client
+			fakeConfig *rest.Config
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().Build()
+			fakeConfig = &rest.Config{Host: "foo"}
+		})
+
+		It("should create a pod context with gardenlinux-tuned wait interval and timeout", func() {
+			ctx, err := gardenlinuxpod.NewPodContext(fakeClient, fakeConfig, map[string]string{})
+
+			Expect(err).To(BeNil())
+			Expect(ctx.WaitInterval).To(Equal(gardenlinuxpod.PodContextWaitInterval))
+			Expect(ctx.WaitTimeout).To(Equal(gardenlinuxpod.PodContextWaitTimeout))
+		})
+	})
+
+	Describe("#NewTestPod", func() {
+		const (
+			testImage    = "test:v0.0.0"
+			sidecarImage = "sidecar:v0.0.0"
+			nodeName     = "worker-1"
+		)
+
+		It("should construct a pod with the given name, namespace and node selector", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Name).To(Equal("my-pod"))
+			Expect(p.Namespace).To(Equal(gardenlinuxpod.SystemNamespace))
+			Expect(p.Spec.NodeSelector).To(Equal(map[string]string{"kubernetes.io/hostname": nodeName}))
+		})
+
+		It("should truncate names longer than MaxPodNameLength", func() {
+			longName := strings.Repeat("a", kubernetespod.MaxPodNameLength+10)
+
+			p := gardenlinuxpod.NewTestPod(longName, testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Name).To(HaveLen(kubernetespod.MaxPodNameLength))
+			Expect(p.Name).To(Equal(strings.Repeat("a", kubernetespod.MaxPodNameLength)))
+		})
+
+		It("should not preserve names at or below MaxPodNameLength", func() {
+			name := strings.Repeat("b", kubernetespod.MaxPodNameLength)
+
+			p := gardenlinuxpod.NewTestPod(name, testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Name).To(Equal(name))
+		})
+
+		It("should omit the node selector when nodeName is empty", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, "", nil)()
+
+			Expect(p.Spec.NodeSelector).To(BeNil())
+		})
+
+		It("should merge additional labels and always set the compliance role label", func() {
+			extra := map[string]string{
+				"foo":     "bar",
+				"example": "value",
+			}
+
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, extra)()
+
+			Expect(p.Labels).To(HaveKeyWithValue("foo", "bar"))
+			Expect(p.Labels).To(HaveKeyWithValue("example", "value"))
+			Expect(p.Labels).To(HaveKeyWithValue(kubernetespod.LabelComplianceRoleKey, gardenlinuxpod.LabelComplianceRoleGardenlinuxTestPod))
+		})
+
+		It("should overwrite an attempt to set the compliance role label from additionalLabels", func() {
+			extra := map[string]string{
+				kubernetespod.LabelComplianceRoleKey: "attacker-value",
+			}
+
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, extra)()
+
+			Expect(p.Labels).To(HaveKeyWithValue(kubernetespod.LabelComplianceRoleKey, gardenlinuxpod.LabelComplianceRoleGardenlinuxTestPod))
+		})
+
+		It("should not mutate the caller's additionalLabels map", func() {
+			extra := map[string]string{"foo": "bar"}
+
+			_ = gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, extra)()
+
+			Expect(extra).To(Equal(map[string]string{"foo": "bar"}))
+		})
+
+		It("should set pod-level security defaults", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Spec.AutomountServiceAccountToken).To(Equal(ptr.To(false)))
+			Expect(p.Spec.HostNetwork).To(BeTrue())
+			Expect(p.Spec.HostPID).To(BeTrue())
+			Expect(p.Spec.HostIPC).To(BeFalse())
+			Expect(p.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
+			Expect(p.Spec.SecurityContext).NotTo(BeNil())
+			Expect(p.Spec.SecurityContext.FSGroup).To(Equal(ptr.To(int64(65532))))
+			Expect(p.Spec.SecurityContext.SeccompProfile).NotTo(BeNil())
+			Expect(p.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+		})
+
+		It("should tolerate all NoSchedule and NoExecute taints", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Spec.Tolerations).To(ConsistOf(
+				corev1.Toleration{Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpExists},
+				corev1.Toleration{Effect: corev1.TaintEffectNoExecute, Operator: corev1.TolerationOpExists},
+			))
+		})
+
+		It("should configure the privileged test container with the test image", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Spec.InitContainers).To(BeEmpty())
+			Expect(p.Spec.Containers).To(HaveLen(2))
+			tc := p.Spec.Containers[0]
+			Expect(tc.Name).To(Equal("gardenlinux-test"))
+			Expect(tc.Image).To(Equal(testImage))
+			Expect(tc.SecurityContext).NotTo(BeNil())
+			Expect(tc.SecurityContext.Privileged).To(Equal(ptr.To(true)))
+			Expect(tc.Command).To(BeEmpty())
+			Expect(tc.Args).To(Equal([]string{
+				"./run_tests",
+				"integration/security/compliance",
+				"-v",
+				"-m",
+				"security_id",
+				"--junit-xml",
+				"output/test.xml",
+				"--system-booted",
+				"--expected-users",
+				"gardener",
+			}))
+			Expect(tc.VolumeMounts).To(ConsistOf(corev1.VolumeMount{
+				Name:      gardenlinuxpod.ReportVolumeName,
+				MountPath: gardenlinuxpod.ReportMountPath,
+			}))
+		})
+
+		It("should configure the reader container", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Spec.Containers).To(HaveLen(2))
+			rc := p.Spec.Containers[1]
+			Expect(rc.Name).To(Equal("container"))
+			Expect(rc.Image).To(Equal(sidecarImage))
+			Expect(rc.Command).To(Equal([]string{
+				"/bin/busybox",
+			}))
+			Expect(rc.Args).To(Equal([]string{
+				"sleep",
+				"900",
+			}))
+
+			Expect(rc.SecurityContext).NotTo(BeNil())
+			Expect(rc.SecurityContext.Privileged).To(Equal(ptr.To(false)))
+			Expect(rc.SecurityContext.AllowPrivilegeEscalation).To(Equal(ptr.To(false)))
+			Expect(rc.SecurityContext.RunAsNonRoot).To(Equal(ptr.To(true)))
+			Expect(rc.SecurityContext.RunAsUser).To(Equal(ptr.To(int64(65532))))
+			Expect(rc.SecurityContext.RunAsGroup).To(Equal(ptr.To(int64(65532))))
+			Expect(rc.SecurityContext.ReadOnlyRootFilesystem).To(Equal(ptr.To(true)))
+			Expect(rc.SecurityContext.Capabilities.Drop).To(Equal([]corev1.Capability{"ALL"}))
+
+			Expect(rc.VolumeMounts).To(ConsistOf(
+				corev1.VolumeMount{
+					Name:      gardenlinuxpod.ReportVolumeName,
+					MountPath: gardenlinuxpod.ReportMountPath,
+					ReadOnly:  true,
+				},
+			))
+		})
+
+		It("should declare a bounded emptyDir volume for the JUnit report", func() {
+			p := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)()
+
+			Expect(p.Spec.Volumes).To(HaveLen(1))
+
+			var reportVolume corev1.Volume
+			for _, v := range p.Spec.Volumes {
+				if v.Name == gardenlinuxpod.ReportVolumeName {
+					reportVolume = v
+				}
+			}
+
+			Expect(reportVolume.EmptyDir).NotTo(BeNil())
+			Expect(reportVolume.EmptyDir.SizeLimit).NotTo(BeNil())
+			Expect(reportVolume.EmptyDir.SizeLimit.Equal(*resource.NewScaledQuantity(gardenlinuxpod.ReportSizeLimitKi, resource.Kilo))).To(BeTrue())
+		})
+
+		It("should return the same pod instance on repeated constructor invocations", func() {
+			ctor := gardenlinuxpod.NewTestPod("my-pod", testImage, sidecarImage, nodeName, nil)
+
+			Expect(ctor()).To(BeIdenticalTo(ctor()))
+		})
+	})
+})

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -7,18 +7,30 @@ package gardenlinux
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
+	"sync"
 
+	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/diki/imagevector"
 	"github.com/gardener/diki/pkg/config"
+	"github.com/gardener/diki/pkg/kubernetes/pod"
+	kubeutils "github.com/gardener/diki/pkg/kubernetes/utils"
+	gardenlinuxpod "github.com/gardener/diki/pkg/provider/managedk8s/ruleset/gardenlinux/pod"
 	"github.com/gardener/diki/pkg/rule"
 	"github.com/gardener/diki/pkg/ruleset"
+	"github.com/gardener/diki/pkg/shared/images"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
+	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
 )
 
 const (
@@ -38,11 +50,13 @@ var (
 
 // Ruleset implements the Gardenlinux Testing Framework ruleset.
 type Ruleset struct {
-	version    string
-	Config     *rest.Config
-	args       Args
-	instanceID string
-	logger     *slog.Logger
+	version           string
+	Config            *rest.Config
+	Client            client.Client
+	ClusterPodContext pod.SimplePodContext
+	args              Args
+	instanceID        string
+	logger            *slog.Logger
 }
 
 // Args are Ruleset specific arguments.
@@ -59,6 +73,22 @@ func New(options ...CreateOption) (*Ruleset, error) {
 	for _, o := range options {
 		o(r)
 	}
+
+	if r.logger == nil {
+		r.logger = slog.Default().With("ruleset", r.ID(), "version", r.Version())
+	}
+
+	c, err := client.New(r.Config, client.Options{})
+	if err != nil {
+		return nil, err
+	}
+	r.Client = c
+
+	podContext, err := gardenlinuxpod.NewPodContext(r.Client, r.Config, nil)
+	if err != nil {
+		return nil, err
+	}
+	r.ClusterPodContext = *podContext
 
 	return r, nil
 }
@@ -132,24 +162,161 @@ func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Pa
 	return allErrs
 }
 
-// Run executes the gardenlinux test Pods and collects the test results.
-// TODO(georgibaltiev): add implementation for the integration of the Gardenlinux ruleset here.
-func (r *Ruleset) Run(_ context.Context) (ruleset.RulesetResult, error) {
-	r.Logger().Warn("the gardenlinux ruleset is not yet supported")
-	return ruleset.RulesetResult{}, nil
-}
-
 // RunRule executes specific Rule of a known Ruleset.
-// The function is not supported for this ruleset, since the implementation of the framework is external
+// The function is not supported for this ruleset, since the implementation of the framework is external.
 func (r *Ruleset) RunRule(_ context.Context, _ string) (rule.RuleResult, error) {
 	return rule.RuleResult{}, fmt.Errorf("the gardenlinux ruleset does not support running rules individually")
 }
 
-// Logger returns the Ruleset's logger.
-// If not set, set it to slog.Default().With("ruleset", r.ID(), "version", r.Version() then return it.
-func (r *Ruleset) Logger() *slog.Logger {
-	if r.logger == nil {
-		r.logger = slog.Default().With("ruleset", r.ID(), "version", r.Version())
+// Run deploys the gardenlinux test Pod on every selected Node in parallel and merges the collected test results into a single RulesetResult.
+func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
+	testImage, err := imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName)
+	if err != nil {
+		return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
 	}
+	testImage.WithOptionalTag(r.version)
+
+	sidecarImage, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
+	if err != nil {
+		return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
+	}
+
+	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)
+	if err != nil {
+		return ruleset.RulesetResult{}, err
+	}
+
+	allClusterPods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)
+	if err != nil {
+		return ruleset.RulesetResult{}, err
+	}
+
+	nodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allClusterPods, nodes)
+	selectedNodes, _ := kubeutils.SelectNodes(nodes, nodesAllocatablePods, r.args.NodeGroupByLabels)
+
+	type rulesetRun struct {
+		result   ruleset.RulesetResult
+		err      error
+		nodeName string
+	}
+
+	var (
+		rulesetResults []ruleset.RulesetResult
+		wg             sync.WaitGroup
+		resultCh       = make(chan rulesetRun)
+	)
+
+	for _, node := range selectedNodes {
+		wg.Go(func() {
+			result, err := r.runOnNode(ctx, node.Name, testImage.String(), sidecarImage.String())
+			resultCh <- rulesetRun{result: result, err: err, nodeName: node.Name}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	finishMsg := "finished ruleset run"
+	resultCount := 0
+	for rulesetRun := range resultCh {
+		resultCount++
+		remaining := len(selectedNodes) - resultCount
+		if rulesetRun.err != nil {
+			r.Logger().Error(finishMsg, "ruleset_id", RulesetID, "node_name", rulesetRun.nodeName, "remaining_nodes", remaining, "error", rulesetRun.err)
+			err = errors.Join(err, fmt.Errorf("ruleset %s on node %s errored: %w", RulesetID, rulesetRun.nodeName, rulesetRun.err))
+		} else {
+			r.Logger().Info(finishMsg, "ruleset_id", RulesetID, "node_name", rulesetRun.nodeName, "remaining_nodes", remaining)
+			rulesetResults = append(rulesetResults, rulesetRun.result)
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return ruleset.RulesetResult{}, err
+	}
+
+	// TODO: maybe return both result and err
+	if err != nil {
+		return ruleset.RulesetResult{}, err
+	}
+
+	// TODO (georgibaltiev): return a merged RulesetResult, based on the gathered results from the slices
+	if len(rulesetResults) == 0 {
+		return ruleset.RulesetResult{}, nil
+	}
+	return rulesetResults[0], nil
+}
+
+func (r *Ruleset) runOnNode(ctx context.Context, nodeName, testImage, sidecarImage string) (ruleset.RulesetResult, error) {
+	podName := fmt.Sprintf("test-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
+
+	defer func() {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), r.ClusterPodContext.WaitTimeout)
+		defer cancel()
+
+		if err := r.ClusterPodContext.Delete(timeoutCtx, podName, gardenlinuxpod.SystemNamespace); err != nil {
+			r.Logger().Error(err.Error())
+		}
+	}()
+
+	additionalLabels := map[string]string{pod.LabelInstanceID: r.instanceID}
+
+	podExecutor, err := r.ClusterPodContext.Create(ctx, gardenlinuxpod.NewTestPod(podName, testImage, sidecarImage, nodeName, additionalLabels))
+	if err != nil {
+		return ruleset.RulesetResult{}, fmt.Errorf("failed to create test pod on node %s: %w", nodeName, err)
+	}
+
+	// TODO (georgibaltiev): Add parsing logic for the report result. Remove the currently defaulted empty RuleResult
+	if _, err = r.readReport(ctx, podExecutor, podName); err != nil {
+		return ruleset.RulesetResult{}, fmt.Errorf("failed to read test report on node %s: %w", nodeName, err)
+	}
+
+	return ruleset.RulesetResult{}, nil
+}
+
+func (r *Ruleset) readReport(ctx context.Context, podExecutor pod.PodExecutor, podName string) (string, error) {
+	timeoutCtx, cancel := context.WithTimeout(ctx, r.ClusterPodContext.WaitTimeout)
+	defer cancel()
+
+	var report string
+	if err := retry.Until(timeoutCtx, r.ClusterPodContext.WaitInterval, func(ctx context.Context) (bool, error) {
+		terminated, err := r.testContainerTerminated(ctx, podName)
+		if err != nil {
+			return retry.MinorError(err)
+		}
+		if !terminated {
+			return retry.MinorError(fmt.Errorf("gardenlinux test container %q has not terminated yet", gardenlinuxpod.TestContainerName))
+		}
+
+		report, err = podExecutor.Execute(ctx, "/bin/busybox cat /tests/tests/output/test.xml", "")
+		if err != nil {
+			return retry.MinorError(err)
+		}
+		return retry.Ok()
+	}); err != nil {
+		return "", fmt.Errorf("failed to read gardenlinux test report %s: %w", gardenlinuxpod.ReportFilename, err)
+	}
+
+	return report, nil
+}
+
+func (r *Ruleset) testContainerTerminated(ctx context.Context, podName string) (bool, error) {
+	testPod := &corev1.Pod{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: gardenlinuxpod.SystemNamespace, Name: podName}, testPod); err != nil {
+		return false, err
+	}
+
+	for _, status := range testPod.Status.ContainerStatuses {
+		if status.Name == gardenlinuxpod.TestContainerName {
+			return status.State.Terminated != nil, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Logger returns the Ruleset's logger.
+func (r *Ruleset) Logger() *slog.Logger {
 	return r.logger
 }

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -12,13 +12,14 @@ import (
 	"log/slog"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/google/uuid"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/diki/imagevector"
@@ -44,6 +45,7 @@ var (
 	_ ruleset.Ruleset = &Ruleset{}
 	// SupportedVersions is a list of available versions for the Gardenlinux Ruleset.
 	// Versions are sorted from newest to oldest.
+	// TODO (georgibaltiev): Re-evaluate support for versions
 	SupportedVersions = []string{"2298.0.0", "2297.0.0"}
 )
 
@@ -138,10 +140,6 @@ func FromGenericConfig(rulesetConfig config.RulesetConfig, managedConfig *rest.C
 func ValidateRulesetConfig(rulesetConfig config.RulesetConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if !slices.Contains(SupportedVersions, rulesetConfig.Version) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("version"), rulesetConfig.Version, SupportedVersions))
-	}
-
 	rulesetArgsByte, err := json.Marshal(rulesetConfig.Args)
 	if err != nil {
 		return append(allErrs, field.Invalid(fldPath.Child("args"), rulesetConfig.Args, err.Error()))
@@ -169,6 +167,11 @@ func (r *Ruleset) RunRule(_ context.Context, _ string) (rule.RuleResult, error) 
 
 // Run deploys the gardenlinux test Pod on every selected Node in parallel and merges the collected test results into a single RulesetResult.
 func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
+
+	if !slices.Contains(SupportedVersions, r.version) {
+		r.Logger().Warn("Ruleset version is not officially supported", "version", r.version, "supportedVersions", SupportedVersions)
+	}
+
 	testImage, err := imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName)
 	if err != nil {
 		return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
@@ -179,6 +182,7 @@ func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
 	if err != nil {
 		return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.DikiOpsImageName, err)
 	}
+	sidecarImage.WithOptionalTag(version.Get().GitVersion)
 
 	nodes, err := kubeutils.GetNodes(ctx, r.Client, 300)
 	if err != nil {
@@ -251,7 +255,7 @@ func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
 
 func (r *Ruleset) runOnNode(ctx context.Context, nodeName, podName, testImage, sidecarImage string) (ruleset.RulesetResult, error) {
 	defer func() {
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), r.PodContext.WaitTimeout)
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 		defer cancel()
 
 		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
@@ -278,16 +282,16 @@ func (r *Ruleset) readReport(ctx context.Context, podExecutor pod.PodExecutor, p
 	timeoutCtx, cancel := context.WithTimeout(ctx, r.PodContext.WaitTimeout)
 	defer cancel()
 
-	var report string
-	if err := retry.Until(timeoutCtx, r.PodContext.WaitInterval, func(ctx context.Context) (bool, error) {
-		terminated, err := r.testContainerTerminated(ctx, podName)
-		if err != nil {
-			return retry.MinorError(err)
-		}
-		if !terminated {
-			return retry.MinorError(fmt.Errorf("gardenlinux test container %q has not terminated yet", gardenlinuxpod.TestContainerName))
-		}
+	if err := r.PodContext.WaitContainerTerminated(timeoutCtx, podName, "kube-system", gardenlinuxpod.TestContainerName); err != nil {
+		return "", fmt.Errorf("failed waiting for gardenlinux test container %q to terminate: %w", gardenlinuxpod.TestContainerName, err)
+	}
 
+	var (
+		report string
+		err    error
+	)
+
+	if err := retry.Until(timeoutCtx, r.PodContext.WaitInterval, func(ctx context.Context) (bool, error) {
 		report, err = podExecutor.Execute(ctx, fmt.Sprintf("/bin/busybox cat %s/%s", gardenlinuxpod.ReportMountPath, gardenlinuxpod.ReportFilename), "")
 		if err != nil {
 			return retry.MinorError(err)
@@ -298,21 +302,6 @@ func (r *Ruleset) readReport(ctx context.Context, podExecutor pod.PodExecutor, p
 	}
 
 	return report, nil
-}
-
-func (r *Ruleset) testContainerTerminated(ctx context.Context, podName string) (bool, error) {
-	testPod := &corev1.Pod{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Name: podName, Namespace: "kube-system"}, testPod); err != nil {
-		return false, err
-	}
-
-	for _, status := range testPod.Status.ContainerStatuses {
-		if status.Name == gardenlinuxpod.TestContainerName {
-			return status.State.Terminated != nil, nil
-		}
-	}
-
-	return false, nil
 }
 
 // Logger returns the Ruleset's logger.

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -49,13 +49,13 @@ var (
 
 // Ruleset implements the Gardenlinux Testing Framework ruleset.
 type Ruleset struct {
-	version           string
-	Config            *rest.Config
-	Client            client.Client
-	ClusterPodContext pod.SimplePodContext
-	args              Args
-	instanceID        string
-	logger            *slog.Logger
+	version    string
+	Config     *rest.Config
+	Client     client.Client
+	PodContext pod.SimplePodContext
+	args       Args
+	instanceID string
+	logger     *slog.Logger
 }
 
 // Args are Ruleset specific arguments.
@@ -87,7 +87,7 @@ func New(options ...CreateOption) (*Ruleset, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.ClusterPodContext = *podContext
+	r.PodContext = *podContext
 
 	return r, nil
 }
@@ -185,12 +185,13 @@ func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
 		return ruleset.RulesetResult{}, err
 	}
 
-	allClusterPods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)
+	allPods, err := kubeutils.GetPods(ctx, r.Client, "", labels.NewSelector(), 300)
 	if err != nil {
 		return ruleset.RulesetResult{}, err
 	}
 
-	nodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allClusterPods, nodes)
+	nodesAllocatablePods := kubeutils.GetNodesAllocatablePodsNum(allPods, nodes)
+	// TODO(georgibaltiev): Address the warning check results from the SelectNodes function.
 	selectedNodes, _ := kubeutils.SelectNodes(nodes, nodesAllocatablePods, r.args.NodeGroupByLabels)
 
 	type rulesetRun struct {
@@ -206,8 +207,9 @@ func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
 	)
 
 	for _, node := range selectedNodes {
+		podName := fmt.Sprintf("diki-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
 		wg.Go(func() {
-			result, err := r.runOnNode(ctx, node.Name, testImage.String(), sidecarImage.String())
+			result, err := r.runOnNode(ctx, node.Name, podName, testImage.String(), sidecarImage.String())
 			resultCh <- rulesetRun{result: result, err: err, nodeName: node.Name}
 		})
 	}
@@ -223,10 +225,10 @@ func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
 		resultCount++
 		remaining := len(selectedNodes) - resultCount
 		if rulesetRun.err != nil {
-			r.Logger().Error(finishMsg, "ruleset_id", RulesetID, "node_name", rulesetRun.nodeName, "remaining_nodes", remaining, "error", rulesetRun.err)
+			r.Logger().Error(finishMsg, "node_name", rulesetRun.nodeName, "remaining_nodes", remaining, "error", rulesetRun.err)
 			err = errors.Join(err, fmt.Errorf("ruleset %s on node %s errored: %w", RulesetID, rulesetRun.nodeName, rulesetRun.err))
 		} else {
-			r.Logger().Info(finishMsg, "ruleset_id", RulesetID, "node_name", rulesetRun.nodeName, "remaining_nodes", remaining)
+			r.Logger().Info(finishMsg, "node_name", rulesetRun.nodeName, "remaining_nodes", remaining)
 			rulesetResults = append(rulesetResults, rulesetRun.result)
 		}
 	}
@@ -247,21 +249,19 @@ func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
 	return rulesetResults[0], nil
 }
 
-func (r *Ruleset) runOnNode(ctx context.Context, nodeName, testImage, sidecarImage string) (ruleset.RulesetResult, error) {
-	podName := fmt.Sprintf("test-%s-%s", r.ID(), sharedrules.Generator.Generate(10))
-
+func (r *Ruleset) runOnNode(ctx context.Context, nodeName, podName, testImage, sidecarImage string) (ruleset.RulesetResult, error) {
 	defer func() {
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), r.ClusterPodContext.WaitTimeout)
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), r.PodContext.WaitTimeout)
 		defer cancel()
 
-		if err := r.ClusterPodContext.Delete(timeoutCtx, podName, gardenlinuxpod.SystemNamespace); err != nil {
+		if err := r.PodContext.Delete(timeoutCtx, podName, "kube-system"); err != nil {
 			r.Logger().Error(err.Error())
 		}
 	}()
 
 	additionalLabels := map[string]string{pod.LabelInstanceID: r.instanceID}
 
-	podExecutor, err := r.ClusterPodContext.Create(ctx, gardenlinuxpod.NewTestPod(podName, testImage, sidecarImage, nodeName, additionalLabels))
+	podExecutor, err := r.PodContext.Create(ctx, gardenlinuxpod.NewTestPod(podName, "kube-system", testImage, sidecarImage, nodeName, additionalLabels))
 	if err != nil {
 		return ruleset.RulesetResult{}, fmt.Errorf("failed to create test pod on node %s: %w", nodeName, err)
 	}
@@ -275,11 +275,11 @@ func (r *Ruleset) runOnNode(ctx context.Context, nodeName, testImage, sidecarIma
 }
 
 func (r *Ruleset) readReport(ctx context.Context, podExecutor pod.PodExecutor, podName string) (string, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, r.ClusterPodContext.WaitTimeout)
+	timeoutCtx, cancel := context.WithTimeout(ctx, r.PodContext.WaitTimeout)
 	defer cancel()
 
 	var report string
-	if err := retry.Until(timeoutCtx, r.ClusterPodContext.WaitInterval, func(ctx context.Context) (bool, error) {
+	if err := retry.Until(timeoutCtx, r.PodContext.WaitInterval, func(ctx context.Context) (bool, error) {
 		terminated, err := r.testContainerTerminated(ctx, podName)
 		if err != nil {
 			return retry.MinorError(err)
@@ -288,7 +288,7 @@ func (r *Ruleset) readReport(ctx context.Context, podExecutor pod.PodExecutor, p
 			return retry.MinorError(fmt.Errorf("gardenlinux test container %q has not terminated yet", gardenlinuxpod.TestContainerName))
 		}
 
-		report, err = podExecutor.Execute(ctx, "/bin/busybox cat /tests/tests/output/test.xml", "")
+		report, err = podExecutor.Execute(ctx, fmt.Sprintf("/bin/busybox cat %s/%s", gardenlinuxpod.ReportMountPath, gardenlinuxpod.ReportFilename), "")
 		if err != nil {
 			return retry.MinorError(err)
 		}
@@ -302,7 +302,7 @@ func (r *Ruleset) readReport(ctx context.Context, podExecutor pod.PodExecutor, p
 
 func (r *Ruleset) testContainerTerminated(ctx context.Context, podName string) (bool, error) {
 	testPod := &corev1.Pod{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: gardenlinuxpod.SystemNamespace, Name: podName}, testPod); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: podName, Namespace: "kube-system"}, testPod); err != nil {
 		return false, err
 	}
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -44,8 +44,7 @@ var (
 	_ ruleset.Ruleset = &Ruleset{}
 	// SupportedVersions is a list of available versions for the Gardenlinux Ruleset.
 	// Versions are sorted from newest to oldest.
-	// TODO(georgibaltiev): introduce support for actual gardenlinux versions and remove dummy values
-	SupportedVersions = []string{"v0.1.0"}
+	SupportedVersions = []string{"2298.0.0", "2297.0.0"}
 )
 
 // Ruleset implements the Gardenlinux Testing Framework ruleset.

--- a/pkg/shared/images/images.go
+++ b/pkg/shared/images/images.go
@@ -7,4 +7,6 @@ package images
 const (
 	// DikiOpsImageName is a constant for the name of the github.com/gardener/diki diki-ops image.
 	DikiOpsImageName = "diki-ops"
+	// GardenlinuxTestImageName is a constant for the name of the ghcr.io/gardenlinux test image.
+	GardenlinuxTestImageName = "gardenlinux-test"
 )


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR is a follow-up to #760 

It expands the newly-introduced `gardenlinux` ruleset by defining a new Pod spec that runs the containerized testing framework, based on [their reccomendation](https://github.com/gardener/diki/pull/772#issue-4900554191) to run tests on K8s environments.

The Pod deploys two containers - the `gardenlinux` test container, and the `diki-ops` report-reader container, which has a sleep timeout of 15 minutes.

Once the testing container has finished (as checked by its' status) a `cat <path-to-report>` command is executed into the report-reader container, which retrieves the XML data as a singular string value.

The user can now specify which version of the `gardenlinux` tests could be ran, and as initial support versions [2298.0.0](https://github.com/gardenlinux/gardenlinux/pkgs/container/test/1035278466?tag=2298.0.0) and [2297.0.0](https://github.com/gardenlinux/gardenlinux/pkgs/container/test/1033038064?tag=2297.0.0) have been added. 

**Which issue(s) this PR fixes**:
Part of #752 

**Special notes for your reviewer**:
The parsing of the XML reports will be done in a separate PR (as marked by the few TODOs left in ruleset.go)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[Gardenlinux Testing Framework] Added Pod resources to run the gardenlinux testing container.
```
