### PR TITLE
Add supported Gardenlinux versions to the Imagevector

### DIFF
--- a/example/config/managedk8s.yaml
+++ b/example/config/managedk8s.yaml
@@ -320,7 +320,7 @@ providers:                   # contains information about known providers
     #       - "*" # a wildcard can be used to match against all volumes in an accepted pod
   - id: gardenlinux
     name: Gardenlinux Testing Framework
-    version: 2298.0.0
+    version: 2324.0.0
     # args:
     #   # node labels used to group nodes by specified label value combinations. 
     #   # Only one node per combination will be tested

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -10,3 +10,13 @@ images:
 - name: gardenlinux-test
   sourceRepository: github.com/gardenlinux/gardenlinux
   repository: ghcr.io/gardenlinux/test
+- name: gardenlinux-test
+  sourceRepository: github.com/gardenlinux/gardenlinux
+  repository: ghcr.io/gardenlinux/test
+  tag: 2324.0.0
+  targetVersion: 2324.0.0
+- name: gardenlinux-test
+  sourceRepository: github.com/gardenlinux/gardenlinux
+  repository: ghcr.io/gardenlinux/test
+  tag: 2323.0.0
+  targetVersion: 2323.0.0

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -33,8 +34,6 @@ import (
 	"github.com/gardener/diki/pkg/shared/images"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
-
-	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
 const (
@@ -170,24 +169,23 @@ func (r *Ruleset) RunRule(_ context.Context, _ string) (rule.RuleResult, error) 
 
 // Run deploys the gardenlinux test Pod on every selected Node in parallel and merges the collected test results into a single RulesetResult.
 func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
-
 	var (
 		testImage *imagevectorutils.Image
 		err       error
 	)
 
-	if !slices.Contains(SupportedVersions, r.version) {
+	if slices.Contains(SupportedVersions, r.version) {
+		testImage, err = imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName, imagevectorutils.TargetVersion(r.version))
+		if err != nil {
+			return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
+		}
+	} else {
 		r.Logger().Warn("Ruleset version is not officially supported", "version", r.version, "supportedVersions", SupportedVersions)
 		testImage, err = imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName)
 		if err != nil {
 			return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
 		}
 		testImage.WithOptionalTag(r.version)
-	} else {
-		testImage, err = imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName, imagevectorutils.TargetVersion(r.version))
-		if err != nil {
-			return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
-		}
 	}
 
 	sidecarImage, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -33,6 +33,8 @@ import (
 	"github.com/gardener/diki/pkg/shared/images"
 	disaoption "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/option"
 	sharedrules "github.com/gardener/diki/pkg/shared/ruleset/disak8sstig/rules"
+
+	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
 const (
@@ -47,7 +49,7 @@ var (
 	// SupportedVersions is a list of available versions for the Gardenlinux Ruleset.
 	// Versions are sorted from newest to oldest.
 	// TODO (georgibaltiev): Re-evaluate support for versions
-	SupportedVersions = []string{"2298.0.0", "2297.0.0"}
+	SupportedVersions = []string{"2324.0.0", "2323.0.0"}
 )
 
 // Ruleset implements the Gardenlinux Testing Framework ruleset.
@@ -169,15 +171,24 @@ func (r *Ruleset) RunRule(_ context.Context, _ string) (rule.RuleResult, error) 
 // Run deploys the gardenlinux test Pod on every selected Node in parallel and merges the collected test results into a single RulesetResult.
 func (r *Ruleset) Run(ctx context.Context) (ruleset.RulesetResult, error) {
 
+	var (
+		testImage *imagevectorutils.Image
+		err       error
+	)
+
 	if !slices.Contains(SupportedVersions, r.version) {
 		r.Logger().Warn("Ruleset version is not officially supported", "version", r.version, "supportedVersions", SupportedVersions)
+		testImage, err = imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName)
+		if err != nil {
+			return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
+		}
+		testImage.WithOptionalTag(r.version)
+	} else {
+		testImage, err = imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName, imagevectorutils.TargetVersion(r.version))
+		if err != nil {
+			return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
+		}
 	}
-
-	testImage, err := imagevector.ImageVector().FindImage(images.GardenlinuxTestImageName)
-	if err != nil {
-		return ruleset.RulesetResult{}, fmt.Errorf("failed to find image version for %s: %w", images.GardenlinuxTestImageName, err)
-	}
-	testImage.WithOptionalTag(r.version)
 
 	sidecarImage, err := imagevector.ImageVector().FindImage(images.DikiOpsImageName)
 	if err != nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR specifies explicitly the experimentally supported versions of the Gardenlinux testing framework container image. Additionally, it adds support for the latest nightly releases.

**Which issue(s) this PR fixes**:
Part of #752 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Diki now supports experimental versions `2324.0.0` and `2323.0.0` of the Gardenlinux testing framework. 
```
