### PR TITLE
Update copyright text

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ocm/branch-info.yaml
+++ b/.ocm/branch-info.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ocm/branch-info.yaml
+++ b/.ocm/branch-info.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,13 +6,13 @@ SPDX-PackageDownloadLocation = "https://github.com/gardener/diki"
 [[annotations]]
 path = [".github/**", ".gitignore", ".golangci.yaml", "example/**", "CODEOWNERS", "OWNERS", "OWNERS_ALIASES", "VERSION", "go.mod", "go.sum", "_typos.toml", "tailwind.config.js", "pkg/report/templates/html/input.css", "pkg/report/templates/html/difference_report.html", "pkg/report/templates/html/merged_report.html", "pkg/report/templates/html/report.html"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**.md"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,13 +6,13 @@ SPDX-PackageDownloadLocation = "https://github.com/gardener/diki"
 [[annotations]]
 path = [".github/**", ".gitignore", ".golangci.yaml", "example/**", "CODEOWNERS", "OWNERS", "OWNERS_ALIASES", "VERSION", "go.mod", "go.sum", "_typos.toml", "tailwind.config.js", "pkg/report/templates/html/input.css", "pkg/report/templates/html/difference_report.html", "pkg/report/templates/html/merged_report.html", "pkg/report/templates/html/report.html"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2017-2025 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**.md"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2017-2025 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/cmd/diki/app/app.go
+++ b/cmd/diki/app/app.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/cmd/diki/main.go
+++ b/cmd/diki/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/cmd/diki/main.go
+++ b/cmd/diki/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/pod-security-standards/pod-security-standards-v0.1.0.yaml
+++ b/docs/rulesets/pod-security-standards/pod-security-standards-v0.1.0.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/pod-security-standards/pod-security-standards-v0.1.0.yaml
+++ b/docs/rulesets/pod-security-standards/pod-security-standards-v0.1.0.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/security-hardened-k8s/security-hardened-k8s-v0.1.0.yaml
+++ b/docs/rulesets/security-hardened-k8s/security-hardened-k8s-v0.1.0.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/security-hardened-k8s/security-hardened-k8s-v0.1.0.yaml
+++ b/docs/rulesets/security-hardened-k8s/security-hardened-k8s-v0.1.0.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.1.0.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.1.0.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.1.0.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.1.0.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
+++ b/docs/rulesets/security-hardened-shoot-cluster/security-hardened-shoot-cluster-v0.2.1.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/gen-new-disak8sstig-version.sh
+++ b/hack/gen-new-disak8sstig-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/gen-new-disak8sstig-version.sh
+++ b/hack/gen-new-disak8sstig-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/gen-styles.sh
+++ b/hack/gen-styles.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/gen-styles.sh
+++ b/hack/gen-styles.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/test-cover.sh
+++ b/hack/test-cover.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/test-cover.sh
+++ b/hack/test-cover.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/imagevector/images.go
+++ b/imagevector/images.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/imagevector/images.go
+++ b/imagevector/images.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/imagevector/imagevector.go
+++ b/imagevector/imagevector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/imagevector/imagevector.go
+++ b/imagevector/imagevector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/merge.go
+++ b/pkg/config/merge/merge.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/merge.go
+++ b/pkg/config/merge/merge.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/merge_suite_test.go
+++ b/pkg/config/merge/merge_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/merge_suite_test.go
+++ b/pkg/config/merge/merge_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/merge_test.go
+++ b/pkg/config/merge/merge_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/merge_test.go
+++ b/pkg/config/merge/merge_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/registry.go
+++ b/pkg/config/merge/registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/merge/registry.go
+++ b/pkg/config/merge/registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/validate/validate_suite_test.go
+++ b/pkg/config/validate/validate_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/validate/validate_suite_test.go
+++ b/pkg/config/validate/validate_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/validate/validate_test.go
+++ b/pkg/config/validate/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/config/validate/validate_test.go
+++ b/pkg/config/validate/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/config/option_config.go
+++ b/pkg/internal/config/option_config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/config/option_config.go
+++ b/pkg/internal/config/option_config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/kubernetes/utils/utils.go
+++ b/pkg/internal/kubernetes/utils/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/kubernetes/utils/utils.go
+++ b/pkg/internal/kubernetes/utils/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/stringgen/fake/generator.go
+++ b/pkg/internal/stringgen/fake/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/stringgen/fake/generator.go
+++ b/pkg/internal/stringgen/fake/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/stringgen/generator.go
+++ b/pkg/internal/stringgen/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/stringgen/generator.go
+++ b/pkg/internal/stringgen/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/set.go
+++ b/pkg/internal/utils/set.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/set.go
+++ b/pkg/internal/utils/set.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/set_test.go
+++ b/pkg/internal/utils/set_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/set_test.go
+++ b/pkg/internal/utils/set_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/utils_suite_test.go
+++ b/pkg/internal/utils/utils_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/utils_suite_test.go
+++ b/pkg/internal/utils/utils_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/etcd.go
+++ b/pkg/kubernetes/config/etcd.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/etcd.go
+++ b/pkg/kubernetes/config/etcd.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/kubeProxy.go
+++ b/pkg/kubernetes/config/kubeProxy.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/kubeProxy.go
+++ b/pkg/kubernetes/config/kubeProxy.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/kubelet.go
+++ b/pkg/kubernetes/config/kubelet.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/kubelet.go
+++ b/pkg/kubernetes/config/kubelet.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/mount.go
+++ b/pkg/kubernetes/config/mount.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/config/mount.go
+++ b/pkg/kubernetes/config/mount.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/fake/fake_suite_test.go
+++ b/pkg/kubernetes/pod/fake/fake_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/fake/fake_suite_test.go
+++ b/pkg/kubernetes/pod/fake/fake_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/fake/pod.go
+++ b/pkg/kubernetes/pod/fake/pod.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/fake/pod.go
+++ b/pkg/kubernetes/pod/fake/pod.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/fake/pod_test.go
+++ b/pkg/kubernetes/pod/fake/pod_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/fake/pod_test.go
+++ b/pkg/kubernetes/pod/fake/pod_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/pod_suite_test.go
+++ b/pkg/kubernetes/pod/pod_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/pod_suite_test.go
+++ b/pkg/kubernetes/pod/pod_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/pod_test.go
+++ b/pkg/kubernetes/pod/pod_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/pod_test.go
+++ b/pkg/kubernetes/pod/pod_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/privileged.go
+++ b/pkg/kubernetes/pod/privileged.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/privileged.go
+++ b/pkg/kubernetes/pod/privileged.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/privileged_test.go
+++ b/pkg/kubernetes/pod/privileged_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/pod/privileged_test.go
+++ b/pkg/kubernetes/pod/privileged_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/utils/utils.go
+++ b/pkg/kubernetes/utils/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/utils/utils_suite_test.go
+++ b/pkg/kubernetes/utils/utils_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/utils/utils_suite_test.go
+++ b/pkg/kubernetes/utils/utils_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/kubernetes/utils/utils_test.go
+++ b/pkg/kubernetes/utils/utils_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/garden.go
+++ b/pkg/provider/builder/garden.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/garden.go
+++ b/pkg/provider/builder/garden.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/gardener.go
+++ b/pkg/provider/builder/gardener.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/gardener.go
+++ b/pkg/provider/builder/gardener.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/managedk8s.go
+++ b/pkg/provider/builder/managedk8s.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/builder/virtualgarden.go
+++ b/pkg/provider/builder/virtualgarden.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/garden_suite_test.go
+++ b/pkg/provider/garden/garden_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/garden_suite_test.go
+++ b/pkg/provider/garden/garden_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/options.go
+++ b/pkg/provider/garden/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/options.go
+++ b/pkg/provider/garden/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/provider.go
+++ b/pkg/provider/garden/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/provider.go
+++ b/pkg/provider/garden/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/merge_registry.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/merge_registry.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1000_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1001_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1002_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/1003_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2000_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2001_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2002_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2003_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2004_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2005_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/2007_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/rules_suite_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/rules/rules_suite_test.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v01_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
+++ b/pkg/provider/garden/ruleset/securityhardenedshoot/v02_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/validate.go
+++ b/pkg/provider/garden/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/validate.go
+++ b/pkg/provider/garden/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/validate_test.go
+++ b/pkg/provider/garden/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/garden/validate_test.go
+++ b/pkg/provider/garden/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/options.go
+++ b/pkg/provider/gardener/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/options.go
+++ b/pkg/provider/gardener/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/provider.go
+++ b/pkg/provider/gardener/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/provider.go
+++ b/pkg/provider/gardener/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/provider_suite_test.go
+++ b/pkg/provider/gardener/provider_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/provider_suite_test.go
+++ b/pkg/provider/gardener/provider_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/provider_test.go
+++ b/pkg/provider/gardener/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/provider_test.go
+++ b/pkg/provider/gardener/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/merge_registry.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/merge_registry.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242377.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242377.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242377.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242377.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242377_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242377_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242377_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242377_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242400_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242414_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242415_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242442_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242451_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242466_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/242467_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/stringgenerator.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/stringgenerator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/rules/stringgenerator.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/rules/stringgenerator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r5_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r5_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r6_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r6_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/ruleset/disak8sstig/v2r6_ruleset.go
+++ b/pkg/provider/gardener/ruleset/disak8sstig/v2r6_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/validate.go
+++ b/pkg/provider/gardener/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/validate.go
+++ b/pkg/provider/gardener/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/validate_test.go
+++ b/pkg/provider/gardener/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/gardener/validate_test.go
+++ b/pkg/provider/gardener/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/export_test.go
+++ b/pkg/provider/managedk8s/export_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/export_test.go
+++ b/pkg/provider/managedk8s/export_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/managedk8s_suite_test.go
+++ b/pkg/provider/managedk8s/managedk8s_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/managedk8s_suite_test.go
+++ b/pkg/provider/managedk8s/managedk8s_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/options.go
+++ b/pkg/provider/managedk8s/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/options.go
+++ b/pkg/provider/managedk8s/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/provider.go
+++ b/pkg/provider/managedk8s/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/provider.go
+++ b/pkg/provider/managedk8s/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/provider_test.go
+++ b/pkg/provider/managedk8s/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/provider_test.go
+++ b/pkg/provider/managedk8s/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/merge_registry.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/merge_registry.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242390_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242400_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242414_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242415_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242442_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242451_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242466_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/242467_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r5_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r5_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r6_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r6_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/disak8sstig/v2r6_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/disak8sstig/v2r6_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit_report_parser_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit_report_parser_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit_report_parser_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/junit_report_parser_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/junitreportparser/report_parser_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/pod/pod_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/gardenlinux/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/merge_registry.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/merge_registry.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/options.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/options.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2000_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2001_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2002_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2003_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2004_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2005_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2006_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2007_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/2008_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/doc.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/doc.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/export_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/export_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/export_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/export_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/rules_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/rules_suite_test.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
+++ b/pkg/provider/managedk8s/ruleset/securityhardenedk8s/v01_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/validate.go
+++ b/pkg/provider/managedk8s/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/validate.go
+++ b/pkg/provider/managedk8s/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/validate_test.go
+++ b/pkg/provider/managedk8s/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/managedk8s/validate_test.go
+++ b/pkg/provider/managedk8s/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/options.go
+++ b/pkg/provider/virtualgarden/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/options.go
+++ b/pkg/provider/virtualgarden/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/provider.go
+++ b/pkg/provider/virtualgarden/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/provider.go
+++ b/pkg/provider/virtualgarden/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/merge_registry.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/merge_registry.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/merge_registry.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242400_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242442_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242451_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242466_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/242467_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/options.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r5_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r5_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r5_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r6_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r6_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r6_ruleset.go
+++ b/pkg/provider/virtualgarden/ruleset/disak8sstig/v2r6_ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/validate.go
+++ b/pkg/provider/virtualgarden/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/validate.go
+++ b/pkg/provider/virtualgarden/validate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/validate_test.go
+++ b/pkg/provider/virtualgarden/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/validate_test.go
+++ b/pkg/provider/virtualgarden/validate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/virtualgarden_suite_test.go
+++ b/pkg/provider/virtualgarden/virtualgarden_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/provider/virtualgarden/virtualgarden_suite_test.go
+++ b/pkg/provider/virtualgarden/virtualgarden_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/difference.go
+++ b/pkg/report/difference.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/difference.go
+++ b/pkg/report/difference.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/difference_test.go
+++ b/pkg/report/difference_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/difference_test.go
+++ b/pkg/report/difference_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/merged_report.go
+++ b/pkg/report/merged_report.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/merged_report.go
+++ b/pkg/report/merged_report.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/merged_report_test.go
+++ b/pkg/report/merged_report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/merged_report_test.go
+++ b/pkg/report/merged_report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/render.go
+++ b/pkg/report/render.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/report_suite_test.go
+++ b/pkg/report/report_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/report_suite_test.go
+++ b/pkg/report/report_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/helpers.go
+++ b/pkg/rule/helpers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/helpers.go
+++ b/pkg/rule/helpers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/helpers_test.go
+++ b/pkg/rule/helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/helpers_test.go
+++ b/pkg/rule/helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/options.go
+++ b/pkg/rule/retry/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/options.go
+++ b/pkg/rule/retry/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/retry_suite_test.go
+++ b/pkg/rule/retry/retry_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/retry_suite_test.go
+++ b/pkg/rule/retry/retry_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/retryablerule.go
+++ b/pkg/rule/retry/retryablerule.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/retryablerule.go
+++ b/pkg/rule/retry/retryablerule.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/retryablerule_test.go
+++ b/pkg/rule/retry/retryablerule_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/retry/retryablerule_test.go
+++ b/pkg/rule/retry/retryablerule_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/rule_suite_test.go
+++ b/pkg/rule/rule_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/rule_suite_test.go
+++ b/pkg/rule/rule_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/skiprule.go
+++ b/pkg/rule/skiprule.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/rule/skiprule.go
+++ b/pkg/rule/skiprule.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/images/images.go
+++ b/pkg/shared/images/images.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/images/images.go
+++ b/pkg/shared/images/images.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/mergetest/mergetest.go
+++ b/pkg/shared/kubernetes/option/mergetest/mergetest.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/mergetest/mergetest.go
+++ b/pkg/shared/kubernetes/option/mergetest/mergetest.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/options.go
+++ b/pkg/shared/kubernetes/option/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/options_suite_test.go
+++ b/pkg/shared/kubernetes/option/options_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/options_suite_test.go
+++ b/pkg/shared/kubernetes/option/options_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/kubernetes/option/options_test.go
+++ b/pkg/shared/kubernetes/option/options_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/provider/provider.go
+++ b/pkg/shared/provider/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/provider/provider.go
+++ b/pkg/shared/provider/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/option/options.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/option/options_suite_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/option/options_suite_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/option/options_test.go
+++ b/pkg/shared/ruleset/disak8sstig/option/options_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_suite_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_suite_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
+++ b/pkg/shared/ruleset/disak8sstig/retryerrors/retryerrors_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242376.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242376.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242376.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242376.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242376_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242376_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242376_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242376_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242378.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242378.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242378.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242378.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242378_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242378_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242378_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242378_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242379.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242379.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242379.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242379.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242379_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242379_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242379_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242379_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242380.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242380.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242380.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242380.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242380_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242380_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242380_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242380_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242381.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242381.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242381.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242381.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242381_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242381_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242381_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242381_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242382.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242382.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242382.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242382.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242382_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242383.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242383.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242383_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242387.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242387.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242387.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242387.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242387_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242387_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242387_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242387_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242389.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242389.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242389.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242389.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242389_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242389_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242389_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242389_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242390.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242390_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242391.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242391.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242391.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242391.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242391_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242391_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242391_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242391_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242392.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242392.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242392.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242392.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242392_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242392_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242392_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242392_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242393.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242393.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242393.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242393.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242393_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242393_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242393_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242393_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242394.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242394.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242394.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242394.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242394_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242394_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242394_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242394_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242395.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242395.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242395.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242395.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242395_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242395_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242395_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242395_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242396.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242396.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242396.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242396.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242396_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242396_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242396_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242396_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242397.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242397.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242397.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242397.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242397_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242397_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242397_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242397_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242402.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242402.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242402.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242402.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242402_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242402_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242402_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242402_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242403.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242403.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242403.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242403.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242403_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242403_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242403_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242403_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242404.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242404.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242404.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242404.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242404_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242404_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242404_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242404_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242406.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242406.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242406.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242406.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242406_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242406_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242406_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242406_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242407.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242407.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242407.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242407.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242407_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242407_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242407_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242407_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242409.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242409.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242409.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242409.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242409_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242409_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242409_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242409_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242417.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242417.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242417_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242418.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242418.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242418.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242418.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242418_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242418_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242418_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242418_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242419.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242419.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242419.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242419.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242419_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242419_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242419_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242419_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242420.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242420.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242420.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242420.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242420_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242420_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242420_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242420_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242421.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242421.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242421.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242421.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242421_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242421_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242421_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242421_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242422.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242422.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242422.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242422.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242422_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242422_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242422_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242422_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242423.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242423.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242423.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242423.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242423_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242423_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242423_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242423_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242424.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242424.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242424.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242424.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242424_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242424_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242424_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242424_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242425.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242425.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242425.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242425.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242425_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242425_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242425_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242425_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242426.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242426.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242426.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242426.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242426_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242426_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242426_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242426_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242427.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242427.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242427.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242427.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242427_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242427_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242427_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242427_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242428.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242428.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242428.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242428.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242428_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242428_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242428_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242428_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242429.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242429.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242429.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242429.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242429_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242429_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242429_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242429_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242430.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242430.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242430.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242430.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242430_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242430_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242430_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242430_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242431.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242431.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242431.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242431.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242431_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242431_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242431_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242431_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242432.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242432.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242432.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242432.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242432_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242432_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242432_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242432_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242433.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242433.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242433.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242433.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242433_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242433_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242433_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242433_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242434.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242434.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242434.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242434.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242434_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242434_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242434_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242434_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242436.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242436.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242436.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242436.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242436_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242436_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242436_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242436_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242438.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242438.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242438.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242438.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242438_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242438_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242438_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242438_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242445.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242445.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242445.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242445.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242445_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242445_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242445_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242445_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242446.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242446.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242446.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242446.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242446_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242446_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242446_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242446_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242447.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242447_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242448_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242449.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242449.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242449.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242449.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242449_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242449_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242449_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242449_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242450.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242450.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242450.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242450.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242450_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242450_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242450_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242450_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242452.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242452.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242452.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242452.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242452_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242452_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242452_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242452_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242453.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242453.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242453.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242453.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242453_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242453_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242453_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242453_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242459.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242459_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242459_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242459_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242460.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242460.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242460.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242460.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242460_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242460_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242460_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242460_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242461.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242461.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242461.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242461.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242461_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242461_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242461_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242461_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242462.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242462.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242462.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242462.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242462_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242462_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242462_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242462_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242463.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242463.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242463.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242463.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242463_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242463_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242463_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242463_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242464.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242464.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242464.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242464.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242464_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242464_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/242464_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/242464_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245541.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245541.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245541.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245541.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245541_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245541_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245541_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245541_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245542.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245542.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245542.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245542.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245542_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245542_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245542_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245542_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245543.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245543.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245543.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245543.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245543_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245543_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245543_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245543_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245544.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245544.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245544.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245544.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245544_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245544_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/245544_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/245544_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/254800.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/254800.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/254800.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/254800.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/254800_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/254800_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/254800_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/254800_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/274882.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/274882.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/274882.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/274882.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/274882_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/274882_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/274882_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/274882_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/doc.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/ids.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/ids.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/ids.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/ids.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/rules_suite_test.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/rules_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/stringgenerator.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/stringgenerator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/disak8sstig/rules/stringgenerator.go
+++ b/pkg/shared/ruleset/disak8sstig/rules/stringgenerator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/ruleset.go
+++ b/pkg/shared/ruleset/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/ruleset.go
+++ b/pkg/shared/ruleset/ruleset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/ruleset_suite_test.go
+++ b/pkg/shared/ruleset/ruleset_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/ruleset_suite_test.go
+++ b/pkg/shared/ruleset/ruleset_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/ruleset_test.go
+++ b/pkg/shared/ruleset/ruleset_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/shared/ruleset/ruleset_test.go
+++ b/pkg/shared/ruleset/ruleset_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the SPDX copyright text from `SAP SE or an SAP affiliate company and Gardener contributors` to `Contributors to the Gardener project` across all files.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```