### PR TITLE
Increase the Pod Context waiting timeout for Gardenlinux pods

### DIFF
--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
@@ -23,7 +23,7 @@ const (
 	PodContextWaitInterval = 2 * time.Second
 	// PodContextWaitTimeout is the maximum time to wait for the test pod to reach Running.
 	// Both containers start immediately, so we only need enough time for image pull + scheduling.
-	PodContextWaitTimeout = 1 * time.Minute
+	PodContextWaitTimeout = 2 * time.Minute
 
 	// TestContainerName is the name of the container running the gardenlinux/tests suite.
 	TestContainerName = "gardenlinux-test"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
There are some issues with the execution of Gardenlinux pods, especially when the image has to be pulled preliminarily. This PR increases the pod timeout in order to not kill pods which are still in progress.

**Which issue(s) this PR fixes**:
Part of #752 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
