### PR TITLE
Handle input version correctly for publish to package repos workflow

### DIFF
--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -10,11 +10,11 @@ on:
       version:
         type: string
         required: true
-        description: The released version (semver without v-prefix, e.g. 0.x.0)
+        description: The released version (e.g. v0.x.0)
   workflow_dispatch:
     inputs:
       version:
-        description: 'The released version (semver without v-prefix, e.g. 0.x.0)'
+        description: 'The released version (e.g. v0.x.0)'
         required: false
         type: string
       dry_run:
@@ -48,7 +48,7 @@ jobs:
         if: ${{ inputs.version != '' }}
         run: |
           set -euo pipefail
-          tag="v${{ inputs.version }}"
+          tag="${{ inputs.version }}"
           base_url="https://github.com/${{ github.repository }}/releases/download/${tag}"
 
           compute_sha() {
@@ -78,7 +78,7 @@ jobs:
             "WINDOWS_SHA=$dummy" >> "$GITHUB_ENV"
 
       # ───── Homebrew tap dispatch ────────────────────────────────────────────
-      - name: Send update to ${{ github.repository_owner}}/homebrew-tap
+      - name: Send update to ${{ github.repository_owner }}/homebrew-tap
         if: ${{ inputs.dry_run == false }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
A bug causing release packages to be sent with wrong version to `homebrew` and `chocolatey` has been fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A bug causing release packages to be sent with wrong version to `homebrew` and `chocolatey` has been fixed.
```
